### PR TITLE
renaming project to "Triton Memory Analyzer"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,6 @@ limitations under the License.
 
 # Contributing
 
-Model Analyzer follows similar contributing guidelines to Triton Inference Server. Please see [the Triton Inference Server contributing document].
+Triton Memory Analyzer follows similar contributing guidelines to Triton Inference Server. Please see [the Triton Inference Server contributing document].
 
 [the Triton Inference Server contributing document]: https://github.com/triton-inference-server/server/blob/master/CONTRIBUTING.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2020, NVIDIA CORPORATION.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,10 @@ RUN apt-get clean && \
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
 COPY src .
-RUN dotnet restore "model-analyzer.csproj"
-RUN dotnet publish "model-analyzer.csproj" -c Release -o /app/publish
+RUN dotnet restore "MemoryAnalyzer.csproj"
+RUN dotnet publish "MemoryAnalyzer.csproj" -c Release -o /app/publish
 
 FROM base
 WORKDIR /app
 COPY --from=build /app/publish .
-ENTRYPOINT ["./model-analyzer"]
+ENTRYPOINT ["./memory-analyzer"]

--- a/MemoryAnalyzer.sln
+++ b/MemoryAnalyzer.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30104.148
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "model-analyzer", "src\model-analyzer.csproj", "{7822DC00-5D0E-497B-91EF-3F012FBC1BC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryAnalyzer", "src\Triton.MemoryAnalyzer.csproj", "{7822DC00-5D0E-497B-91EF-3F012FBC1BC7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "model-analyzer.UnitTests", "tests\model-analyzer.UnitTests.csproj", "{E35A1BFA-97E4-4F24-84E4-FC04F3E1A917}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryAnalyzer.Tests", "tests\Triton.MemoryAnalyzer.Tests.csproj", "{E35A1BFA-97E4-4F24-84E4-FC04F3E1A917}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -13,32 +13,32 @@ limitations under the License.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-lightgrey.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Model Analyzer
+# Triton Memory Analyzer
 
-Model Analyzer is used for gathering compute and memory requirements of models used with NVIDIA Triton Inference Server. It runs each selected model on Triton Inference Server with the given batch sizes and concurrency values. As the configurations run, Model Analyzer will capture and export the metrics in CSV format to your chosen directory.
+Triton Memory Analyzer is used for gathering memory requirements of models used with Triton Inference Server. It runs each selected model on Triton Inference Server with the given batch sizes and concurrency values. As the configurations run, Triton Memory Analyzer will capture and export the metrics in CSV format to your chosen directory.
 
 These metrics will be listed for each batch size and concurrency value. Baseline metrics for the server running with no models will also be provided. These values can be used for optimizing the loading and running of models.
 
-![Interface](images/interface-preview.png?raw=true "Model Analyzer Interface")
+![Interface](images/interface-preview.png?raw=true "Triton Memory Analyzer Interface")
 
 See [this NVIDIA Developer Blog post] for potential use cases.
 
 
 ## Requirements
 
-Model Analyzer supports the following products and environments:
+Triton Memory Analyzer supports the following products and environments:
 - All K80 and newer Tesla GPUs
 - NVSwitch on DGX-2 and HGX-2
 - All Maxwell and newer non-Tesla GPUs
 - CUDA 7.5+ and NVIDIA Driver R384+
 
-Model Analyzer requires [NVIDIA-Docker], a supported Tesla Recommend Driver, and a supported [CUDA toolkit].
+Triton Memory Analyzer requires [NVIDIA-Docker], a supported Tesla Recommend Driver, and a supported [CUDA toolkit].
 
-Ports 8000, 8001, and 8002 on your network need to be available for the Triton server. Model Analyzer supports Triton Inference Server version 20.02-py3. If you do not have the Triton server image locally, the first run will take a couple of minutes to pull it.
+Ports 8000, 8001, and 8002 on your network need to be available for the Triton server. Triton Memory Analyzer supports Triton Inference Server version 20.02-py3. If you do not have the Triton server image locally, the first run will take a couple of minutes to pull it.
 
 ## Metrics
 
-The metrics collected by Model Analyzer are listed below:
+The metrics collected by Triton Memory Analyzer are listed below:
 
 - **Throughput**: Number of inference requests per second
 - **Maximum Memory Utilization**: Maximum percentage of time during which global (device) memory was being read or written
@@ -47,20 +47,20 @@ The metrics collected by Model Analyzer are listed below:
 
 ## Documentation
 
-Model Analyzer runs as a command line interface (CLI), standalone Docker container, or Helm chart. Documentation for each is provided in the [docs] folder.
+Triton Memory Analyzer runs as a command line interface (CLI), standalone Docker container, or Helm chart. Documentation for each is provided in the [docs] folder.
 
 ## Quick Start
 
-The [docs] folder hosts all information about building Model Analyzer from source.  
-If you want to use Model Analyzer right away, there are two options:
+The [docs] folder hosts all information about building Triton Memory Analyzer from source.
+If you want to use Triton Memory Analyzer right away, there are two options:
 
 ##### You have supported hardware and drivers, [NVIDIA-Docker], and [.NET SDK].
 
 ```
-git clone https://github.com/NVIDIA/model-analyzer
-cd src
+git clone https://github.com/triton-inference-server/model_analyzer.git
+cd model_analyzer/src
 dotnet publish -c Release
-./model-analyzer -m MODELS \
+./memory-analyzer -m MODELS \
         --model-folder /ABSOLUTE/PATH/TO/MODELS \
         -e /PATH/TO/EXPORT/DIRECTORY \
         --export -b BATCH-SIZES \
@@ -71,12 +71,13 @@ dotnet publish -c Release
 ##### You have supported hardware and drivers and [NVIDIA-Docker].
 
 ```
-git clone https://github.com/NVIDIA/model-analyzer
-docker build -f Dockerfile -t model-analyzer .
+git clone https://github.com/triton-inference-server/model_analyzer.git
+cd model_analyzer/src
+docker build -f Dockerfile -t memory-analyzer .
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
         -v /ABSOLUTE/PATH/TO/MODELS:ABSOLUTE/PATH/TO/MODELS \
         -v /ABSOLUTE/PATH/TO/EXPORT/DIRECTORY:/results --net=host \
-        model-analyzer:ANALYZER-VERSION \
+        memory-analyzer:ANALYZER-VERSION \
         --batch BATCH-SIZES --concurrency CONCURRENCY-VALUES \
         --model-names MODEL-NAMES \
         --triton-version TRITON-VERSION \
@@ -88,7 +89,7 @@ If you need a Triton-ready model to try out Model Analyzer, you can download and
 
 ## Contributing
 
-Contributions to Model Analyzer are more than welcome. To
+Contributions to Triton Memory Analyzer are more than welcome. To
 contribute make a pull request and follow the guidelines outlined in
 the [Contributing] document.
 
@@ -110,7 +111,7 @@ document. Ensure posted examples are:
 * verifiable – test the code you're about to provide to make sure it
   reproduces the problem. Remove all other problems that are not
   related to your request/question.
-   
+
 ## Support
 
 Please start by reviewing the [docs] folder and searching the current project issues. If you do not find a relevant issue, feel free to open one.

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -13,7 +13,7 @@ limitations under the License.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-lightgrey.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Model Analyzer Command Line Interface (CLI)
+# Triton Memory Analyzer Command Line Interface (CLI)
 
 ## Requirements
 
@@ -22,10 +22,10 @@ In addition to the base requirements, the CLI requires .NET Core SDK.
 ## Procedure
 
 1. Compile the CLI by navigating to the `src` folder and running `dotnet publish -c Release'
-2. Then, change directories into the folder where Model Analyzer was published: `cd bin/Release/netcoreapp3.1/linux-x64/publish/`
-3. You can type `./model-analyzer` to see command line argument options. You can also run the below command, replacing the capitalized arguments:
+2. Then, change directories into the folder where Triton Memory Analyzer was published: `cd bin/Release/netcoreapp3.1/linux-x64/publish/`
+3. You can type `./memory-analyzer` to see command line argument options. You can also run the below command, replacing the capitalized arguments:
 
-        ./model-analyzer -m MODELS \
+        ./memory-analyzer -m MODELS \
         --model-folder /ABSOLUTE/PATH/TO/MODELS \
         -e /PATH/TO/EXPORT/DIRECTORY \
         --export -b BATCH-SIZES \
@@ -34,7 +34,7 @@ In addition to the base requirements, the CLI requires .NET Core SDK.
 
 Please reference the below sample command:
 
-        ./model-analyzer -m chest_xray,covid19_xray \
+        ./memory-analyzer -m chest_xray,covid19_xray \
         --model-folder /home/user/models \
         -e /home/user/results \
         --export -b 1,4,8 \

--- a/docs/docker/overview.md
+++ b/docs/docker/overview.md
@@ -13,17 +13,17 @@ limitations under the License.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-lightgrey.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Model Analyzer Docker Container
+# Triton Memory Analyzer Docker Container
 
 ## Procedure
 
-1. Build the Docker container by navigating to the root folder and running `docker build -f Dockerfile -t model-analyzer .'
+1. Build the Docker container by navigating to the root folder and running `docker build -f Dockerfile -t memory-analyzer .'
 2. Run the below command, replacing the capitalized arguments:
 
         docker run -v /var/run/docker.sock:/var/run/docker.sock \
         -v /ABSOLUTE/PATH/TO/MODELS:/ABSOLUTE/PATH/TO/MODELS \
         -v /ABSOLUTE/PATH/TO/EXPORT/DIRECTORY:/results --net=host \
-        model-analyzer:ANALYZER-VERSION \
+        memory-analyzer:ANALYZER-VERSION \
         --batch BATCH-SIZES --concurrency CONCURRENCY-VALUES \
         --model-names MODEL-NAMES \
         --triton-version TRITON-VERSION \
@@ -35,7 +35,7 @@ Please reference the below sample command:
         docker run -v /var/run/docker.sock:/var/run/docker.sock \
         -v /home/user1/models:/home/user1/models \
         -v /home/user1/results:/results --net=host \
-        model-analyzer:0.7.3-2008.1 \
+        memory-analyzer:0.7.3-2008.1 \
         --batch 1,4,8 --concurrency 2,4,8 \
         --model-names chest_xray,covid19_xray\
         --triton-version 20.02-py3 \

--- a/docs/helm/overview.md
+++ b/docs/helm/overview.md
@@ -13,15 +13,15 @@ limitations under the License.
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-lightgrey.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Model Analyzer Helm Chart
+# Triton Memory Analyzer Helm Chart
 
 ## Requirements
 
-In additiom to the base requirements, the Helm version also requires Kubernetes and Helm.
+In addition to the base requirements, the Helm version also requires Kubernetes and Helm.
 
 ## Procedure
 
-1. Build the Docker container by navigating to the root folder and running `docker build -f Dockerfile -t model-analyzer .'
+1. Build the Docker container by navigating to the root folder and running `docker build -f Dockerfile -t memory-analyzer .'
 2. Change directories into `helm-chart` folder.
 3. Create the below text file as `config.yaml`, updating the field values:
 

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,11 +1,11 @@
 # Copyright 2020, NVIDIA CORPORATION.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,5 +15,5 @@
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
-name: model-analyzer
+name: memory-analyzer
 version: 0.1.0

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,11 +1,11 @@
 # Copyright 2020, NVIDIA CORPORATION.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "model-analyzer.name" -}}
+{{- define "memory-analyzer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -25,7 +25,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "model-analyzer.fullname" -}}
+{{- define "memory-analyzer.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -41,16 +41,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "model-analyzer.chart" -}}
+{{- define "memory-analyzer.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "model-analyzer.labels" -}}
-app.kubernetes.io/name: {{ include "model-analyzer.name" . }}
-helm.sh/chart: {{ include "model-analyzer.chart" . }}
+{{- define "memory-analyzer.labels" -}}
+app.kubernetes.io/name: {{ include "memory-analyzer.name" . }}
+helm.sh/chart: {{ include "memory-analyzer.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -61,9 +61,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "model-analyzer.serviceAccountName" -}}
+{{- define "memory-analyzer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "model-analyzer.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "memory-analyzer.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/helm-chart/templates/job.yaml
+++ b/helm-chart/templates/job.yaml
@@ -1,11 +1,11 @@
 # Copyright 2020, NVIDIA CORPORATION.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,9 +15,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-model-analyzer
+  name: {{ .Release.Name }}-memory-analyzer
   labels:
-    app: {{ .Release.Name }}-model-analyzer
+    app: {{ .Release.Name }}-memory-analyzer
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
 spec:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,18 +1,18 @@
 # Copyright 2020, NVIDIA CORPORATION.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Values for Model Analyzer
+# Values for Triton Memory Analyzer
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -34,7 +34,7 @@ resultsPath: /home/results
 #Specifies how long to gather server-only metrics
 baseDuration: 6
 
-#Specifies list of model batch sizes 
+#Specifies list of model batch sizes
 batch: 1,2
 
 #Specifies comma-delimited list of concurrency values
@@ -57,7 +57,7 @@ perfBuffer: 3
 images:
 
   analyzer:
-    image: model-analyzer
+    image: memory-analyzer
 
   triton:
     image: nvcr.io/nvidia/tensorrtserver

--- a/src/Client/Exceptions.cs
+++ b/src/Client/Exceptions.cs
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Net;
 
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
     /// <summary>
     /// Exception Class to define exceptions to be thrown when an error is encountered

--- a/src/Client/Grpc/Api.cs
+++ b/src/Client/Grpc/Api.cs
@@ -8,7 +8,7 @@
 using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
 
     /// <summary>Holder for reflection information generated from api.proto</summary>
@@ -55,12 +55,12 @@ namespace ModelAnalyzer.Client
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferSharedMemory), global::ModelAnalyzer.Client.InferSharedMemory.Parser, new[]{ "Name", "Offset", "ByteSize" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequestHeader), global::ModelAnalyzer.Client.InferRequestHeader.Parser, new[]{ "Id", "Flags", "CorrelationId", "BatchSize", "Input", "Output" }, null, new[]{ typeof(global::ModelAnalyzer.Client.InferRequestHeader.Types.Flag) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequestHeader.Types.Input), global::ModelAnalyzer.Client.InferRequestHeader.Types.Input.Parser, new[]{ "Name", "Dims", "BatchByteSize", "SharedMemory" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequestHeader.Types.Output), global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Parser, new[]{ "Name", "Cls", "SharedMemory" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class), global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class.Parser, new[]{ "Count" }, null, null, null)})}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponseHeader), global::ModelAnalyzer.Client.InferResponseHeader.Parser, new[]{ "Id", "ModelName", "ModelVersion", "BatchSize", "Output" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponseHeader.Types.Output), global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Parser, new[]{ "Name", "Raw", "BatchClasses" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw), global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw.Parser, new[]{ "Dims", "BatchByteSize" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class), global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class.Parser, new[]{ "Idx", "Value", "Label" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes), global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes.Parser, new[]{ "Cls" }, null, null, null)})})
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferSharedMemory), global::Triton.MemoryAnalyzer.Client.InferSharedMemory.Parser, new[]{ "Name", "Offset", "ByteSize" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequestHeader), global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Parser, new[]{ "Id", "Flags", "CorrelationId", "BatchSize", "Input", "Output" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Flag) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input), global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input.Parser, new[]{ "Name", "Dims", "BatchByteSize", "SharedMemory" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output), global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Parser, new[]{ "Name", "Cls", "SharedMemory" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class), global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class.Parser, new[]{ "Count" }, null, null, null)})}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponseHeader), global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Parser, new[]{ "Id", "ModelName", "ModelVersion", "BatchSize", "Output" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output), global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Parser, new[]{ "Name", "Raw", "BatchClasses" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw), global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw.Parser, new[]{ "Dims", "BatchByteSize" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class), global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class.Parser, new[]{ "Idx", "Value", "Label" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes), global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes.Parser, new[]{ "Cls" }, null, null, null)})})
           }));
     }
     #endregion
@@ -82,7 +82,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -296,7 +296,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[1]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[1]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -405,9 +405,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "input" field.</summary>
     public const int InputFieldNumber = 2;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.InferRequestHeader.Types.Input> _repeated_input_codec
-        = pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.InferRequestHeader.Types.Input.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Input> input_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Input>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input> _repeated_input_codec
+        = pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input> input_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input>();
     /// <summary>
     ///@@  .. cpp:var:: Input input (repeated)
     ///@@
@@ -416,15 +416,15 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Input> Input {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Input> Input {
       get { return input_; }
     }
 
     /// <summary>Field number for the "output" field.</summary>
     public const int OutputFieldNumber = 3;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.InferRequestHeader.Types.Output> _repeated_output_codec
-        = pb::FieldCodec.ForMessage(26, global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Output> output_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Output>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output> _repeated_output_codec
+        = pb::FieldCodec.ForMessage(26, global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output> output_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output>();
     /// <summary>
     ///@@  .. cpp:var:: Output output (repeated)
     ///@@
@@ -433,7 +433,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.InferRequestHeader.Types.Output> Output {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output> Output {
       get { return output_; }
     }
 
@@ -636,7 +636,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.InferRequestHeader.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -722,7 +722,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "shared_memory" field.</summary>
         public const int SharedMemoryFieldNumber = 4;
-        private global::ModelAnalyzer.Client.InferSharedMemory sharedMemory_;
+        private global::Triton.MemoryAnalyzer.Client.InferSharedMemory sharedMemory_;
         /// <summary>
         ///@@    .. cpp:var:: InferSharedMemory shared_memory
         ///@@
@@ -732,7 +732,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.InferSharedMemory SharedMemory {
+        public global::Triton.MemoryAnalyzer.Client.InferSharedMemory SharedMemory {
           get { return sharedMemory_; }
           set {
             sharedMemory_ = value;
@@ -830,7 +830,7 @@ namespace ModelAnalyzer.Client
           }
           if (other.sharedMemory_ != null) {
             if (sharedMemory_ == null) {
-              SharedMemory = new global::ModelAnalyzer.Client.InferSharedMemory();
+              SharedMemory = new global::Triton.MemoryAnalyzer.Client.InferSharedMemory();
             }
             SharedMemory.MergeFrom(other.SharedMemory);
           }
@@ -860,7 +860,7 @@ namespace ModelAnalyzer.Client
               }
               case 34: {
                 if (sharedMemory_ == null) {
-                  SharedMemory = new global::ModelAnalyzer.Client.InferSharedMemory();
+                  SharedMemory = new global::Triton.MemoryAnalyzer.Client.InferSharedMemory();
                 }
                 input.ReadMessage(SharedMemory);
                 break;
@@ -886,7 +886,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.InferRequestHeader.Descriptor.NestedTypes[1]; }
+          get { return global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Descriptor.NestedTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -933,7 +933,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "cls" field.</summary>
         public const int ClsFieldNumber = 3;
-        private global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class cls_;
+        private global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class cls_;
         /// <summary>
         ///@@    .. cpp:var:: Class cls
         ///@@
@@ -944,7 +944,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class Cls {
+        public global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class Cls {
           get { return cls_; }
           set {
             cls_ = value;
@@ -953,7 +953,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "shared_memory" field.</summary>
         public const int SharedMemoryFieldNumber = 4;
-        private global::ModelAnalyzer.Client.InferSharedMemory sharedMemory_;
+        private global::Triton.MemoryAnalyzer.Client.InferSharedMemory sharedMemory_;
         /// <summary>
         ///@@    .. cpp:var:: InferSharedMemory shared_memory
         ///@@
@@ -963,7 +963,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.InferSharedMemory SharedMemory {
+        public global::Triton.MemoryAnalyzer.Client.InferSharedMemory SharedMemory {
           get { return sharedMemory_; }
           set {
             sharedMemory_ = value;
@@ -1053,13 +1053,13 @@ namespace ModelAnalyzer.Client
           }
           if (other.cls_ != null) {
             if (cls_ == null) {
-              Cls = new global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class();
+              Cls = new global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class();
             }
             Cls.MergeFrom(other.Cls);
           }
           if (other.sharedMemory_ != null) {
             if (sharedMemory_ == null) {
-              SharedMemory = new global::ModelAnalyzer.Client.InferSharedMemory();
+              SharedMemory = new global::Triton.MemoryAnalyzer.Client.InferSharedMemory();
             }
             SharedMemory.MergeFrom(other.SharedMemory);
           }
@@ -1080,14 +1080,14 @@ namespace ModelAnalyzer.Client
               }
               case 26: {
                 if (cls_ == null) {
-                  Cls = new global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class();
+                  Cls = new global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Types.Class();
                 }
                 input.ReadMessage(Cls);
                 break;
               }
               case 34: {
                 if (sharedMemory_ == null) {
-                  SharedMemory = new global::ModelAnalyzer.Client.InferSharedMemory();
+                  SharedMemory = new global::Triton.MemoryAnalyzer.Client.InferSharedMemory();
                 }
                 input.ReadMessage(SharedMemory);
                 break;
@@ -1114,7 +1114,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.InferRequestHeader.Types.Output.Descriptor.NestedTypes[0]; }
+              get { return global::Triton.MemoryAnalyzer.Client.InferRequestHeader.Types.Output.Descriptor.NestedTypes[0]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1270,7 +1270,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[2]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ApiReflection.Descriptor.MessageTypes[2]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1374,9 +1374,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "output" field.</summary>
     public const int OutputFieldNumber = 4;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output> _repeated_output_codec
-        = pb::FieldCodec.ForMessage(34, global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output> output_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output> _repeated_output_codec
+        = pb::FieldCodec.ForMessage(34, global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output> output_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output>();
     /// <summary>
     ///@@  .. cpp:var:: Output output (repeated)
     ///@@
@@ -1385,7 +1385,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output> Output {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output> Output {
       get { return output_; }
     }
 
@@ -1547,7 +1547,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.InferResponseHeader.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1594,7 +1594,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "raw" field.</summary>
         public const int RawFieldNumber = 2;
-        private global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw raw_;
+        private global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw raw_;
         /// <summary>
         ///@@    .. cpp:var:: Raw raw
         ///@@
@@ -1605,7 +1605,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw Raw {
+        public global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw Raw {
           get { return raw_; }
           set {
             raw_ = value;
@@ -1614,9 +1614,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "batch_classes" field.</summary>
         public const int BatchClassesFieldNumber = 3;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> _repeated_batchClasses_codec
-            = pb::FieldCodec.ForMessage(26, global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> batchClasses_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> _repeated_batchClasses_codec
+            = pb::FieldCodec.ForMessage(26, global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> batchClasses_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes>();
         /// <summary>
         ///@@    .. cpp:var:: Classes batch_classes (repeated)
         ///@@
@@ -1627,7 +1627,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> BatchClasses {
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Classes> BatchClasses {
           get { return batchClasses_; }
         }
 
@@ -1709,7 +1709,7 @@ namespace ModelAnalyzer.Client
           }
           if (other.raw_ != null) {
             if (raw_ == null) {
-              Raw = new global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw();
+              Raw = new global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw();
             }
             Raw.MergeFrom(other.Raw);
           }
@@ -1731,7 +1731,7 @@ namespace ModelAnalyzer.Client
               }
               case 18: {
                 if (raw_ == null) {
-                  Raw = new global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw();
+                  Raw = new global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Raw();
                 }
                 input.ReadMessage(Raw);
                 break;
@@ -1762,7 +1762,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[0]; }
+              get { return global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[0]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1932,7 +1932,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[1]; }
+              get { return global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[1]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2143,7 +2143,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[2]; }
+              get { return global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Descriptor.NestedTypes[2]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2171,9 +2171,9 @@ namespace ModelAnalyzer.Client
 
             /// <summary>Field number for the "cls" field.</summary>
             public const int ClsFieldNumber = 1;
-            private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> _repeated_cls_codec
-                = pb::FieldCodec.ForMessage(10, global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class.Parser);
-            private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> cls_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class>();
+            private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> _repeated_cls_codec
+                = pb::FieldCodec.ForMessage(10, global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class.Parser);
+            private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> cls_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class>();
             /// <summary>
             ///@@      .. cpp:var:: Class cls (repeated)
             ///@@
@@ -2181,7 +2181,7 @@ namespace ModelAnalyzer.Client
             ///@@
             /// </summary>
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-            public pbc::RepeatedField<global::ModelAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> Cls {
+            public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.InferResponseHeader.Types.Output.Types.Class> Cls {
               get { return cls_; }
             }
 

--- a/src/Client/Grpc/GrpcService.cs
+++ b/src/Client/Grpc/GrpcService.cs
@@ -8,7 +8,7 @@
 using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
 
     /// <summary>Holder for reflection information generated from grpc_service.proto</summary>
@@ -94,24 +94,24 @@ namespace ModelAnalyzer.Client
             "ci5SZXBvc2l0b3J5UmVxdWVzdBoqLm52aWRpYS5pbmZlcmVuY2VzZXJ2ZXIu",
             "UmVwb3NpdG9yeVJlc3BvbnNlIgBiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::ModelAnalyzer.Client.ApiReflection.Descriptor, global::ModelAnalyzer.Client.RequestStatusReflection.Descriptor, global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Triton.MemoryAnalyzer.Client.ApiReflection.Descriptor, global::Triton.MemoryAnalyzer.Client.RequestStatusReflection.Descriptor, global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.StatusRequest), global::ModelAnalyzer.Client.StatusRequest.Parser, new[]{ "ModelName" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.StatusResponse), global::ModelAnalyzer.Client.StatusResponse.Parser, new[]{ "RequestStatus", "ServerStatus" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.HealthRequest), global::ModelAnalyzer.Client.HealthRequest.Parser, new[]{ "Mode" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.HealthResponse), global::ModelAnalyzer.Client.HealthResponse.Parser, new[]{ "RequestStatus", "Health" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelControlRequest), global::ModelAnalyzer.Client.ModelControlRequest.Parser, new[]{ "ModelName", "Type" }, null, new[]{ typeof(global::ModelAnalyzer.Client.ModelControlRequest.Types.Type) }, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelControlResponse), global::ModelAnalyzer.Client.ModelControlResponse.Parser, new[]{ "RequestStatus" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Parser, new[]{ "Register", "Unregister", "UnregisterAll", "Status" }, new[]{ "SharedMemoryControl" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Parser, new[]{ "Name", "SystemSharedMemory", "CudaSharedMemory", "ByteSize" }, new[]{ "SharedMemoryTypes" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier.Parser, new[]{ "SharedMemoryKey", "Offset" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier.Parser, new[]{ "RawHandle", "DeviceId" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister.Parser, new[]{ "Name" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll.Parser, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status.Parser, null, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlResponse), global::ModelAnalyzer.Client.SharedMemoryControlResponse.Parser, new[]{ "RequestStatus", "SharedMemoryStatus" }, new[]{ "SharedMemoryControl" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status), global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status.Parser, new[]{ "SharedMemoryRegion" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequest), global::ModelAnalyzer.Client.InferRequest.Parser, new[]{ "ModelName", "ModelVersion", "MetaData", "RawInput" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferResponse), global::ModelAnalyzer.Client.InferResponse.Parser, new[]{ "RequestStatus", "MetaData", "RawOutput" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.RepositoryRequest), global::ModelAnalyzer.Client.RepositoryRequest.Parser, new[]{ "Index" }, new[]{ "RequestType" }, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.RepositoryResponse), global::ModelAnalyzer.Client.RepositoryResponse.Parser, new[]{ "RequestStatus", "Index" }, new[]{ "ResponseType" }, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.StatusRequest), global::Triton.MemoryAnalyzer.Client.StatusRequest.Parser, new[]{ "ModelName" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.StatusResponse), global::Triton.MemoryAnalyzer.Client.StatusResponse.Parser, new[]{ "RequestStatus", "ServerStatus" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.HealthRequest), global::Triton.MemoryAnalyzer.Client.HealthRequest.Parser, new[]{ "Mode" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.HealthResponse), global::Triton.MemoryAnalyzer.Client.HealthResponse.Parser, new[]{ "RequestStatus", "Health" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelControlRequest), global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Parser, new[]{ "ModelName", "Type" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Types.Type) }, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelControlResponse), global::Triton.MemoryAnalyzer.Client.ModelControlResponse.Parser, new[]{ "RequestStatus" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Parser, new[]{ "Register", "Unregister", "UnregisterAll", "Status" }, new[]{ "SharedMemoryControl" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Parser, new[]{ "Name", "SystemSharedMemory", "CudaSharedMemory", "ByteSize" }, new[]{ "SharedMemoryTypes" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier.Parser, new[]{ "SharedMemoryKey", "Offset" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier.Parser, new[]{ "RawHandle", "DeviceId" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister.Parser, new[]{ "Name" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll.Parser, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status.Parser, null, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Parser, new[]{ "RequestStatus", "SharedMemoryStatus" }, new[]{ "SharedMemoryControl" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status.Parser, new[]{ "SharedMemoryRegion" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequest), global::Triton.MemoryAnalyzer.Client.InferRequest.Parser, new[]{ "ModelName", "ModelVersion", "MetaData", "RawInput" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferResponse), global::Triton.MemoryAnalyzer.Client.InferResponse.Parser, new[]{ "RequestStatus", "MetaData", "RawOutput" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.RepositoryRequest), global::Triton.MemoryAnalyzer.Client.RepositoryRequest.Parser, new[]{ "Index" }, new[]{ "RequestType" }, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.RepositoryResponse), global::Triton.MemoryAnalyzer.Client.RepositoryResponse.Parser, new[]{ "RequestStatus", "Index" }, new[]{ "ResponseType" }, null, null)
           }));
     }
     #endregion
@@ -133,7 +133,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -277,7 +277,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[1]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[1]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -306,7 +306,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -315,7 +315,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -324,7 +324,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "server_status" field.</summary>
     public const int ServerStatusFieldNumber = 2;
-    private global::ModelAnalyzer.Client.ServerStatus serverStatus_;
+    private global::Triton.MemoryAnalyzer.Client.ServerStatus serverStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: ServerStatus server_status
@@ -333,7 +333,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ServerStatus ServerStatus {
+    public global::Triton.MemoryAnalyzer.Client.ServerStatus ServerStatus {
       get { return serverStatus_; }
       set {
         serverStatus_ = value;
@@ -411,13 +411,13 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
       if (other.serverStatus_ != null) {
         if (serverStatus_ == null) {
-          ServerStatus = new global::ModelAnalyzer.Client.ServerStatus();
+          ServerStatus = new global::Triton.MemoryAnalyzer.Client.ServerStatus();
         }
         ServerStatus.MergeFrom(other.ServerStatus);
       }
@@ -434,14 +434,14 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
           }
           case 18: {
             if (serverStatus_ == null) {
-              ServerStatus = new global::ModelAnalyzer.Client.ServerStatus();
+              ServerStatus = new global::Triton.MemoryAnalyzer.Client.ServerStatus();
             }
             input.ReadMessage(ServerStatus);
             break;
@@ -467,7 +467,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[2]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[2]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -612,7 +612,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[3]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[3]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -641,7 +641,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -650,7 +650,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -747,7 +747,7 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
@@ -767,7 +767,7 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
@@ -797,7 +797,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[4]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -844,7 +844,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "type" field.</summary>
     public const int TypeFieldNumber = 2;
-    private global::ModelAnalyzer.Client.ModelControlRequest.Types.Type type_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Types.Type type_ = 0;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: Type type
@@ -853,7 +853,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelControlRequest.Types.Type Type {
+    public global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Types.Type Type {
       get { return type_; }
       set {
         type_ = value;
@@ -951,7 +951,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 16: {
-            Type = (global::ModelAnalyzer.Client.ModelControlRequest.Types.Type) input.ReadEnum();
+            Type = (global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Types.Type) input.ReadEnum();
             break;
           }
         }
@@ -1006,7 +1006,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[5]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1034,7 +1034,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -1043,7 +1043,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -1112,7 +1112,7 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
@@ -1129,7 +1129,7 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
@@ -1155,7 +1155,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[6]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[6]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1204,8 +1204,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register Register {
-      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Register ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register) sharedMemoryControl_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register Register {
+      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Register ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register) sharedMemoryControl_ : null; }
       set {
         sharedMemoryControl_ = value;
         sharedMemoryControlCase_ = value == null ? SharedMemoryControlOneofCase.None : SharedMemoryControlOneofCase.Register;
@@ -1221,8 +1221,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister Unregister {
-      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Unregister ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister) sharedMemoryControl_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister Unregister {
+      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Unregister ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister) sharedMemoryControl_ : null; }
       set {
         sharedMemoryControl_ = value;
         sharedMemoryControlCase_ = value == null ? SharedMemoryControlOneofCase.None : SharedMemoryControlOneofCase.Unregister;
@@ -1238,8 +1238,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll UnregisterAll {
-      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.UnregisterAll ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll) sharedMemoryControl_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll UnregisterAll {
+      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.UnregisterAll ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll) sharedMemoryControl_ : null; }
       set {
         sharedMemoryControl_ = value;
         sharedMemoryControlCase_ = value == null ? SharedMemoryControlOneofCase.None : SharedMemoryControlOneofCase.UnregisterAll;
@@ -1255,8 +1255,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status Status {
-      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Status ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status) sharedMemoryControl_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status Status {
+      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Status ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status) sharedMemoryControl_ : null; }
       set {
         sharedMemoryControl_ = value;
         sharedMemoryControlCase_ = value == null ? SharedMemoryControlOneofCase.None : SharedMemoryControlOneofCase.Status;
@@ -1376,25 +1376,25 @@ namespace ModelAnalyzer.Client
       switch (other.SharedMemoryControlCase) {
         case SharedMemoryControlOneofCase.Register:
           if (Register == null) {
-            Register = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register();
+            Register = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register();
           }
           Register.MergeFrom(other.Register);
           break;
         case SharedMemoryControlOneofCase.Unregister:
           if (Unregister == null) {
-            Unregister = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister();
+            Unregister = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister();
           }
           Unregister.MergeFrom(other.Unregister);
           break;
         case SharedMemoryControlOneofCase.UnregisterAll:
           if (UnregisterAll == null) {
-            UnregisterAll = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll();
+            UnregisterAll = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll();
           }
           UnregisterAll.MergeFrom(other.UnregisterAll);
           break;
         case SharedMemoryControlOneofCase.Status:
           if (Status == null) {
-            Status = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status();
+            Status = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status();
           }
           Status.MergeFrom(other.Status);
           break;
@@ -1412,7 +1412,7 @@ namespace ModelAnalyzer.Client
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register();
+            global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register();
             if (sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Register) {
               subBuilder.MergeFrom(Register);
             }
@@ -1421,7 +1421,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 18: {
-            global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister();
+            global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Unregister();
             if (sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Unregister) {
               subBuilder.MergeFrom(Unregister);
             }
@@ -1430,7 +1430,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 26: {
-            global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll();
+            global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.UnregisterAll();
             if (sharedMemoryControlCase_ == SharedMemoryControlOneofCase.UnregisterAll) {
               subBuilder.MergeFrom(UnregisterAll);
             }
@@ -1439,7 +1439,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 34: {
-            global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Status();
+            global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Status();
             if (sharedMemoryControlCase_ == SharedMemoryControlOneofCase.Status) {
               subBuilder.MergeFrom(Status);
             }
@@ -1469,7 +1469,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1533,8 +1533,8 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier SystemSharedMemory {
-          get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier) sharedMemoryTypes_ : null; }
+        public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier SystemSharedMemory {
+          get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier) sharedMemoryTypes_ : null; }
           set {
             sharedMemoryTypes_ = value;
             sharedMemoryTypesCase_ = value == null ? SharedMemoryTypesOneofCase.None : SharedMemoryTypesOneofCase.SystemSharedMemory;
@@ -1551,8 +1551,8 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier CudaSharedMemory {
-          get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory ? (global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier) sharedMemoryTypes_ : null; }
+        public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier CudaSharedMemory {
+          get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier) sharedMemoryTypes_ : null; }
           set {
             sharedMemoryTypes_ = value;
             sharedMemoryTypesCase_ = value == null ? SharedMemoryTypesOneofCase.None : SharedMemoryTypesOneofCase.CudaSharedMemory;
@@ -1693,13 +1693,13 @@ namespace ModelAnalyzer.Client
           switch (other.SharedMemoryTypesCase) {
             case SharedMemoryTypesOneofCase.SystemSharedMemory:
               if (SystemSharedMemory == null) {
-                SystemSharedMemory = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier();
+                SystemSharedMemory = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier();
               }
               SystemSharedMemory.MergeFrom(other.SystemSharedMemory);
               break;
             case SharedMemoryTypesOneofCase.CudaSharedMemory:
               if (CudaSharedMemory == null) {
-                CudaSharedMemory = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier();
+                CudaSharedMemory = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier();
               }
               CudaSharedMemory.MergeFrom(other.CudaSharedMemory);
               break;
@@ -1721,7 +1721,7 @@ namespace ModelAnalyzer.Client
                 break;
               }
               case 18: {
-                global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier();
+                global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.SystemSharedMemoryIdentifier();
                 if (sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory) {
                   subBuilder.MergeFrom(SystemSharedMemory);
                 }
@@ -1730,7 +1730,7 @@ namespace ModelAnalyzer.Client
                 break;
               }
               case 26: {
-                global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier();
+                global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Types.CUDASharedMemoryIdentifier();
                 if (sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory) {
                   subBuilder.MergeFrom(CudaSharedMemory);
                 }
@@ -1765,7 +1765,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Descriptor.NestedTypes[0]; }
+              get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Descriptor.NestedTypes[0]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1944,7 +1944,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Descriptor.NestedTypes[1]; }
+              get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Types.Register.Descriptor.NestedTypes[1]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2124,7 +2124,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[1]; }
+          get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2266,7 +2266,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[2]; }
+          get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2373,7 +2373,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[3]; }
+          get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Descriptor.NestedTypes[3]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2486,7 +2486,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[7]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2520,7 +2520,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -2529,7 +2529,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -2546,8 +2546,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status SharedMemoryStatus {
-      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.SharedMemoryStatus ? (global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status) sharedMemoryControl_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status SharedMemoryStatus {
+      get { return sharedMemoryControlCase_ == SharedMemoryControlOneofCase.SharedMemoryStatus ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status) sharedMemoryControl_ : null; }
       set {
         sharedMemoryControl_ = value;
         sharedMemoryControlCase_ = value == null ? SharedMemoryControlOneofCase.None : SharedMemoryControlOneofCase.SharedMemoryStatus;
@@ -2645,14 +2645,14 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
       switch (other.SharedMemoryControlCase) {
         case SharedMemoryControlOneofCase.SharedMemoryStatus:
           if (SharedMemoryStatus == null) {
-            SharedMemoryStatus = new global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status();
+            SharedMemoryStatus = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status();
           }
           SharedMemoryStatus.MergeFrom(other.SharedMemoryStatus);
           break;
@@ -2671,13 +2671,13 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
           }
           case 18: {
-            global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status subBuilder = new global::ModelAnalyzer.Client.SharedMemoryControlResponse.Types.Status();
+            global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Types.Status();
             if (sharedMemoryControlCase_ == SharedMemoryControlOneofCase.SharedMemoryStatus) {
               subBuilder.MergeFrom(SharedMemoryStatus);
             }
@@ -2708,7 +2708,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.SharedMemoryControlResponse.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2736,9 +2736,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "shared_memory_region" field.</summary>
         public const int SharedMemoryRegionFieldNumber = 1;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.SharedMemoryRegion> _repeated_sharedMemoryRegion_codec
-            = pb::FieldCodec.ForMessage(10, global::ModelAnalyzer.Client.SharedMemoryRegion.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion> sharedMemoryRegion_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> _repeated_sharedMemoryRegion_codec
+            = pb::FieldCodec.ForMessage(10, global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> sharedMemoryRegion_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion>();
         /// <summary>
         ///@@
         ///@@  .. cpp:var:: SharedMemoryRegion shared_memory_region
@@ -2747,7 +2747,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion> SharedMemoryRegion {
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> SharedMemoryRegion {
           get { return sharedMemoryRegion_; }
         }
 
@@ -2848,7 +2848,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[8]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2914,7 +2914,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "meta_data" field.</summary>
     public const int MetaDataFieldNumber = 3;
-    private global::ModelAnalyzer.Client.InferRequestHeader metaData_;
+    private global::Triton.MemoryAnalyzer.Client.InferRequestHeader metaData_;
     /// <summary>
     ///@@  .. cpp:var:: InferRequestHeader meta_data
     ///@@
@@ -2923,7 +2923,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.InferRequestHeader MetaData {
+    public global::Triton.MemoryAnalyzer.Client.InferRequestHeader MetaData {
       get { return metaData_; }
       set {
         metaData_ = value;
@@ -3036,7 +3036,7 @@ namespace ModelAnalyzer.Client
       }
       if (other.metaData_ != null) {
         if (metaData_ == null) {
-          MetaData = new global::ModelAnalyzer.Client.InferRequestHeader();
+          MetaData = new global::Triton.MemoryAnalyzer.Client.InferRequestHeader();
         }
         MetaData.MergeFrom(other.MetaData);
       }
@@ -3062,7 +3062,7 @@ namespace ModelAnalyzer.Client
           }
           case 26: {
             if (metaData_ == null) {
-              MetaData = new global::ModelAnalyzer.Client.InferRequestHeader();
+              MetaData = new global::Triton.MemoryAnalyzer.Client.InferRequestHeader();
             }
             input.ReadMessage(MetaData);
             break;
@@ -3092,7 +3092,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[9]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3122,7 +3122,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -3131,7 +3131,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -3140,7 +3140,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "meta_data" field.</summary>
     public const int MetaDataFieldNumber = 2;
-    private global::ModelAnalyzer.Client.InferResponseHeader metaData_;
+    private global::Triton.MemoryAnalyzer.Client.InferResponseHeader metaData_;
     /// <summary>
     ///@@  .. cpp:var:: InferResponseHeader meta_data
     ///@@
@@ -3148,7 +3148,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.InferResponseHeader MetaData {
+    public global::Triton.MemoryAnalyzer.Client.InferResponseHeader MetaData {
       get { return metaData_; }
       set {
         metaData_ = value;
@@ -3246,13 +3246,13 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
       if (other.metaData_ != null) {
         if (metaData_ == null) {
-          MetaData = new global::ModelAnalyzer.Client.InferResponseHeader();
+          MetaData = new global::Triton.MemoryAnalyzer.Client.InferResponseHeader();
         }
         MetaData.MergeFrom(other.MetaData);
       }
@@ -3270,14 +3270,14 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
           }
           case 18: {
             if (metaData_ == null) {
-              MetaData = new global::ModelAnalyzer.Client.InferResponseHeader();
+              MetaData = new global::Triton.MemoryAnalyzer.Client.InferResponseHeader();
             }
             input.ReadMessage(MetaData);
             break;
@@ -3307,7 +3307,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[10]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3478,7 +3478,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[11]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3512,7 +3512,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "request_status" field.</summary>
     public const int RequestStatusFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatus requestStatus_;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatus requestStatus_;
     /// <summary>
     ///@@
     ///@@  .. cpp:var:: RequestStatus request_status
@@ -3521,7 +3521,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatus RequestStatus {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatus RequestStatus {
       get { return requestStatus_; }
       set {
         requestStatus_ = value;
@@ -3538,8 +3538,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelRepositoryIndex Index {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Index ? (global::ModelAnalyzer.Client.ModelRepositoryIndex) responseType_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex Index {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Index ? (global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex) responseType_ : null; }
       set {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Index;
@@ -3637,14 +3637,14 @@ namespace ModelAnalyzer.Client
       }
       if (other.requestStatus_ != null) {
         if (requestStatus_ == null) {
-          RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+          RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
         }
         RequestStatus.MergeFrom(other.RequestStatus);
       }
       switch (other.ResponseTypeCase) {
         case ResponseTypeOneofCase.Index:
           if (Index == null) {
-            Index = new global::ModelAnalyzer.Client.ModelRepositoryIndex();
+            Index = new global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex();
           }
           Index.MergeFrom(other.Index);
           break;
@@ -3663,13 +3663,13 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (requestStatus_ == null) {
-              RequestStatus = new global::ModelAnalyzer.Client.RequestStatus();
+              RequestStatus = new global::Triton.MemoryAnalyzer.Client.RequestStatus();
             }
             input.ReadMessage(RequestStatus);
             break;
           }
           case 18: {
-            global::ModelAnalyzer.Client.ModelRepositoryIndex subBuilder = new global::ModelAnalyzer.Client.ModelRepositoryIndex();
+            global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex();
             if (responseTypeCase_ == ResponseTypeOneofCase.Index) {
               subBuilder.MergeFrom(Index);
             }

--- a/src/Client/Grpc/GrpcServiceGrpc.cs
+++ b/src/Client/Grpc/GrpcServiceGrpc.cs
@@ -34,7 +34,7 @@
 
 using grpc = global::Grpc.Core;
 
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
     /// <summary>
     ///@@
@@ -47,62 +47,62 @@ namespace ModelAnalyzer.Client
   {
     static readonly string __ServiceName = "nvidia.inferenceserver.GRPCService";
 
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.StatusRequest> __Marshaller_nvidia_inferenceserver_StatusRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.StatusRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.StatusResponse> __Marshaller_nvidia_inferenceserver_StatusResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.StatusResponse.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.HealthRequest> __Marshaller_nvidia_inferenceserver_HealthRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.HealthRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.HealthResponse> __Marshaller_nvidia_inferenceserver_HealthResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.HealthResponse.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.InferRequest> __Marshaller_nvidia_inferenceserver_InferRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.InferRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.InferResponse> __Marshaller_nvidia_inferenceserver_InferResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.InferResponse.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.ModelControlRequest> __Marshaller_nvidia_inferenceserver_ModelControlRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.ModelControlRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.ModelControlResponse> __Marshaller_nvidia_inferenceserver_ModelControlResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.ModelControlResponse.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.SharedMemoryControlRequest> __Marshaller_nvidia_inferenceserver_SharedMemoryControlRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.SharedMemoryControlRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.SharedMemoryControlResponse> __Marshaller_nvidia_inferenceserver_SharedMemoryControlResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.SharedMemoryControlResponse.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.RepositoryRequest> __Marshaller_nvidia_inferenceserver_RepositoryRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.RepositoryRequest.Parser.ParseFrom);
-    static readonly grpc::Marshaller<global::ModelAnalyzer.Client.RepositoryResponse> __Marshaller_nvidia_inferenceserver_RepositoryResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::ModelAnalyzer.Client.RepositoryResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.StatusRequest> __Marshaller_nvidia_inferenceserver_StatusRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.StatusRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.StatusResponse> __Marshaller_nvidia_inferenceserver_StatusResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.StatusResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.HealthRequest> __Marshaller_nvidia_inferenceserver_HealthRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.HealthRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.HealthResponse> __Marshaller_nvidia_inferenceserver_HealthResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.HealthResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.InferRequest> __Marshaller_nvidia_inferenceserver_InferRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.InferRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.InferResponse> __Marshaller_nvidia_inferenceserver_InferResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.InferResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.ModelControlRequest> __Marshaller_nvidia_inferenceserver_ModelControlRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.ModelControlRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.ModelControlResponse> __Marshaller_nvidia_inferenceserver_ModelControlResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.ModelControlResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest> __Marshaller_nvidia_inferenceserver_SharedMemoryControlRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse> __Marshaller_nvidia_inferenceserver_SharedMemoryControlResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.RepositoryRequest> __Marshaller_nvidia_inferenceserver_RepositoryRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.RepositoryRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Triton.MemoryAnalyzer.Client.RepositoryResponse> __Marshaller_nvidia_inferenceserver_RepositoryResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Triton.MemoryAnalyzer.Client.RepositoryResponse.Parser.ParseFrom);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.StatusRequest, global::ModelAnalyzer.Client.StatusResponse> __Method_Status = new grpc::Method<global::ModelAnalyzer.Client.StatusRequest, global::ModelAnalyzer.Client.StatusResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.StatusRequest, global::Triton.MemoryAnalyzer.Client.StatusResponse> __Method_Status = new grpc::Method<global::Triton.MemoryAnalyzer.Client.StatusRequest, global::Triton.MemoryAnalyzer.Client.StatusResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "Status",
         __Marshaller_nvidia_inferenceserver_StatusRequest,
         __Marshaller_nvidia_inferenceserver_StatusResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.HealthRequest, global::ModelAnalyzer.Client.HealthResponse> __Method_Health = new grpc::Method<global::ModelAnalyzer.Client.HealthRequest, global::ModelAnalyzer.Client.HealthResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.HealthRequest, global::Triton.MemoryAnalyzer.Client.HealthResponse> __Method_Health = new grpc::Method<global::Triton.MemoryAnalyzer.Client.HealthRequest, global::Triton.MemoryAnalyzer.Client.HealthResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "Health",
         __Marshaller_nvidia_inferenceserver_HealthRequest,
         __Marshaller_nvidia_inferenceserver_HealthResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse> __Method_Infer = new grpc::Method<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse> __Method_Infer = new grpc::Method<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "Infer",
         __Marshaller_nvidia_inferenceserver_InferRequest,
         __Marshaller_nvidia_inferenceserver_InferResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse> __Method_StreamInfer = new grpc::Method<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse> __Method_StreamInfer = new grpc::Method<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse>(
         grpc::MethodType.DuplexStreaming,
         __ServiceName,
         "StreamInfer",
         __Marshaller_nvidia_inferenceserver_InferRequest,
         __Marshaller_nvidia_inferenceserver_InferResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.ModelControlRequest, global::ModelAnalyzer.Client.ModelControlResponse> __Method_ModelControl = new grpc::Method<global::ModelAnalyzer.Client.ModelControlRequest, global::ModelAnalyzer.Client.ModelControlResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.ModelControlRequest, global::Triton.MemoryAnalyzer.Client.ModelControlResponse> __Method_ModelControl = new grpc::Method<global::Triton.MemoryAnalyzer.Client.ModelControlRequest, global::Triton.MemoryAnalyzer.Client.ModelControlResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "ModelControl",
         __Marshaller_nvidia_inferenceserver_ModelControlRequest,
         __Marshaller_nvidia_inferenceserver_ModelControlResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.SharedMemoryControlRequest, global::ModelAnalyzer.Client.SharedMemoryControlResponse> __Method_SharedMemoryControl = new grpc::Method<global::ModelAnalyzer.Client.SharedMemoryControlRequest, global::ModelAnalyzer.Client.SharedMemoryControlResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest, global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse> __Method_SharedMemoryControl = new grpc::Method<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest, global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "SharedMemoryControl",
         __Marshaller_nvidia_inferenceserver_SharedMemoryControlRequest,
         __Marshaller_nvidia_inferenceserver_SharedMemoryControlResponse);
 
-    static readonly grpc::Method<global::ModelAnalyzer.Client.RepositoryRequest, global::ModelAnalyzer.Client.RepositoryResponse> __Method_Repository = new grpc::Method<global::ModelAnalyzer.Client.RepositoryRequest, global::ModelAnalyzer.Client.RepositoryResponse>(
+    static readonly grpc::Method<global::Triton.MemoryAnalyzer.Client.RepositoryRequest, global::Triton.MemoryAnalyzer.Client.RepositoryResponse> __Method_Repository = new grpc::Method<global::Triton.MemoryAnalyzer.Client.RepositoryRequest, global::Triton.MemoryAnalyzer.Client.RepositoryResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
         "Repository",
@@ -112,7 +112,7 @@ namespace ModelAnalyzer.Client
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
     {
-      get { return global::ModelAnalyzer.Client.GrpcServiceReflection.Descriptor.Services[0]; }
+      get { return global::Triton.MemoryAnalyzer.Client.GrpcServiceReflection.Descriptor.Services[0]; }
     }
 
     /// <summary>Base class for server-side implementations of GRPCService</summary>
@@ -127,7 +127,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.StatusResponse> Status(global::ModelAnalyzer.Client.StatusRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.StatusResponse> Status(global::Triton.MemoryAnalyzer.Client.StatusRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -141,7 +141,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.HealthResponse> Health(global::ModelAnalyzer.Client.HealthRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.HealthResponse> Health(global::Triton.MemoryAnalyzer.Client.HealthRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -157,7 +157,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.InferResponse> Infer(global::ModelAnalyzer.Client.InferRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.InferResponse> Infer(global::Triton.MemoryAnalyzer.Client.InferRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -175,7 +175,7 @@ namespace ModelAnalyzer.Client
       /// <param name="responseStream">Used for sending responses back to the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>A task indicating completion of the handler.</returns>
-      public virtual global::System.Threading.Tasks.Task StreamInfer(grpc::IAsyncStreamReader<global::ModelAnalyzer.Client.InferRequest> requestStream, grpc::IServerStreamWriter<global::ModelAnalyzer.Client.InferResponse> responseStream, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task StreamInfer(grpc::IAsyncStreamReader<global::Triton.MemoryAnalyzer.Client.InferRequest> requestStream, grpc::IServerStreamWriter<global::Triton.MemoryAnalyzer.Client.InferResponse> responseStream, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -190,7 +190,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.ModelControlResponse> ModelControl(global::ModelAnalyzer.Client.ModelControlRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.ModelControlResponse> ModelControl(global::Triton.MemoryAnalyzer.Client.ModelControlRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -205,7 +205,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControl(global::ModelAnalyzer.Client.SharedMemoryControlRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControl(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -219,7 +219,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
       /// <returns>The response to send back to the client (wrapped by a task).</returns>
-      public virtual global::System.Threading.Tasks.Task<global::ModelAnalyzer.Client.RepositoryResponse> Repository(global::ModelAnalyzer.Client.RepositoryRequest request, grpc::ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Triton.MemoryAnalyzer.Client.RepositoryResponse> Repository(global::Triton.MemoryAnalyzer.Client.RepositoryRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -260,7 +260,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.StatusResponse Status(global::ModelAnalyzer.Client.StatusRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.StatusResponse Status(global::Triton.MemoryAnalyzer.Client.StatusRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Status(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -273,7 +273,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.StatusResponse Status(global::ModelAnalyzer.Client.StatusRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.StatusResponse Status(global::Triton.MemoryAnalyzer.Client.StatusRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_Status, null, options, request);
       }
@@ -288,7 +288,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.StatusResponse> StatusAsync(global::ModelAnalyzer.Client.StatusRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.StatusResponse> StatusAsync(global::Triton.MemoryAnalyzer.Client.StatusRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StatusAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -301,7 +301,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.StatusResponse> StatusAsync(global::ModelAnalyzer.Client.StatusRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.StatusResponse> StatusAsync(global::Triton.MemoryAnalyzer.Client.StatusRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_Status, null, options, request);
       }
@@ -316,7 +316,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.HealthResponse Health(global::ModelAnalyzer.Client.HealthRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.HealthResponse Health(global::Triton.MemoryAnalyzer.Client.HealthRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Health(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -329,7 +329,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.HealthResponse Health(global::ModelAnalyzer.Client.HealthRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.HealthResponse Health(global::Triton.MemoryAnalyzer.Client.HealthRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_Health, null, options, request);
       }
@@ -344,7 +344,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.HealthResponse> HealthAsync(global::ModelAnalyzer.Client.HealthRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.HealthResponse> HealthAsync(global::Triton.MemoryAnalyzer.Client.HealthRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return HealthAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -357,7 +357,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.HealthResponse> HealthAsync(global::ModelAnalyzer.Client.HealthRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.HealthResponse> HealthAsync(global::Triton.MemoryAnalyzer.Client.HealthRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_Health, null, options, request);
       }
@@ -374,7 +374,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.InferResponse Infer(global::ModelAnalyzer.Client.InferRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.InferResponse Infer(global::Triton.MemoryAnalyzer.Client.InferRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Infer(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -389,7 +389,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.InferResponse Infer(global::ModelAnalyzer.Client.InferRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.InferResponse Infer(global::Triton.MemoryAnalyzer.Client.InferRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_Infer, null, options, request);
       }
@@ -406,7 +406,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.InferResponse> InferAsync(global::ModelAnalyzer.Client.InferRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.InferResponse> InferAsync(global::Triton.MemoryAnalyzer.Client.InferRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return InferAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -421,7 +421,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.InferResponse> InferAsync(global::ModelAnalyzer.Client.InferRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.InferResponse> InferAsync(global::Triton.MemoryAnalyzer.Client.InferRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_Infer, null, options, request);
       }
@@ -438,7 +438,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse> StreamInfer(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse> StreamInfer(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamInfer(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -453,7 +453,7 @@ namespace ModelAnalyzer.Client
       /// </summary>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse> StreamInfer(grpc::CallOptions options)
+      public virtual grpc::AsyncDuplexStreamingCall<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse> StreamInfer(grpc::CallOptions options)
       {
         return CallInvoker.AsyncDuplexStreamingCall(__Method_StreamInfer, null, options);
       }
@@ -469,7 +469,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.ModelControlResponse ModelControl(global::ModelAnalyzer.Client.ModelControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.ModelControlResponse ModelControl(global::Triton.MemoryAnalyzer.Client.ModelControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ModelControl(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -483,7 +483,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.ModelControlResponse ModelControl(global::ModelAnalyzer.Client.ModelControlRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.ModelControlResponse ModelControl(global::Triton.MemoryAnalyzer.Client.ModelControlRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_ModelControl, null, options, request);
       }
@@ -499,7 +499,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.ModelControlResponse> ModelControlAsync(global::ModelAnalyzer.Client.ModelControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.ModelControlResponse> ModelControlAsync(global::Triton.MemoryAnalyzer.Client.ModelControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ModelControlAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -513,7 +513,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.ModelControlResponse> ModelControlAsync(global::ModelAnalyzer.Client.ModelControlRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.ModelControlResponse> ModelControlAsync(global::Triton.MemoryAnalyzer.Client.ModelControlRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_ModelControl, null, options, request);
       }
@@ -529,7 +529,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.SharedMemoryControlResponse SharedMemoryControl(global::ModelAnalyzer.Client.SharedMemoryControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse SharedMemoryControl(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return SharedMemoryControl(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -543,7 +543,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.SharedMemoryControlResponse SharedMemoryControl(global::ModelAnalyzer.Client.SharedMemoryControlRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse SharedMemoryControl(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_SharedMemoryControl, null, options, request);
       }
@@ -559,7 +559,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControlAsync(global::ModelAnalyzer.Client.SharedMemoryControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControlAsync(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return SharedMemoryControlAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -573,7 +573,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControlAsync(global::ModelAnalyzer.Client.SharedMemoryControlRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse> SharedMemoryControlAsync(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_SharedMemoryControl, null, options, request);
       }
@@ -588,7 +588,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.RepositoryResponse Repository(global::ModelAnalyzer.Client.RepositoryRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Triton.MemoryAnalyzer.Client.RepositoryResponse Repository(global::Triton.MemoryAnalyzer.Client.RepositoryRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Repository(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -601,7 +601,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::ModelAnalyzer.Client.RepositoryResponse Repository(global::ModelAnalyzer.Client.RepositoryRequest request, grpc::CallOptions options)
+      public virtual global::Triton.MemoryAnalyzer.Client.RepositoryResponse Repository(global::Triton.MemoryAnalyzer.Client.RepositoryRequest request, grpc::CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_Repository, null, options, request);
       }
@@ -616,7 +616,7 @@ namespace ModelAnalyzer.Client
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.RepositoryResponse> RepositoryAsync(global::ModelAnalyzer.Client.RepositoryRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.RepositoryResponse> RepositoryAsync(global::Triton.MemoryAnalyzer.Client.RepositoryRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return RepositoryAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -629,7 +629,7 @@ namespace ModelAnalyzer.Client
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::ModelAnalyzer.Client.RepositoryResponse> RepositoryAsync(global::ModelAnalyzer.Client.RepositoryRequest request, grpc::CallOptions options)
+      public virtual grpc::AsyncUnaryCall<global::Triton.MemoryAnalyzer.Client.RepositoryResponse> RepositoryAsync(global::Triton.MemoryAnalyzer.Client.RepositoryRequest request, grpc::CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_Repository, null, options, request);
       }
@@ -660,13 +660,13 @@ namespace ModelAnalyzer.Client
     /// <param name="serviceImpl">An object implementing the server-side handling logic.</param>
     public static void BindService(grpc::ServiceBinderBase serviceBinder, GRPCServiceBase serviceImpl)
     {
-      serviceBinder.AddMethod(__Method_Status, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.StatusRequest, global::ModelAnalyzer.Client.StatusResponse>(serviceImpl.Status));
-      serviceBinder.AddMethod(__Method_Health, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.HealthRequest, global::ModelAnalyzer.Client.HealthResponse>(serviceImpl.Health));
-      serviceBinder.AddMethod(__Method_Infer, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse>(serviceImpl.Infer));
-      serviceBinder.AddMethod(__Method_StreamInfer, serviceImpl == null ? null : new grpc::DuplexStreamingServerMethod<global::ModelAnalyzer.Client.InferRequest, global::ModelAnalyzer.Client.InferResponse>(serviceImpl.StreamInfer));
-      serviceBinder.AddMethod(__Method_ModelControl, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.ModelControlRequest, global::ModelAnalyzer.Client.ModelControlResponse>(serviceImpl.ModelControl));
-      serviceBinder.AddMethod(__Method_SharedMemoryControl, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.SharedMemoryControlRequest, global::ModelAnalyzer.Client.SharedMemoryControlResponse>(serviceImpl.SharedMemoryControl));
-      serviceBinder.AddMethod(__Method_Repository, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::ModelAnalyzer.Client.RepositoryRequest, global::ModelAnalyzer.Client.RepositoryResponse>(serviceImpl.Repository));
+      serviceBinder.AddMethod(__Method_Status, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.StatusRequest, global::Triton.MemoryAnalyzer.Client.StatusResponse>(serviceImpl.Status));
+      serviceBinder.AddMethod(__Method_Health, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.HealthRequest, global::Triton.MemoryAnalyzer.Client.HealthResponse>(serviceImpl.Health));
+      serviceBinder.AddMethod(__Method_Infer, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse>(serviceImpl.Infer));
+      serviceBinder.AddMethod(__Method_StreamInfer, serviceImpl == null ? null : new grpc::DuplexStreamingServerMethod<global::Triton.MemoryAnalyzer.Client.InferRequest, global::Triton.MemoryAnalyzer.Client.InferResponse>(serviceImpl.StreamInfer));
+      serviceBinder.AddMethod(__Method_ModelControl, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.ModelControlRequest, global::Triton.MemoryAnalyzer.Client.ModelControlResponse>(serviceImpl.ModelControl));
+      serviceBinder.AddMethod(__Method_SharedMemoryControl, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequest, global::Triton.MemoryAnalyzer.Client.SharedMemoryControlResponse>(serviceImpl.SharedMemoryControl));
+      serviceBinder.AddMethod(__Method_Repository, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Triton.MemoryAnalyzer.Client.RepositoryRequest, global::Triton.MemoryAnalyzer.Client.RepositoryResponse>(serviceImpl.Repository));
     }
 
   }

--- a/src/Client/Grpc/ModelConfig.cs
+++ b/src/Client/Grpc/ModelConfig.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
 
   /// <summary>Holder for reflection information generated from model_config.proto</summary>
@@ -143,27 +143,27 @@ namespace ModelAnalyzer.Client
             "VFlQRV9TVFJJTkcQDWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::ModelAnalyzer.Client.DataType), }, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelInstanceGroup), global::ModelAnalyzer.Client.ModelInstanceGroup.Parser, new[]{ "Name", "Kind", "Count", "Gpus", "Profile" }, null, new[]{ typeof(global::ModelAnalyzer.Client.ModelInstanceGroup.Types.Kind) }, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelTensorReshape), global::ModelAnalyzer.Client.ModelTensorReshape.Parser, new[]{ "Shape" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelInput), global::ModelAnalyzer.Client.ModelInput.Parser, new[]{ "Name", "DataType", "Format", "Dims", "Reshape" }, null, new[]{ typeof(global::ModelAnalyzer.Client.ModelInput.Types.Format) }, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOutput), global::ModelAnalyzer.Client.ModelOutput.Parser, new[]{ "Name", "DataType", "Dims", "Reshape", "LabelFilename" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelVersionPolicy), global::ModelAnalyzer.Client.ModelVersionPolicy.Parser, new[]{ "Latest", "All", "Specific" }, new[]{ "PolicyChoice" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest), global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest.Parser, new[]{ "NumVersions" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All), global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All.Parser, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific), global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific.Parser, new[]{ "Versions" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy), global::ModelAnalyzer.Client.ModelOptimizationPolicy.Parser, new[]{ "Graph", "Priority", "Cuda", "ExecutionAccelerators" }, null, new[]{ typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph), global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph.Parser, new[]{ "Level" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda), global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda.Parser, new[]{ "Graphs" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators), global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Parser, new[]{ "GpuExecutionAccelerator", "CpuExecutionAccelerator" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator), global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser, new[]{ "Name", "Parameters" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, })})}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelDynamicBatching), global::ModelAnalyzer.Client.ModelDynamicBatching.Parser, new[]{ "PreferredBatchSize", "MaxQueueDelayMicroseconds", "PreserveOrdering" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelSequenceBatching), global::ModelAnalyzer.Client.ModelSequenceBatching.Parser, new[]{ "Direct", "Oldest", "MaxSequenceIdleMicroseconds", "ControlInput" }, new[]{ "StrategyChoice" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control), global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Parser, new[]{ "Kind", "Int32FalseTrue", "Fp32FalseTrue", "DataType" }, null, new[]{ typeof(global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind) }, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput), global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput.Parser, new[]{ "Name", "Control" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect), global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect.Parser, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest), global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest.Parser, new[]{ "MaxCandidateSequences", "PreferredBatchSize", "MaxQueueDelayMicroseconds" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelEnsembling), global::ModelAnalyzer.Client.ModelEnsembling.Parser, new[]{ "Step" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelEnsembling.Types.Step), global::ModelAnalyzer.Client.ModelEnsembling.Types.Step.Parser, new[]{ "ModelName", "ModelVersion", "InputMap", "OutputMap" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, })}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelParameter), global::ModelAnalyzer.Client.ModelParameter.Parser, new[]{ "StringValue" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelWarmup), global::ModelAnalyzer.Client.ModelWarmup.Parser, new[]{ "Name", "BatchSize", "Inputs" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelWarmup.Types.Input), global::ModelAnalyzer.Client.ModelWarmup.Types.Input.Parser, new[]{ "DataType", "Dims", "ZeroData", "RandomData", "InputDataFile" }, new[]{ "InputDataType" }, null, null),
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Triton.MemoryAnalyzer.Client.DataType), }, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup), global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Parser, new[]{ "Name", "Kind", "Count", "Gpus", "Profile" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Types.Kind) }, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelTensorReshape), global::Triton.MemoryAnalyzer.Client.ModelTensorReshape.Parser, new[]{ "Shape" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelInput), global::Triton.MemoryAnalyzer.Client.ModelInput.Parser, new[]{ "Name", "DataType", "Format", "Dims", "Reshape" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.ModelInput.Types.Format) }, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOutput), global::Triton.MemoryAnalyzer.Client.ModelOutput.Parser, new[]{ "Name", "DataType", "Dims", "Reshape", "LabelFilename" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy), global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Parser, new[]{ "Latest", "All", "Specific" }, new[]{ "PolicyChoice" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest), global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest.Parser, new[]{ "NumVersions" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All), global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All.Parser, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific), global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific.Parser, new[]{ "Versions" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy), global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Parser, new[]{ "Graph", "Priority", "Cuda", "ExecutionAccelerators" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph), global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph.Parser, new[]{ "Level" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda), global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda.Parser, new[]{ "Graphs" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators), global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Parser, new[]{ "GpuExecutionAccelerator", "CpuExecutionAccelerator" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator), global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser, new[]{ "Name", "Parameters" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, })})}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching), global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching.Parser, new[]{ "PreferredBatchSize", "MaxQueueDelayMicroseconds", "PreserveOrdering" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching), global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Parser, new[]{ "Direct", "Oldest", "MaxSequenceIdleMicroseconds", "ControlInput" }, new[]{ "StrategyChoice" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control), global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Parser, new[]{ "Kind", "Int32FalseTrue", "Fp32FalseTrue", "DataType" }, null, new[]{ typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind) }, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput), global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput.Parser, new[]{ "Name", "Control" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect), global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect.Parser, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest), global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest.Parser, new[]{ "MaxCandidateSequences", "PreferredBatchSize", "MaxQueueDelayMicroseconds" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelEnsembling), global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Parser, new[]{ "Step" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step), global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step.Parser, new[]{ "ModelName", "ModelVersion", "InputMap", "OutputMap" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, })}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelParameter), global::Triton.MemoryAnalyzer.Client.ModelParameter.Parser, new[]{ "StringValue" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelWarmup), global::Triton.MemoryAnalyzer.Client.ModelWarmup.Parser, new[]{ "Name", "BatchSize", "Inputs" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input), global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input.Parser, new[]{ "DataType", "Dims", "ZeroData", "RandomData", "InputDataFile" }, new[]{ "InputDataType" }, null, null),
             null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelConfig), global::ModelAnalyzer.Client.ModelConfig.Parser, new[]{ "Name", "Platform", "VersionPolicy", "MaxBatchSize", "Input", "Output", "Optimization", "DynamicBatching", "SequenceBatching", "EnsembleScheduling", "InstanceGroup", "DefaultModelFilename", "CcModelFilenames", "MetricTags", "Parameters", "ModelWarmup" }, new[]{ "SchedulingChoice" }, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, })
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelConfig), global::Triton.MemoryAnalyzer.Client.ModelConfig.Parser, new[]{ "Name", "Platform", "VersionPolicy", "MaxBatchSize", "Input", "Output", "Optimization", "DynamicBatching", "SequenceBatching", "EnsembleScheduling", "InstanceGroup", "DefaultModelFilename", "CcModelFilenames", "MetricTags", "Parameters", "ModelWarmup" }, new[]{ "SchedulingChoice" }, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, })
           }));
     }
     #endregion
@@ -255,7 +255,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -307,7 +307,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "kind" field.</summary>
     public const int KindFieldNumber = 4;
-    private global::ModelAnalyzer.Client.ModelInstanceGroup.Types.Kind kind_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Types.Kind kind_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: Kind kind
     ///@@
@@ -318,7 +318,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelInstanceGroup.Types.Kind Kind {
+    public global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Types.Kind Kind {
       get { return kind_; }
       set {
         kind_ = value;
@@ -506,7 +506,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 32: {
-            Kind = (global::ModelAnalyzer.Client.ModelInstanceGroup.Types.Kind) input.ReadEnum();
+            Kind = (global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Types.Kind) input.ReadEnum();
             break;
           }
           case 42: {
@@ -588,7 +588,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[1]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[1]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -723,7 +723,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[2]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[2]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -772,7 +772,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "data_type" field.</summary>
     public const int DataTypeFieldNumber = 2;
-    private global::ModelAnalyzer.Client.DataType dataType_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.DataType dataType_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: DataType data_type
     ///@@
@@ -780,7 +780,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.DataType DataType {
+    public global::Triton.MemoryAnalyzer.Client.DataType DataType {
       get { return dataType_; }
       set {
         dataType_ = value;
@@ -789,7 +789,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "format" field.</summary>
     public const int FormatFieldNumber = 3;
-    private global::ModelAnalyzer.Client.ModelInput.Types.Format format_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.ModelInput.Types.Format format_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: Format format
     ///@@
@@ -797,7 +797,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelInput.Types.Format Format {
+    public global::Triton.MemoryAnalyzer.Client.ModelInput.Types.Format Format {
       get { return format_; }
       set {
         format_ = value;
@@ -823,7 +823,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "reshape" field.</summary>
     public const int ReshapeFieldNumber = 5;
-    private global::ModelAnalyzer.Client.ModelTensorReshape reshape_;
+    private global::Triton.MemoryAnalyzer.Client.ModelTensorReshape reshape_;
     /// <summary>
     ///@@  .. cpp:var:: ModelTensorReshape reshape
     ///@@
@@ -834,7 +834,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelTensorReshape Reshape {
+    public global::Triton.MemoryAnalyzer.Client.ModelTensorReshape Reshape {
       get { return reshape_; }
       set {
         reshape_ = value;
@@ -944,7 +944,7 @@ namespace ModelAnalyzer.Client
       dims_.Add(other.dims_);
       if (other.reshape_ != null) {
         if (reshape_ == null) {
-          Reshape = new global::ModelAnalyzer.Client.ModelTensorReshape();
+          Reshape = new global::Triton.MemoryAnalyzer.Client.ModelTensorReshape();
         }
         Reshape.MergeFrom(other.Reshape);
       }
@@ -964,11 +964,11 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 16: {
-            DataType = (global::ModelAnalyzer.Client.DataType) input.ReadEnum();
+            DataType = (global::Triton.MemoryAnalyzer.Client.DataType) input.ReadEnum();
             break;
           }
           case 24: {
-            Format = (global::ModelAnalyzer.Client.ModelInput.Types.Format) input.ReadEnum();
+            Format = (global::Triton.MemoryAnalyzer.Client.ModelInput.Types.Format) input.ReadEnum();
             break;
           }
           case 34:
@@ -978,7 +978,7 @@ namespace ModelAnalyzer.Client
           }
           case 42: {
             if (reshape_ == null) {
-              Reshape = new global::ModelAnalyzer.Client.ModelTensorReshape();
+              Reshape = new global::Triton.MemoryAnalyzer.Client.ModelTensorReshape();
             }
             input.ReadMessage(Reshape);
             break;
@@ -1050,7 +1050,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[3]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[3]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1099,7 +1099,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "data_type" field.</summary>
     public const int DataTypeFieldNumber = 2;
-    private global::ModelAnalyzer.Client.DataType dataType_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.DataType dataType_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: DataType data_type
     ///@@
@@ -1107,7 +1107,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.DataType DataType {
+    public global::Triton.MemoryAnalyzer.Client.DataType DataType {
       get { return dataType_; }
       set {
         dataType_ = value;
@@ -1132,7 +1132,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "reshape" field.</summary>
     public const int ReshapeFieldNumber = 5;
-    private global::ModelAnalyzer.Client.ModelTensorReshape reshape_;
+    private global::Triton.MemoryAnalyzer.Client.ModelTensorReshape reshape_;
     /// <summary>
     ///@@  .. cpp:var:: ModelTensorReshape reshape
     ///@@
@@ -1143,7 +1143,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelTensorReshape Reshape {
+    public global::Triton.MemoryAnalyzer.Client.ModelTensorReshape Reshape {
       get { return reshape_; }
       set {
         reshape_ = value;
@@ -1268,7 +1268,7 @@ namespace ModelAnalyzer.Client
       dims_.Add(other.dims_);
       if (other.reshape_ != null) {
         if (reshape_ == null) {
-          Reshape = new global::ModelAnalyzer.Client.ModelTensorReshape();
+          Reshape = new global::Triton.MemoryAnalyzer.Client.ModelTensorReshape();
         }
         Reshape.MergeFrom(other.Reshape);
       }
@@ -1291,7 +1291,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 16: {
-            DataType = (global::ModelAnalyzer.Client.DataType) input.ReadEnum();
+            DataType = (global::Triton.MemoryAnalyzer.Client.DataType) input.ReadEnum();
             break;
           }
           case 26:
@@ -1305,7 +1305,7 @@ namespace ModelAnalyzer.Client
           }
           case 42: {
             if (reshape_ == null) {
-              Reshape = new global::ModelAnalyzer.Client.ModelTensorReshape();
+              Reshape = new global::Triton.MemoryAnalyzer.Client.ModelTensorReshape();
             }
             input.ReadMessage(Reshape);
             break;
@@ -1332,7 +1332,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[4]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1378,8 +1378,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest Latest {
-      get { return policyChoiceCase_ == PolicyChoiceOneofCase.Latest ? (global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest) policyChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest Latest {
+      get { return policyChoiceCase_ == PolicyChoiceOneofCase.Latest ? (global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest) policyChoice_ : null; }
       set {
         policyChoice_ = value;
         policyChoiceCase_ = value == null ? PolicyChoiceOneofCase.None : PolicyChoiceOneofCase.Latest;
@@ -1395,8 +1395,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All All {
-      get { return policyChoiceCase_ == PolicyChoiceOneofCase.All ? (global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All) policyChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All All {
+      get { return policyChoiceCase_ == PolicyChoiceOneofCase.All ? (global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All) policyChoice_ : null; }
       set {
         policyChoice_ = value;
         policyChoiceCase_ = value == null ? PolicyChoiceOneofCase.None : PolicyChoiceOneofCase.All;
@@ -1412,8 +1412,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific Specific {
-      get { return policyChoiceCase_ == PolicyChoiceOneofCase.Specific ? (global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific) policyChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific Specific {
+      get { return policyChoiceCase_ == PolicyChoiceOneofCase.Specific ? (global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific) policyChoice_ : null; }
       set {
         policyChoice_ = value;
         policyChoiceCase_ = value == null ? PolicyChoiceOneofCase.None : PolicyChoiceOneofCase.Specific;
@@ -1523,19 +1523,19 @@ namespace ModelAnalyzer.Client
       switch (other.PolicyChoiceCase) {
         case PolicyChoiceOneofCase.Latest:
           if (Latest == null) {
-            Latest = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest();
+            Latest = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest();
           }
           Latest.MergeFrom(other.Latest);
           break;
         case PolicyChoiceOneofCase.All:
           if (All == null) {
-            All = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All();
+            All = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All();
           }
           All.MergeFrom(other.All);
           break;
         case PolicyChoiceOneofCase.Specific:
           if (Specific == null) {
-            Specific = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific();
+            Specific = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific();
           }
           Specific.MergeFrom(other.Specific);
           break;
@@ -1553,7 +1553,7 @@ namespace ModelAnalyzer.Client
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 10: {
-            global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest subBuilder = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Latest();
+            global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Latest();
             if (policyChoiceCase_ == PolicyChoiceOneofCase.Latest) {
               subBuilder.MergeFrom(Latest);
             }
@@ -1562,7 +1562,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 18: {
-            global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All subBuilder = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.All();
+            global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.All();
             if (policyChoiceCase_ == PolicyChoiceOneofCase.All) {
               subBuilder.MergeFrom(All);
             }
@@ -1571,7 +1571,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 26: {
-            global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific subBuilder = new global::ModelAnalyzer.Client.ModelVersionPolicy.Types.Specific();
+            global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Types.Specific();
             if (policyChoiceCase_ == PolicyChoiceOneofCase.Specific) {
               subBuilder.MergeFrom(Specific);
             }
@@ -1602,7 +1602,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1746,7 +1746,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[1]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1853,7 +1853,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[2]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1995,7 +1995,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[5]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2026,7 +2026,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "graph" field.</summary>
     public const int GraphFieldNumber = 1;
-    private global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph graph_;
+    private global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph graph_;
     /// <summary>
     ///@@  .. cpp:var:: Graph graph
     ///@@
@@ -2034,7 +2034,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph Graph {
+    public global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph Graph {
       get { return graph_; }
       set {
         graph_ = value;
@@ -2043,7 +2043,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "priority" field.</summary>
     public const int PriorityFieldNumber = 2;
-    private global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority priority_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority priority_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: ModelPriority priority
     ///@@
@@ -2051,7 +2051,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority Priority {
+    public global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority Priority {
       get { return priority_; }
       set {
         priority_ = value;
@@ -2060,7 +2060,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "cuda" field.</summary>
     public const int CudaFieldNumber = 3;
-    private global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda cuda_;
+    private global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda cuda_;
     /// <summary>
     ///@@  .. cpp:var:: Cuda cuda
     ///@@
@@ -2068,7 +2068,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda Cuda {
+    public global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda Cuda {
       get { return cuda_; }
       set {
         cuda_ = value;
@@ -2077,7 +2077,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "execution_accelerators" field.</summary>
     public const int ExecutionAcceleratorsFieldNumber = 4;
-    private global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators executionAccelerators_;
+    private global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators executionAccelerators_;
     /// <summary>
     ///@@  .. cpp:var:: ExecutionAccelerators execution_accelerators
     ///@@
@@ -2085,7 +2085,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators ExecutionAccelerators {
+    public global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators ExecutionAccelerators {
       get { return executionAccelerators_; }
       set {
         executionAccelerators_ = value;
@@ -2181,7 +2181,7 @@ namespace ModelAnalyzer.Client
       }
       if (other.graph_ != null) {
         if (graph_ == null) {
-          Graph = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph();
+          Graph = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph();
         }
         Graph.MergeFrom(other.Graph);
       }
@@ -2190,13 +2190,13 @@ namespace ModelAnalyzer.Client
       }
       if (other.cuda_ != null) {
         if (cuda_ == null) {
-          Cuda = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda();
+          Cuda = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda();
         }
         Cuda.MergeFrom(other.Cuda);
       }
       if (other.executionAccelerators_ != null) {
         if (executionAccelerators_ == null) {
-          ExecutionAccelerators = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators();
+          ExecutionAccelerators = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators();
         }
         ExecutionAccelerators.MergeFrom(other.ExecutionAccelerators);
       }
@@ -2213,25 +2213,25 @@ namespace ModelAnalyzer.Client
             break;
           case 10: {
             if (graph_ == null) {
-              Graph = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Graph();
+              Graph = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Graph();
             }
             input.ReadMessage(Graph);
             break;
           }
           case 16: {
-            Priority = (global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority) input.ReadEnum();
+            Priority = (global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ModelPriority) input.ReadEnum();
             break;
           }
           case 26: {
             if (cuda_ == null) {
-              Cuda = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda();
+              Cuda = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.Cuda();
             }
             input.ReadMessage(Cuda);
             break;
           }
           case 34: {
             if (executionAccelerators_ == null) {
-              ExecutionAccelerators = new global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators();
+              ExecutionAccelerators = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators();
             }
             input.ReadMessage(ExecutionAccelerators);
             break;
@@ -2295,7 +2295,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2442,7 +2442,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[1]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2597,7 +2597,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[2]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2626,9 +2626,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "gpu_execution_accelerator" field.</summary>
         public const int GpuExecutionAcceleratorFieldNumber = 1;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> _repeated_gpuExecutionAccelerator_codec
-            = pb::FieldCodec.ForMessage(10, global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> gpuExecutionAccelerator_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> _repeated_gpuExecutionAccelerator_codec
+            = pb::FieldCodec.ForMessage(10, global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> gpuExecutionAccelerator_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator>();
         /// <summary>
         ///@@    .. cpp:var:: Accelerator gpu_execution_accelerator (repeated)
         ///@@
@@ -2665,15 +2665,15 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> GpuExecutionAccelerator {
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> GpuExecutionAccelerator {
           get { return gpuExecutionAccelerator_; }
         }
 
         /// <summary>Field number for the "cpu_execution_accelerator" field.</summary>
         public const int CpuExecutionAcceleratorFieldNumber = 2;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> _repeated_cpuExecutionAccelerator_codec
-            = pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> cpuExecutionAccelerator_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> _repeated_cpuExecutionAccelerator_codec
+            = pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> cpuExecutionAccelerator_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator>();
         /// <summary>
         ///@@    .. cpp:var:: Accelerator cpu_execution_accelerator (repeated)
         ///@@
@@ -2685,7 +2685,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> CpuExecutionAccelerator {
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Types.Accelerator> CpuExecutionAccelerator {
           get { return cpuExecutionAccelerator_; }
         }
 
@@ -2794,7 +2794,7 @@ namespace ModelAnalyzer.Client
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public static pbr::MessageDescriptor Descriptor {
-              get { return global::ModelAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Descriptor.NestedTypes[0]; }
+              get { return global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy.Types.ExecutionAccelerators.Descriptor.NestedTypes[0]; }
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2973,7 +2973,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[6]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[6]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3190,7 +3190,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[7]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3235,8 +3235,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect Direct {
-      get { return strategyChoiceCase_ == StrategyChoiceOneofCase.Direct ? (global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect) strategyChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect Direct {
+      get { return strategyChoiceCase_ == StrategyChoiceOneofCase.Direct ? (global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect) strategyChoice_ : null; }
       set {
         strategyChoice_ = value;
         strategyChoiceCase_ = value == null ? StrategyChoiceOneofCase.None : StrategyChoiceOneofCase.Direct;
@@ -3252,8 +3252,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest Oldest {
-      get { return strategyChoiceCase_ == StrategyChoiceOneofCase.Oldest ? (global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest) strategyChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest Oldest {
+      get { return strategyChoiceCase_ == StrategyChoiceOneofCase.Oldest ? (global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest) strategyChoice_ : null; }
       set {
         strategyChoice_ = value;
         strategyChoiceCase_ = value == null ? StrategyChoiceOneofCase.None : StrategyChoiceOneofCase.Oldest;
@@ -3285,9 +3285,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "control_input" field.</summary>
     public const int ControlInputFieldNumber = 2;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> _repeated_controlInput_codec
-        = pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> controlInput_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> _repeated_controlInput_codec
+        = pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> controlInput_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput>();
     /// <summary>
     ///@@  .. cpp:var:: ControlInput control_input (repeated)
     ///@@
@@ -3297,7 +3297,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> ControlInput {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.ControlInput> ControlInput {
       get { return controlInput_; }
     }
 
@@ -3411,13 +3411,13 @@ namespace ModelAnalyzer.Client
       switch (other.StrategyChoiceCase) {
         case StrategyChoiceOneofCase.Direct:
           if (Direct == null) {
-            Direct = new global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect();
+            Direct = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect();
           }
           Direct.MergeFrom(other.Direct);
           break;
         case StrategyChoiceOneofCase.Oldest:
           if (Oldest == null) {
-            Oldest = new global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest();
+            Oldest = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest();
           }
           Oldest.MergeFrom(other.Oldest);
           break;
@@ -3443,7 +3443,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 26: {
-            global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect subBuilder = new global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect();
+            global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyDirect();
             if (strategyChoiceCase_ == StrategyChoiceOneofCase.Direct) {
               subBuilder.MergeFrom(Direct);
             }
@@ -3452,7 +3452,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 34: {
-            global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest subBuilder = new global::ModelAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest();
+            global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.StrategyOldest();
             if (strategyChoiceCase_ == StrategyChoiceOneofCase.Oldest) {
               subBuilder.MergeFrom(Oldest);
             }
@@ -3483,7 +3483,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3514,7 +3514,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "kind" field.</summary>
         public const int KindFieldNumber = 1;
-        private global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind kind_ = 0;
+        private global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind kind_ = 0;
         /// <summary>
         ///@@    .. cpp:var:: Kind kind
         ///@@
@@ -3522,7 +3522,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind Kind {
+        public global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind Kind {
           get { return kind_; }
           set {
             kind_ = value;
@@ -3571,7 +3571,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "data_type" field.</summary>
         public const int DataTypeFieldNumber = 4;
-        private global::ModelAnalyzer.Client.DataType dataType_ = 0;
+        private global::Triton.MemoryAnalyzer.Client.DataType dataType_ = 0;
         /// <summary>
         ///@@    .. cpp:var:: DataType data_type
         ///@@
@@ -3579,7 +3579,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.DataType DataType {
+        public global::Triton.MemoryAnalyzer.Client.DataType DataType {
           get { return dataType_; }
           set {
             dataType_ = value;
@@ -3683,7 +3683,7 @@ namespace ModelAnalyzer.Client
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 8: {
-                Kind = (global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind) input.ReadEnum();
+                Kind = (global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Types.Kind) input.ReadEnum();
                 break;
               }
               case 18:
@@ -3697,7 +3697,7 @@ namespace ModelAnalyzer.Client
                 break;
               }
               case 32: {
-                DataType = (global::ModelAnalyzer.Client.DataType) input.ReadEnum();
+                DataType = (global::Triton.MemoryAnalyzer.Client.DataType) input.ReadEnum();
                 break;
               }
             }
@@ -3781,7 +3781,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[1]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3827,9 +3827,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "control" field.</summary>
         public const int ControlFieldNumber = 2;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control> _repeated_control_codec
-            = pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control> control_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control> _repeated_control_codec
+            = pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control> control_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control>();
         /// <summary>
         ///@@    .. cpp:var:: Control control (repeated)
         ///@@
@@ -3838,7 +3838,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelSequenceBatching.Types.Control> Control {
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Types.Control> Control {
           get { return control_; }
         }
 
@@ -3953,7 +3953,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[2]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4067,7 +4067,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[3]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching.Descriptor.NestedTypes[3]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4285,7 +4285,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[8]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4313,9 +4313,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "step" field.</summary>
     public const int StepFieldNumber = 1;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelEnsembling.Types.Step> _repeated_step_codec
-        = pb::FieldCodec.ForMessage(10, global::ModelAnalyzer.Client.ModelEnsembling.Types.Step.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelEnsembling.Types.Step> step_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelEnsembling.Types.Step>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step> _repeated_step_codec
+        = pb::FieldCodec.ForMessage(10, global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step> step_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step>();
     /// <summary>
     ///@@  .. cpp:var:: Step step (repeated)
     ///@@
@@ -4323,7 +4323,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelEnsembling.Types.Step> Step {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Types.Step> Step {
       get { return step_; }
     }
 
@@ -4422,7 +4422,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelEnsembling.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelEnsembling.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4664,7 +4664,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[9]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4806,7 +4806,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[10]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -4873,9 +4873,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "inputs" field.</summary>
     public const int InputsFieldNumber = 3;
-    private static readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelWarmup.Types.Input>.Codec _map_inputs_codec
-        = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelWarmup.Types.Input>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelWarmup.Types.Input.Parser), 26);
-    private readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelWarmup.Types.Input> inputs_ = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelWarmup.Types.Input>();
+    private static readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input>.Codec _map_inputs_codec
+        = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input.Parser), 26);
+    private readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input> inputs_ = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input>();
     /// <summary>
     ///@@  .. cpp:var:: map&lt;string, Input> inputs
     ///@@
@@ -4884,7 +4884,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::MapField<string, global::ModelAnalyzer.Client.ModelWarmup.Types.Input> Inputs {
+    public pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Types.Input> Inputs {
       get { return inputs_; }
     }
 
@@ -5014,7 +5014,7 @@ namespace ModelAnalyzer.Client
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor {
-          get { return global::ModelAnalyzer.Client.ModelWarmup.Descriptor.NestedTypes[0]; }
+          get { return global::Triton.MemoryAnalyzer.Client.ModelWarmup.Descriptor.NestedTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5055,7 +5055,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "data_type" field.</summary>
         public const int DataTypeFieldNumber = 1;
-        private global::ModelAnalyzer.Client.DataType dataType_ = 0;
+        private global::Triton.MemoryAnalyzer.Client.DataType dataType_ = 0;
         /// <summary>
         ///@@    .. cpp:var:: DataType data_type
         ///@@
@@ -5063,7 +5063,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.DataType DataType {
+        public global::Triton.MemoryAnalyzer.Client.DataType DataType {
           get { return dataType_; }
           set {
             dataType_ = value;
@@ -5286,7 +5286,7 @@ namespace ModelAnalyzer.Client
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
               case 8: {
-                DataType = (global::ModelAnalyzer.Client.DataType) input.ReadEnum();
+                DataType = (global::Triton.MemoryAnalyzer.Client.DataType) input.ReadEnum();
                 break;
               }
               case 18:
@@ -5332,7 +5332,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[11]; }
+      get { return global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5421,7 +5421,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "version_policy" field.</summary>
     public const int VersionPolicyFieldNumber = 3;
-    private global::ModelAnalyzer.Client.ModelVersionPolicy versionPolicy_;
+    private global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy versionPolicy_;
     /// <summary>
     ///@@  .. cpp:var:: ModelVersionPolicy version_policy
     ///@@
@@ -5429,7 +5429,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelVersionPolicy VersionPolicy {
+    public global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy VersionPolicy {
       get { return versionPolicy_; }
       set {
         versionPolicy_ = value;
@@ -5468,9 +5468,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "input" field.</summary>
     public const int InputFieldNumber = 5;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelInput> _repeated_input_codec
-        = pb::FieldCodec.ForMessage(42, global::ModelAnalyzer.Client.ModelInput.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInput> input_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInput>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelInput> _repeated_input_codec
+        = pb::FieldCodec.ForMessage(42, global::Triton.MemoryAnalyzer.Client.ModelInput.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInput> input_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInput>();
     /// <summary>
     ///@@  .. cpp:var:: ModelInput input (repeated)
     ///@@
@@ -5478,15 +5478,15 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInput> Input {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInput> Input {
       get { return input_; }
     }
 
     /// <summary>Field number for the "output" field.</summary>
     public const int OutputFieldNumber = 6;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelOutput> _repeated_output_codec
-        = pb::FieldCodec.ForMessage(50, global::ModelAnalyzer.Client.ModelOutput.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOutput> output_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOutput>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelOutput> _repeated_output_codec
+        = pb::FieldCodec.ForMessage(50, global::Triton.MemoryAnalyzer.Client.ModelOutput.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOutput> output_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOutput>();
     /// <summary>
     ///@@  .. cpp:var:: ModelOutput output (repeated)
     ///@@
@@ -5494,13 +5494,13 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelOutput> Output {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelOutput> Output {
       get { return output_; }
     }
 
     /// <summary>Field number for the "optimization" field.</summary>
     public const int OptimizationFieldNumber = 12;
-    private global::ModelAnalyzer.Client.ModelOptimizationPolicy optimization_;
+    private global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy optimization_;
     /// <summary>
     ///@@  .. cpp:var:: ModelOptimizationPolicy optimization
     ///@@
@@ -5509,7 +5509,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelOptimizationPolicy Optimization {
+    public global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy Optimization {
       get { return optimization_; }
       set {
         optimization_ = value;
@@ -5528,8 +5528,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelDynamicBatching DynamicBatching {
-      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.DynamicBatching ? (global::ModelAnalyzer.Client.ModelDynamicBatching) schedulingChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching DynamicBatching {
+      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.DynamicBatching ? (global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching) schedulingChoice_ : null; }
       set {
         schedulingChoice_ = value;
         schedulingChoiceCase_ = value == null ? SchedulingChoiceOneofCase.None : SchedulingChoiceOneofCase.DynamicBatching;
@@ -5550,8 +5550,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelSequenceBatching SequenceBatching {
-      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.SequenceBatching ? (global::ModelAnalyzer.Client.ModelSequenceBatching) schedulingChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching SequenceBatching {
+      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.SequenceBatching ? (global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching) schedulingChoice_ : null; }
       set {
         schedulingChoice_ = value;
         schedulingChoiceCase_ = value == null ? SchedulingChoiceOneofCase.None : SchedulingChoiceOneofCase.SequenceBatching;
@@ -5572,8 +5572,8 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.ModelEnsembling EnsembleScheduling {
-      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.EnsembleScheduling ? (global::ModelAnalyzer.Client.ModelEnsembling) schedulingChoice_ : null; }
+    public global::Triton.MemoryAnalyzer.Client.ModelEnsembling EnsembleScheduling {
+      get { return schedulingChoiceCase_ == SchedulingChoiceOneofCase.EnsembleScheduling ? (global::Triton.MemoryAnalyzer.Client.ModelEnsembling) schedulingChoice_ : null; }
       set {
         schedulingChoice_ = value;
         schedulingChoiceCase_ = value == null ? SchedulingChoiceOneofCase.None : SchedulingChoiceOneofCase.EnsembleScheduling;
@@ -5582,9 +5582,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "instance_group" field.</summary>
     public const int InstanceGroupFieldNumber = 7;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelInstanceGroup> _repeated_instanceGroup_codec
-        = pb::FieldCodec.ForMessage(58, global::ModelAnalyzer.Client.ModelInstanceGroup.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInstanceGroup> instanceGroup_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInstanceGroup>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup> _repeated_instanceGroup_codec
+        = pb::FieldCodec.ForMessage(58, global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup> instanceGroup_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup>();
     /// <summary>
     ///@@  .. cpp:var:: ModelInstanceGroup instance_group (repeated)
     ///@@
@@ -5593,7 +5593,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelInstanceGroup> InstanceGroup {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelInstanceGroup> InstanceGroup {
       get { return instanceGroup_; }
     }
 
@@ -5656,9 +5656,9 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "parameters" field.</summary>
     public const int ParametersFieldNumber = 14;
-    private static readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelParameter>.Codec _map_parameters_codec
-        = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelParameter>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelParameter.Parser), 114);
-    private readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelParameter> parameters_ = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelParameter>();
+    private static readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelParameter>.Codec _map_parameters_codec
+        = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelParameter>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelParameter.Parser), 114);
+    private readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelParameter> parameters_ = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelParameter>();
     /// <summary>
     ///@@  .. cpp:var:: map&lt;string,ModelParameter> parameters
     ///@@
@@ -5667,15 +5667,15 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::MapField<string, global::ModelAnalyzer.Client.ModelParameter> Parameters {
+    public pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelParameter> Parameters {
       get { return parameters_; }
     }
 
     /// <summary>Field number for the "model_warmup" field.</summary>
     public const int ModelWarmupFieldNumber = 16;
-    private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelWarmup> _repeated_modelWarmup_codec
-        = pb::FieldCodec.ForMessage(130, global::ModelAnalyzer.Client.ModelWarmup.Parser);
-    private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelWarmup> modelWarmup_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelWarmup>();
+    private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelWarmup> _repeated_modelWarmup_codec
+        = pb::FieldCodec.ForMessage(130, global::Triton.MemoryAnalyzer.Client.ModelWarmup.Parser);
+    private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelWarmup> modelWarmup_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelWarmup>();
     /// <summary>
     ///@@  .. cpp:var:: ModelWarmup model_warmup (repeated)
     ///@@
@@ -5687,7 +5687,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelWarmup> ModelWarmup {
+    public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelWarmup> ModelWarmup {
       get { return modelWarmup_; }
     }
 
@@ -5881,7 +5881,7 @@ namespace ModelAnalyzer.Client
       }
       if (other.versionPolicy_ != null) {
         if (versionPolicy_ == null) {
-          VersionPolicy = new global::ModelAnalyzer.Client.ModelVersionPolicy();
+          VersionPolicy = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy();
         }
         VersionPolicy.MergeFrom(other.VersionPolicy);
       }
@@ -5892,7 +5892,7 @@ namespace ModelAnalyzer.Client
       output_.Add(other.output_);
       if (other.optimization_ != null) {
         if (optimization_ == null) {
-          Optimization = new global::ModelAnalyzer.Client.ModelOptimizationPolicy();
+          Optimization = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy();
         }
         Optimization.MergeFrom(other.Optimization);
       }
@@ -5907,19 +5907,19 @@ namespace ModelAnalyzer.Client
       switch (other.SchedulingChoiceCase) {
         case SchedulingChoiceOneofCase.DynamicBatching:
           if (DynamicBatching == null) {
-            DynamicBatching = new global::ModelAnalyzer.Client.ModelDynamicBatching();
+            DynamicBatching = new global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching();
           }
           DynamicBatching.MergeFrom(other.DynamicBatching);
           break;
         case SchedulingChoiceOneofCase.SequenceBatching:
           if (SequenceBatching == null) {
-            SequenceBatching = new global::ModelAnalyzer.Client.ModelSequenceBatching();
+            SequenceBatching = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching();
           }
           SequenceBatching.MergeFrom(other.SequenceBatching);
           break;
         case SchedulingChoiceOneofCase.EnsembleScheduling:
           if (EnsembleScheduling == null) {
-            EnsembleScheduling = new global::ModelAnalyzer.Client.ModelEnsembling();
+            EnsembleScheduling = new global::Triton.MemoryAnalyzer.Client.ModelEnsembling();
           }
           EnsembleScheduling.MergeFrom(other.EnsembleScheduling);
           break;
@@ -5946,7 +5946,7 @@ namespace ModelAnalyzer.Client
           }
           case 26: {
             if (versionPolicy_ == null) {
-              VersionPolicy = new global::ModelAnalyzer.Client.ModelVersionPolicy();
+              VersionPolicy = new global::Triton.MemoryAnalyzer.Client.ModelVersionPolicy();
             }
             input.ReadMessage(VersionPolicy);
             break;
@@ -5980,7 +5980,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 90: {
-            global::ModelAnalyzer.Client.ModelDynamicBatching subBuilder = new global::ModelAnalyzer.Client.ModelDynamicBatching();
+            global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelDynamicBatching();
             if (schedulingChoiceCase_ == SchedulingChoiceOneofCase.DynamicBatching) {
               subBuilder.MergeFrom(DynamicBatching);
             }
@@ -5990,13 +5990,13 @@ namespace ModelAnalyzer.Client
           }
           case 98: {
             if (optimization_ == null) {
-              Optimization = new global::ModelAnalyzer.Client.ModelOptimizationPolicy();
+              Optimization = new global::Triton.MemoryAnalyzer.Client.ModelOptimizationPolicy();
             }
             input.ReadMessage(Optimization);
             break;
           }
           case 106: {
-            global::ModelAnalyzer.Client.ModelSequenceBatching subBuilder = new global::ModelAnalyzer.Client.ModelSequenceBatching();
+            global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelSequenceBatching();
             if (schedulingChoiceCase_ == SchedulingChoiceOneofCase.SequenceBatching) {
               subBuilder.MergeFrom(SequenceBatching);
             }
@@ -6009,7 +6009,7 @@ namespace ModelAnalyzer.Client
             break;
           }
           case 122: {
-            global::ModelAnalyzer.Client.ModelEnsembling subBuilder = new global::ModelAnalyzer.Client.ModelEnsembling();
+            global::Triton.MemoryAnalyzer.Client.ModelEnsembling subBuilder = new global::Triton.MemoryAnalyzer.Client.ModelEnsembling();
             if (schedulingChoiceCase_ == SchedulingChoiceOneofCase.EnsembleScheduling) {
               subBuilder.MergeFrom(EnsembleScheduling);
             }

--- a/src/Client/Grpc/RequestStatus.cs
+++ b/src/Client/Grpc/RequestStatus.cs
@@ -7,7 +7,7 @@
 
 using pb = global::Google.Protobuf;
 using pbr = global::Google.Protobuf.Reflection;
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
 
     /// <summary>Holder for reflection information generated from request_status.proto</summary>
@@ -33,8 +33,8 @@ namespace ModelAnalyzer.Client
             "Cg5BTFJFQURZX0VYSVNUUxAIYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::ModelAnalyzer.Client.RequestStatusCode), }, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.RequestStatus), global::ModelAnalyzer.Client.RequestStatus.Parser, new[]{ "Code", "Msg", "ServerId", "RequestId" }, null, null, null)
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Triton.MemoryAnalyzer.Client.RequestStatusCode), }, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.RequestStatus), global::Triton.MemoryAnalyzer.Client.RequestStatus.Parser, new[]{ "Code", "Msg", "ServerId", "RequestId" }, null, null, null)
           }));
     }
     #endregion
@@ -138,7 +138,7 @@ namespace ModelAnalyzer.Client
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::ModelAnalyzer.Client.RequestStatusReflection.Descriptor.MessageTypes[0]; }
+      get { return global::Triton.MemoryAnalyzer.Client.RequestStatusReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -169,7 +169,7 @@ namespace ModelAnalyzer.Client
 
     /// <summary>Field number for the "code" field.</summary>
     public const int CodeFieldNumber = 1;
-    private global::ModelAnalyzer.Client.RequestStatusCode code_ = 0;
+    private global::Triton.MemoryAnalyzer.Client.RequestStatusCode code_ = 0;
     /// <summary>
     ///@@  .. cpp:var:: RequestStatusCode code
     ///@@
@@ -177,7 +177,7 @@ namespace ModelAnalyzer.Client
     ///@@
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::ModelAnalyzer.Client.RequestStatusCode Code {
+    public global::Triton.MemoryAnalyzer.Client.RequestStatusCode Code {
       get { return code_; }
       set {
         code_ = value;
@@ -348,7 +348,7 @@ namespace ModelAnalyzer.Client
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 8: {
-            Code = (global::ModelAnalyzer.Client.RequestStatusCode) input.ReadEnum();
+            Code = (global::Triton.MemoryAnalyzer.Client.RequestStatusCode) input.ReadEnum();
             break;
           }
           case 18: {

--- a/src/Client/Grpc/ServerStatus.cs
+++ b/src/Client/Grpc/ServerStatus.cs
@@ -8,7 +8,7 @@
 using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
 
     /// <summary>Holder for reflection information generated from server_status.proto</summary>
@@ -95,23 +95,23 @@ namespace ModelAnalyzer.Client
                   "VElBTElaSU5HEAESEAoMU0VSVkVSX1JFQURZEAISEgoOU0VSVkVSX0VYSVRJ",
                   "TkcQAxIfChtTRVJWRVJfRkFJTEVEX1RPX0lOSVRJQUxJWkUQCmIGcHJvdG8z"));
             descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-                new pbr::FileDescriptor[] { global::ModelAnalyzer.Client.ModelConfigReflection.Descriptor, },
-                new pbr::GeneratedClrTypeInfo(new[] { typeof(global::ModelAnalyzer.Client.ModelReadyState), typeof(global::ModelAnalyzer.Client.ServerReadyState), }, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.StatDuration), global::ModelAnalyzer.Client.StatDuration.Parser, new[]{ "Count", "TotalTimeNs" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.StatusRequestStats), global::ModelAnalyzer.Client.StatusRequestStats.Parser, new[]{ "Success" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.HealthRequestStats), global::ModelAnalyzer.Client.HealthRequestStats.Parser, new[]{ "Success" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelControlRequestStats), global::ModelAnalyzer.Client.ModelControlRequestStats.Parser, new[]{ "Success" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryControlRequestStats), global::ModelAnalyzer.Client.SharedMemoryControlRequestStats.Parser, new[]{ "Success" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.RepositoryRequestStats), global::ModelAnalyzer.Client.RepositoryRequestStats.Parser, new[]{ "Success" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.InferRequestStats), global::ModelAnalyzer.Client.InferRequestStats.Parser, new[]{ "Success", "Failed", "Compute", "Queue" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelReadyStateReason), global::ModelAnalyzer.Client.ModelReadyStateReason.Parser, new[]{ "Message" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelVersionStatus), global::ModelAnalyzer.Client.ModelVersionStatus.Parser, new[]{ "ReadyState", "ReadyStateReason", "InferStats", "ModelExecutionCount", "ModelInferenceCount", "LastInferenceTimestampMilliseconds" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelStatus), global::ModelAnalyzer.Client.ModelStatus.Parser, new[]{ "Config", "VersionStatus" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryRegion), global::ModelAnalyzer.Client.SharedMemoryRegion.Parser, new[]{ "Name", "SystemSharedMemory", "CudaSharedMemory", "ByteSize" }, new[]{ "SharedMemoryTypes" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory), global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory.Parser, new[]{ "SharedMemoryKey", "Offset" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory), global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory.Parser, new[]{ "DeviceId" }, null, null, null)}),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ServerStatus), global::ModelAnalyzer.Client.ServerStatus.Parser, new[]{ "Id", "Version", "ReadyState", "UptimeNs", "ModelStatus", "StatusStats", "HealthStats", "ModelControlStats", "ShmControlStats", "RepositoryStats" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.SharedMemoryStatus), global::ModelAnalyzer.Client.SharedMemoryStatus.Parser, new[]{ "SharedMemoryRegion" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelRepositoryIndex), global::ModelAnalyzer.Client.ModelRepositoryIndex.Parser, new[]{ "Models" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry), global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry.Parser, new[]{ "Name" }, null, null, null)})
+                new pbr::FileDescriptor[] { global::Triton.MemoryAnalyzer.Client.ModelConfigReflection.Descriptor, },
+                new pbr::GeneratedClrTypeInfo(new[] { typeof(global::Triton.MemoryAnalyzer.Client.ModelReadyState), typeof(global::Triton.MemoryAnalyzer.Client.ServerReadyState), }, new pbr::GeneratedClrTypeInfo[] {
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.StatDuration), global::Triton.MemoryAnalyzer.Client.StatDuration.Parser, new[]{ "Count", "TotalTimeNs" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.StatusRequestStats), global::Triton.MemoryAnalyzer.Client.StatusRequestStats.Parser, new[]{ "Success" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.HealthRequestStats), global::Triton.MemoryAnalyzer.Client.HealthRequestStats.Parser, new[]{ "Success" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats), global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats.Parser, new[]{ "Success" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats), global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats.Parser, new[]{ "Success" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats), global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats.Parser, new[]{ "Success" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.InferRequestStats), global::Triton.MemoryAnalyzer.Client.InferRequestStats.Parser, new[]{ "Success", "Failed", "Compute", "Queue" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason), global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason.Parser, new[]{ "Message" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelVersionStatus), global::Triton.MemoryAnalyzer.Client.ModelVersionStatus.Parser, new[]{ "ReadyState", "ReadyStateReason", "InferStats", "ModelExecutionCount", "ModelInferenceCount", "LastInferenceTimestampMilliseconds" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelStatus), global::Triton.MemoryAnalyzer.Client.ModelStatus.Parser, new[]{ "Config", "VersionStatus" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion), global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Parser, new[]{ "Name", "SystemSharedMemory", "CudaSharedMemory", "ByteSize" }, new[]{ "SharedMemoryTypes" }, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory), global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory.Parser, new[]{ "SharedMemoryKey", "Offset" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory), global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory.Parser, new[]{ "DeviceId" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ServerStatus), global::Triton.MemoryAnalyzer.Client.ServerStatus.Parser, new[]{ "Id", "Version", "ReadyState", "UptimeNs", "ModelStatus", "StatusStats", "HealthStats", "ModelControlStats", "ShmControlStats", "RepositoryStats" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.SharedMemoryStatus), global::Triton.MemoryAnalyzer.Client.SharedMemoryStatus.Parser, new[]{ "SharedMemoryRegion" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex), global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Parser, new[]{ "Models" }, null, null, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry), global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry.Parser, new[]{ "Name" }, null, null, null)})
                 }));
         }
         #endregion
@@ -236,7 +236,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[0]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[0]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -446,7 +446,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[1]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[1]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -478,7 +478,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -487,7 +487,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -575,7 +575,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -597,7 +597,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -625,7 +625,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[2]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[2]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -657,7 +657,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -666,7 +666,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -754,7 +754,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -776,7 +776,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -804,7 +804,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[3]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[3]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -836,7 +836,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -845,7 +845,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -933,7 +933,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -955,7 +955,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -983,7 +983,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[4]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[4]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1015,7 +1015,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -1024,7 +1024,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -1112,7 +1112,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -1134,7 +1134,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -1162,7 +1162,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[5]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[5]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1194,7 +1194,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -1203,7 +1203,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -1291,7 +1291,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -1313,7 +1313,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -1341,7 +1341,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[6]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[6]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1376,7 +1376,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "success" field.</summary>
         public const int SuccessFieldNumber = 1;
-        private global::ModelAnalyzer.Client.StatDuration success_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration success_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration success
         ///@@
@@ -1385,7 +1385,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Success
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Success
         {
             get { return success_; }
             set
@@ -1396,7 +1396,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "failed" field.</summary>
         public const int FailedFieldNumber = 2;
-        private global::ModelAnalyzer.Client.StatDuration failed_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration failed_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration failed
         ///@@
@@ -1405,7 +1405,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Failed
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Failed
         {
             get { return failed_; }
             set
@@ -1416,7 +1416,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "compute" field.</summary>
         public const int ComputeFieldNumber = 3;
-        private global::ModelAnalyzer.Client.StatDuration compute_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration compute_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration compute
         ///@@
@@ -1427,7 +1427,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Compute
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Compute
         {
             get { return compute_; }
             set
@@ -1438,7 +1438,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "queue" field.</summary>
         public const int QueueFieldNumber = 4;
-        private global::ModelAnalyzer.Client.StatDuration queue_;
+        private global::Triton.MemoryAnalyzer.Client.StatDuration queue_;
         /// <summary>
         ///@@  .. cpp:var:: StatDuration queue
         ///@@
@@ -1447,7 +1447,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatDuration Queue
+        public global::Triton.MemoryAnalyzer.Client.StatDuration Queue
         {
             get { return queue_; }
             set
@@ -1568,7 +1568,7 @@ namespace ModelAnalyzer.Client
             {
                 if (success_ == null)
                 {
-                    Success = new global::ModelAnalyzer.Client.StatDuration();
+                    Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Success.MergeFrom(other.Success);
             }
@@ -1576,7 +1576,7 @@ namespace ModelAnalyzer.Client
             {
                 if (failed_ == null)
                 {
-                    Failed = new global::ModelAnalyzer.Client.StatDuration();
+                    Failed = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Failed.MergeFrom(other.Failed);
             }
@@ -1584,7 +1584,7 @@ namespace ModelAnalyzer.Client
             {
                 if (compute_ == null)
                 {
-                    Compute = new global::ModelAnalyzer.Client.StatDuration();
+                    Compute = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Compute.MergeFrom(other.Compute);
             }
@@ -1592,7 +1592,7 @@ namespace ModelAnalyzer.Client
             {
                 if (queue_ == null)
                 {
-                    Queue = new global::ModelAnalyzer.Client.StatDuration();
+                    Queue = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                 }
                 Queue.MergeFrom(other.Queue);
             }
@@ -1614,7 +1614,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (success_ == null)
                             {
-                                Success = new global::ModelAnalyzer.Client.StatDuration();
+                                Success = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Success);
                             break;
@@ -1623,7 +1623,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (failed_ == null)
                             {
-                                Failed = new global::ModelAnalyzer.Client.StatDuration();
+                                Failed = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Failed);
                             break;
@@ -1632,7 +1632,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (compute_ == null)
                             {
-                                Compute = new global::ModelAnalyzer.Client.StatDuration();
+                                Compute = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Compute);
                             break;
@@ -1641,7 +1641,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (queue_ == null)
                             {
-                                Queue = new global::ModelAnalyzer.Client.StatDuration();
+                                Queue = new global::Triton.MemoryAnalyzer.Client.StatDuration();
                             }
                             input.ReadMessage(Queue);
                             break;
@@ -1669,7 +1669,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[7]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[7]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1840,7 +1840,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[8]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[8]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1877,7 +1877,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "ready_state" field.</summary>
         public const int ReadyStateFieldNumber = 1;
-        private global::ModelAnalyzer.Client.ModelReadyState readyState_ = 0;
+        private global::Triton.MemoryAnalyzer.Client.ModelReadyState readyState_ = 0;
         /// <summary>
         ///@@  .. cpp:var:: ModelReadyState ready_state
         ///@@
@@ -1885,7 +1885,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ModelReadyState ReadyState
+        public global::Triton.MemoryAnalyzer.Client.ModelReadyState ReadyState
         {
             get { return readyState_; }
             set
@@ -1896,7 +1896,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "ready_state_reason" field.</summary>
         public const int ReadyStateReasonFieldNumber = 5;
-        private global::ModelAnalyzer.Client.ModelReadyStateReason readyStateReason_;
+        private global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason readyStateReason_;
         /// <summary>
         ///@@  .. cpp:var:: ModelReadyStateReason ready_state_reason
         ///@@
@@ -1904,7 +1904,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ModelReadyStateReason ReadyStateReason
+        public global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason ReadyStateReason
         {
             get { return readyStateReason_; }
             set
@@ -1915,9 +1915,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "infer_stats" field.</summary>
         public const int InferStatsFieldNumber = 2;
-        private static readonly pbc::MapField<uint, global::ModelAnalyzer.Client.InferRequestStats>.Codec _map_inferStats_codec
-            = new pbc::MapField<uint, global::ModelAnalyzer.Client.InferRequestStats>.Codec(pb::FieldCodec.ForUInt32(8), pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.InferRequestStats.Parser), 18);
-        private readonly pbc::MapField<uint, global::ModelAnalyzer.Client.InferRequestStats> inferStats_ = new pbc::MapField<uint, global::ModelAnalyzer.Client.InferRequestStats>();
+        private static readonly pbc::MapField<uint, global::Triton.MemoryAnalyzer.Client.InferRequestStats>.Codec _map_inferStats_codec
+            = new pbc::MapField<uint, global::Triton.MemoryAnalyzer.Client.InferRequestStats>.Codec(pb::FieldCodec.ForUInt32(8), pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.InferRequestStats.Parser), 18);
+        private readonly pbc::MapField<uint, global::Triton.MemoryAnalyzer.Client.InferRequestStats> inferStats_ = new pbc::MapField<uint, global::Triton.MemoryAnalyzer.Client.InferRequestStats>();
         /// <summary>
         ///@@  .. cpp:var:: map&lt;uint32, InferRequestStats> infer_stats
         ///@@
@@ -1928,7 +1928,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::MapField<uint, global::ModelAnalyzer.Client.InferRequestStats> InferStats
+        public pbc::MapField<uint, global::Triton.MemoryAnalyzer.Client.InferRequestStats> InferStats
         {
             get { return inferStats_; }
         }
@@ -2127,7 +2127,7 @@ namespace ModelAnalyzer.Client
             {
                 if (readyStateReason_ == null)
                 {
-                    ReadyStateReason = new global::ModelAnalyzer.Client.ModelReadyStateReason();
+                    ReadyStateReason = new global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason();
                 }
                 ReadyStateReason.MergeFrom(other.ReadyStateReason);
             }
@@ -2160,7 +2160,7 @@ namespace ModelAnalyzer.Client
                         break;
                     case 8:
                         {
-                            ReadyState = (global::ModelAnalyzer.Client.ModelReadyState)input.ReadEnum();
+                            ReadyState = (global::Triton.MemoryAnalyzer.Client.ModelReadyState)input.ReadEnum();
                             break;
                         }
                     case 18:
@@ -2182,7 +2182,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (readyStateReason_ == null)
                             {
-                                ReadyStateReason = new global::ModelAnalyzer.Client.ModelReadyStateReason();
+                                ReadyStateReason = new global::Triton.MemoryAnalyzer.Client.ModelReadyStateReason();
                             }
                             input.ReadMessage(ReadyStateReason);
                             break;
@@ -2215,7 +2215,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[9]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[9]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2248,7 +2248,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "config" field.</summary>
         public const int ConfigFieldNumber = 1;
-        private global::ModelAnalyzer.Client.ModelConfig config_;
+        private global::Triton.MemoryAnalyzer.Client.ModelConfig config_;
         /// <summary>
         ///@@  .. cpp:var:: ModelConfig config
         ///@@
@@ -2256,7 +2256,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ModelConfig Config
+        public global::Triton.MemoryAnalyzer.Client.ModelConfig Config
         {
             get { return config_; }
             set
@@ -2267,9 +2267,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "version_status" field.</summary>
         public const int VersionStatusFieldNumber = 2;
-        private static readonly pbc::MapField<long, global::ModelAnalyzer.Client.ModelVersionStatus>.Codec _map_versionStatus_codec
-            = new pbc::MapField<long, global::ModelAnalyzer.Client.ModelVersionStatus>.Codec(pb::FieldCodec.ForInt64(8), pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelVersionStatus.Parser), 18);
-        private readonly pbc::MapField<long, global::ModelAnalyzer.Client.ModelVersionStatus> versionStatus_ = new pbc::MapField<long, global::ModelAnalyzer.Client.ModelVersionStatus>();
+        private static readonly pbc::MapField<long, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus>.Codec _map_versionStatus_codec
+            = new pbc::MapField<long, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus>.Codec(pb::FieldCodec.ForInt64(8), pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus.Parser), 18);
+        private readonly pbc::MapField<long, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus> versionStatus_ = new pbc::MapField<long, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus>();
         /// <summary>
         ///@@  .. cpp:var:: map&lt;int64, ModelVersionStatus> version_status
         ///@@
@@ -2281,7 +2281,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::MapField<long, global::ModelAnalyzer.Client.ModelVersionStatus> VersionStatus
+        public pbc::MapField<long, global::Triton.MemoryAnalyzer.Client.ModelVersionStatus> VersionStatus
         {
             get { return versionStatus_; }
         }
@@ -2369,7 +2369,7 @@ namespace ModelAnalyzer.Client
             {
                 if (config_ == null)
                 {
-                    Config = new global::ModelAnalyzer.Client.ModelConfig();
+                    Config = new global::Triton.MemoryAnalyzer.Client.ModelConfig();
                 }
                 Config.MergeFrom(other.Config);
             }
@@ -2392,7 +2392,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (config_ == null)
                             {
-                                Config = new global::ModelAnalyzer.Client.ModelConfig();
+                                Config = new global::Triton.MemoryAnalyzer.Client.ModelConfig();
                             }
                             input.ReadMessage(Config);
                             break;
@@ -2425,7 +2425,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[10]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[10]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2496,9 +2496,9 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory SystemSharedMemory
+        public global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory SystemSharedMemory
         {
-            get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory ? (global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory)sharedMemoryTypes_ : null; }
+            get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory)sharedMemoryTypes_ : null; }
             set
             {
                 sharedMemoryTypes_ = value;
@@ -2516,9 +2516,9 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory CudaSharedMemory
+        public global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory CudaSharedMemory
         {
-            get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory ? (global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory)sharedMemoryTypes_ : null; }
+            get { return sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory ? (global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory)sharedMemoryTypes_ : null; }
             set
             {
                 sharedMemoryTypes_ = value;
@@ -2690,14 +2690,14 @@ namespace ModelAnalyzer.Client
                 case SharedMemoryTypesOneofCase.SystemSharedMemory:
                     if (SystemSharedMemory == null)
                     {
-                        SystemSharedMemory = new global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory();
+                        SystemSharedMemory = new global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory();
                     }
                     SystemSharedMemory.MergeFrom(other.SystemSharedMemory);
                     break;
                 case SharedMemoryTypesOneofCase.CudaSharedMemory:
                     if (CudaSharedMemory == null)
                     {
-                        CudaSharedMemory = new global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory();
+                        CudaSharedMemory = new global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory();
                     }
                     CudaSharedMemory.MergeFrom(other.CudaSharedMemory);
                     break;
@@ -2724,7 +2724,7 @@ namespace ModelAnalyzer.Client
                         }
                     case 18:
                         {
-                            global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory subBuilder = new global::ModelAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory();
+                            global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.SystemSharedMemory();
                             if (sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.SystemSharedMemory)
                             {
                                 subBuilder.MergeFrom(SystemSharedMemory);
@@ -2735,7 +2735,7 @@ namespace ModelAnalyzer.Client
                         }
                     case 26:
                         {
-                            global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory subBuilder = new global::ModelAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory();
+                            global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory subBuilder = new global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Types.CudaSharedMemory();
                             if (sharedMemoryTypesCase_ == SharedMemoryTypesOneofCase.CudaSharedMemory)
                             {
                                 subBuilder.MergeFrom(CudaSharedMemory);
@@ -2768,7 +2768,7 @@ namespace ModelAnalyzer.Client
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
                 public static pbr::MessageDescriptor Descriptor
                 {
-                    get { return global::ModelAnalyzer.Client.SharedMemoryRegion.Descriptor.NestedTypes[0]; }
+                    get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Descriptor.NestedTypes[0]; }
                 }
 
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2974,7 +2974,7 @@ namespace ModelAnalyzer.Client
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
                 public static pbr::MessageDescriptor Descriptor
                 {
-                    get { return global::ModelAnalyzer.Client.SharedMemoryRegion.Descriptor.NestedTypes[1]; }
+                    get { return global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Descriptor.NestedTypes[1]; }
                 }
 
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3149,7 +3149,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[11]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[11]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3228,7 +3228,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "ready_state" field.</summary>
         public const int ReadyStateFieldNumber = 7;
-        private global::ModelAnalyzer.Client.ServerReadyState readyState_ = 0;
+        private global::Triton.MemoryAnalyzer.Client.ServerReadyState readyState_ = 0;
         /// <summary>
         ///@@  .. cpp:var:: ServerReadyState ready_state
         ///@@
@@ -3236,7 +3236,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ServerReadyState ReadyState
+        public global::Triton.MemoryAnalyzer.Client.ServerReadyState ReadyState
         {
             get { return readyState_; }
             set
@@ -3266,9 +3266,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "model_status" field.</summary>
         public const int ModelStatusFieldNumber = 4;
-        private static readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelStatus>.Codec _map_modelStatus_codec
-            = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelStatus>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.ModelStatus.Parser), 34);
-        private readonly pbc::MapField<string, global::ModelAnalyzer.Client.ModelStatus> modelStatus_ = new pbc::MapField<string, global::ModelAnalyzer.Client.ModelStatus>();
+        private static readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelStatus>.Codec _map_modelStatus_codec
+            = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelStatus>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.ModelStatus.Parser), 34);
+        private readonly pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelStatus> modelStatus_ = new pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelStatus>();
         /// <summary>
         ///@@  .. cpp:var:: map&lt;string, ModelStatus> model_status
         ///@@
@@ -3277,14 +3277,14 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::MapField<string, global::ModelAnalyzer.Client.ModelStatus> ModelStatus
+        public pbc::MapField<string, global::Triton.MemoryAnalyzer.Client.ModelStatus> ModelStatus
         {
             get { return modelStatus_; }
         }
 
         /// <summary>Field number for the "status_stats" field.</summary>
         public const int StatusStatsFieldNumber = 5;
-        private global::ModelAnalyzer.Client.StatusRequestStats statusStats_;
+        private global::Triton.MemoryAnalyzer.Client.StatusRequestStats statusStats_;
         /// <summary>
         ///@@  .. cpp:var:: StatusRequestStats status_stats
         ///@@
@@ -3292,7 +3292,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.StatusRequestStats StatusStats
+        public global::Triton.MemoryAnalyzer.Client.StatusRequestStats StatusStats
         {
             get { return statusStats_; }
             set
@@ -3303,7 +3303,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "health_stats" field.</summary>
         public const int HealthStatsFieldNumber = 8;
-        private global::ModelAnalyzer.Client.HealthRequestStats healthStats_;
+        private global::Triton.MemoryAnalyzer.Client.HealthRequestStats healthStats_;
         /// <summary>
         ///@@  .. cpp:var:: HealthRequestStats health_stats
         ///@@
@@ -3311,7 +3311,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.HealthRequestStats HealthStats
+        public global::Triton.MemoryAnalyzer.Client.HealthRequestStats HealthStats
         {
             get { return healthStats_; }
             set
@@ -3322,7 +3322,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "model_control_stats" field.</summary>
         public const int ModelControlStatsFieldNumber = 9;
-        private global::ModelAnalyzer.Client.ModelControlRequestStats modelControlStats_;
+        private global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats modelControlStats_;
         /// <summary>
         ///@@  .. cpp:var:: ModelControlRequestStats model_control_stats
         ///@@
@@ -3330,7 +3330,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.ModelControlRequestStats ModelControlStats
+        public global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats ModelControlStats
         {
             get { return modelControlStats_; }
             set
@@ -3341,7 +3341,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "shm_control_stats" field.</summary>
         public const int ShmControlStatsFieldNumber = 10;
-        private global::ModelAnalyzer.Client.SharedMemoryControlRequestStats shmControlStats_;
+        private global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats shmControlStats_;
         /// <summary>
         ///@@  .. cpp:var:: SharedMemoryControlRequestStats shm_control_stats
         ///@@
@@ -3349,7 +3349,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.SharedMemoryControlRequestStats ShmControlStats
+        public global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats ShmControlStats
         {
             get { return shmControlStats_; }
             set
@@ -3360,7 +3360,7 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "repository_stats" field.</summary>
         public const int RepositoryStatsFieldNumber = 11;
-        private global::ModelAnalyzer.Client.RepositoryRequestStats repositoryStats_;
+        private global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats repositoryStats_;
         /// <summary>
         ///@@  .. cpp:var:: RepositoryRequestStats repository_stats
         ///@@
@@ -3368,7 +3368,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public global::ModelAnalyzer.Client.RepositoryRequestStats RepositoryStats
+        public global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats RepositoryStats
         {
             get { return repositoryStats_; }
             set
@@ -3565,7 +3565,7 @@ namespace ModelAnalyzer.Client
             {
                 if (statusStats_ == null)
                 {
-                    StatusStats = new global::ModelAnalyzer.Client.StatusRequestStats();
+                    StatusStats = new global::Triton.MemoryAnalyzer.Client.StatusRequestStats();
                 }
                 StatusStats.MergeFrom(other.StatusStats);
             }
@@ -3573,7 +3573,7 @@ namespace ModelAnalyzer.Client
             {
                 if (healthStats_ == null)
                 {
-                    HealthStats = new global::ModelAnalyzer.Client.HealthRequestStats();
+                    HealthStats = new global::Triton.MemoryAnalyzer.Client.HealthRequestStats();
                 }
                 HealthStats.MergeFrom(other.HealthStats);
             }
@@ -3581,7 +3581,7 @@ namespace ModelAnalyzer.Client
             {
                 if (modelControlStats_ == null)
                 {
-                    ModelControlStats = new global::ModelAnalyzer.Client.ModelControlRequestStats();
+                    ModelControlStats = new global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats();
                 }
                 ModelControlStats.MergeFrom(other.ModelControlStats);
             }
@@ -3589,7 +3589,7 @@ namespace ModelAnalyzer.Client
             {
                 if (shmControlStats_ == null)
                 {
-                    ShmControlStats = new global::ModelAnalyzer.Client.SharedMemoryControlRequestStats();
+                    ShmControlStats = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats();
                 }
                 ShmControlStats.MergeFrom(other.ShmControlStats);
             }
@@ -3597,7 +3597,7 @@ namespace ModelAnalyzer.Client
             {
                 if (repositoryStats_ == null)
                 {
-                    RepositoryStats = new global::ModelAnalyzer.Client.RepositoryRequestStats();
+                    RepositoryStats = new global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats();
                 }
                 RepositoryStats.MergeFrom(other.RepositoryStats);
             }
@@ -3639,21 +3639,21 @@ namespace ModelAnalyzer.Client
                         {
                             if (statusStats_ == null)
                             {
-                                StatusStats = new global::ModelAnalyzer.Client.StatusRequestStats();
+                                StatusStats = new global::Triton.MemoryAnalyzer.Client.StatusRequestStats();
                             }
                             input.ReadMessage(StatusStats);
                             break;
                         }
                     case 56:
                         {
-                            ReadyState = (global::ModelAnalyzer.Client.ServerReadyState)input.ReadEnum();
+                            ReadyState = (global::Triton.MemoryAnalyzer.Client.ServerReadyState)input.ReadEnum();
                             break;
                         }
                     case 66:
                         {
                             if (healthStats_ == null)
                             {
-                                HealthStats = new global::ModelAnalyzer.Client.HealthRequestStats();
+                                HealthStats = new global::Triton.MemoryAnalyzer.Client.HealthRequestStats();
                             }
                             input.ReadMessage(HealthStats);
                             break;
@@ -3662,7 +3662,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (modelControlStats_ == null)
                             {
-                                ModelControlStats = new global::ModelAnalyzer.Client.ModelControlRequestStats();
+                                ModelControlStats = new global::Triton.MemoryAnalyzer.Client.ModelControlRequestStats();
                             }
                             input.ReadMessage(ModelControlStats);
                             break;
@@ -3671,7 +3671,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (shmControlStats_ == null)
                             {
-                                ShmControlStats = new global::ModelAnalyzer.Client.SharedMemoryControlRequestStats();
+                                ShmControlStats = new global::Triton.MemoryAnalyzer.Client.SharedMemoryControlRequestStats();
                             }
                             input.ReadMessage(ShmControlStats);
                             break;
@@ -3680,7 +3680,7 @@ namespace ModelAnalyzer.Client
                         {
                             if (repositoryStats_ == null)
                             {
-                                RepositoryStats = new global::ModelAnalyzer.Client.RepositoryRequestStats();
+                                RepositoryStats = new global::Triton.MemoryAnalyzer.Client.RepositoryRequestStats();
                             }
                             input.ReadMessage(RepositoryStats);
                             break;
@@ -3708,7 +3708,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[12]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[12]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3740,9 +3740,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "shared_memory_region" field.</summary>
         public const int SharedMemoryRegionFieldNumber = 2;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.SharedMemoryRegion> _repeated_sharedMemoryRegion_codec
-            = pb::FieldCodec.ForMessage(18, global::ModelAnalyzer.Client.SharedMemoryRegion.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion> sharedMemoryRegion_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> _repeated_sharedMemoryRegion_codec
+            = pb::FieldCodec.ForMessage(18, global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> sharedMemoryRegion_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion>();
         /// <summary>
         ///@@
         ///@@  .. cpp:var:: SharedMemoryRegion shared_memory_region (repeated)
@@ -3751,7 +3751,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.SharedMemoryRegion> SharedMemoryRegion
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.SharedMemoryRegion> SharedMemoryRegion
         {
             get { return sharedMemoryRegion_; }
         }
@@ -3867,7 +3867,7 @@ namespace ModelAnalyzer.Client
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pbr::MessageDescriptor Descriptor
         {
-            get { return global::ModelAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[13]; }
+            get { return global::Triton.MemoryAnalyzer.Client.ServerStatusReflection.Descriptor.MessageTypes[13]; }
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3899,9 +3899,9 @@ namespace ModelAnalyzer.Client
 
         /// <summary>Field number for the "models" field.</summary>
         public const int ModelsFieldNumber = 1;
-        private static readonly pb::FieldCodec<global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> _repeated_models_codec
-            = pb::FieldCodec.ForMessage(10, global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry.Parser);
-        private readonly pbc::RepeatedField<global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> models_ = new pbc::RepeatedField<global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry>();
+        private static readonly pb::FieldCodec<global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> _repeated_models_codec
+            = pb::FieldCodec.ForMessage(10, global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry.Parser);
+        private readonly pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> models_ = new pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry>();
         /// <summary>
         ///@@
         ///@@  .. cpp:var:: ModelEntry models (repeated)
@@ -3910,7 +3910,7 @@ namespace ModelAnalyzer.Client
         ///@@
         /// </summary>
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-        public pbc::RepeatedField<global::ModelAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> Models
+        public pbc::RepeatedField<global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Types.ModelEntry> Models
         {
             get { return models_; }
         }
@@ -4029,7 +4029,7 @@ namespace ModelAnalyzer.Client
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
                 public static pbr::MessageDescriptor Descriptor
                 {
-                    get { return global::ModelAnalyzer.Client.ModelRepositoryIndex.Descriptor.NestedTypes[0]; }
+                    get { return global::Triton.MemoryAnalyzer.Client.ModelRepositoryIndex.Descriptor.NestedTypes[0]; }
                 }
 
                 [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/src/Client/TritonGrpcClient.cs
+++ b/src/Client/TritonGrpcClient.cs
@@ -26,13 +26,13 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-using Grpc.Core;
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Grpc.Core;
 
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
     /// <summary>
     /// Interface to an object which abstracts the client calls to the Inference Server.
@@ -116,7 +116,7 @@ namespace ModelAnalyzer.Client
 
             try
             {
-                var grpcClient = new GRPCService.GRPCServiceClient(channel);
+                var grpcClient = new MemoryAnalyzer.Client.GRPCService.GRPCServiceClient(channel);
 
                 foreach (var modelName in models)
                 {

--- a/src/Client/TritonGrpcStatus.cs
+++ b/src/Client/TritonGrpcStatus.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 
 using static System.StringComparer;
 
-namespace ModelAnalyzer.Client
+namespace Triton.MemoryAnalyzer.Client
 {
     /// <summary>
     /// Interface to an object which defines the inference server status returned by making a

--- a/src/GpuMetricSample.cs
+++ b/src/GpuMetricSample.cs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *****************************************************************************/
 
-using ModelAnalyzer.Metrics;
 using System;
+using Triton.MemoryAnalyzer.Metrics;
 
-namespace ModelAnalyzer
+namespace Triton.MemoryAnalyzer
 {
     /// <summary>
     /// Class to store an instance of Gpu Metrics

--- a/src/Metrics/FieldGroup.cs
+++ b/src/Metrics/FieldGroup.cs
@@ -17,7 +17,7 @@ limitations under the License.
 using System;
 using static System.Threading.Interlocked;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     public struct FieldGroupInfo
     {

--- a/src/Metrics/GpuGroup.cs
+++ b/src/Metrics/GpuGroup.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using static System.Threading.Interlocked;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     /// <summary>
     /// GPU group information.

--- a/src/Metrics/GpuMetrics.cs
+++ b/src/Metrics/GpuMetrics.cs
@@ -16,7 +16,7 @@ limitations under the License.
 
 using System;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     /// <summary>
     /// GPU metrics interface

--- a/src/Metrics/Watcher.cs
+++ b/src/Metrics/Watcher.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Text;
 using static System.Threading.Interlocked;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     /// <summary>
     /// Represents field data values.

--- a/src/Metrics/libdcgm/constants.cs
+++ b/src/Metrics/libdcgm/constants.cs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *****************************************************************************/
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     partial class libdcgm
     {

--- a/src/Metrics/libdcgm/functions.cs
+++ b/src/Metrics/libdcgm/functions.cs
@@ -17,7 +17,7 @@ limitations under the License.
 using System;
 using System.Runtime.InteropServices;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     static unsafe partial class libdcgm
     {

--- a/src/Metrics/libdcgm/types.cs
+++ b/src/Metrics/libdcgm/types.cs
@@ -17,7 +17,7 @@ limitations under the License.
 using System;
 using System.Runtime.InteropServices;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     /// <summary>
     /// Represents a set of memory, SM, and video clocks for a device. This can be current values or a target values based on context

--- a/src/Metrics/libdcgm/utils.cs
+++ b/src/Metrics/libdcgm/utils.cs
@@ -17,7 +17,7 @@ limitations under the License.
 using System;
 using System.Runtime.InteropServices;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     internal static class Utils
     {

--- a/src/MetricsCollector.cs
+++ b/src/MetricsCollector.cs
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *****************************************************************************/
 
-using ModelAnalyzer.Metrics;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using Triton.MemoryAnalyzer.Metrics;
 
-namespace ModelAnalyzer
+namespace Triton.MemoryAnalyzer
 {
     /// <summary>
     /// Class used to store configuration of Metrics Collector

--- a/src/ModelAnalyzer.cs
+++ b/src/ModelAnalyzer.cs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *****************************************************************************/
 
-using ModelAnalyzer.Client;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -22,8 +21,9 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Triton.MemoryAnalyzer.Client;
 
-namespace ModelAnalyzer
+namespace Triton.MemoryAnalyzer
 {
     /// <summary>
     /// Class used to store configuration of Model Analyzer

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *****************************************************************************/
 
-using CommandLine;
-using ModelAnalyzer.Client;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using CommandLine;
+using Triton.MemoryAnalyzer.Client;
 
-namespace ModelAnalyzer
+namespace Triton.MemoryAnalyzer
 {
     /// <summary>
     /// Class for launching Model Analyzer

--- a/src/Triton.MemoryAnalyzer.csproj
+++ b/src/Triton.MemoryAnalyzer.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020, NVIDIA CORPORATION.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,19 +17,22 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyName>memory-analyzer</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <Optimize>true</Optimize>
+    <OutputType>Exe</OutputType>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../src/model-analyzer.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
+    <PackageReference Include="Grpc" Version="2.31.0" />
     <PackageReference Include="Nvidia.Dcgm.Client-Linux64" Version="1.7.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/FunctionalTests.cs
+++ b/tests/FunctionalTests.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 using System.Xml;
 using Xunit;
 
-namespace ModelAnalyzer.Metrics
+namespace Triton.MemoryAnalyzer.Metrics
 {
     public class GpuMetricsTest
     {

--- a/tests/Triton.MemoryAnalyzer.Tests.csproj
+++ b/tests/Triton.MemoryAnalyzer.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 Copyright 2020, NVIDIA CORPORATION.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,21 +17,27 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <Optimize>true</Optimize>
-    <OutputType>Exe</OutputType>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc" Version="2.31.0" />
+    <ProjectReference Include="../src/Triton.MemoryAnalyzer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Nvidia.Dcgm.Client-Linux64" Version="1.7.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change renames the project from "Model Analyzer" to "Triton Memory Analyzer" to better align its name with its intended use case.

Follow-up changes will remove the GPU utilization data outputs from the project. These are being removed because they can provide a misleading picture of the actual GPU utilization, and because Triton Performance Analyzer provides clearer and more accurate information.

/CC @deadeyegoodwin 