### PR TITLE
Add a separator to OutputTable.to_string_formatter

### DIFF
--- a/model_analyzer/output/output_table.py
+++ b/model_analyzer/output/output_table.py
@@ -32,6 +32,7 @@ class OutputTable:
     generic table interface 
     with headers rows
     """
+
     def __init__(self, headers):
         """
         Parameters
@@ -174,7 +175,7 @@ class OutputTable:
         index = self._headers.index(header)
         self.remove_column_by_index(index)
 
-    def to_formatted_string(self, column_width=12):
+    def to_formatted_string(self, column_width=None, separator=''):
         """
         Converts the table into its string representation
         making it easy to write by a writer
@@ -183,7 +184,11 @@ class OutputTable:
         ----------
         column_width : int
             The width in characters of each column in this
-            table.
+            table. If None, then each cell will be the width 
+            of its contents.
+        separator : str
+            The string that will separate columns of a row in th
+            table
         
         Returns
         -------
@@ -192,16 +197,19 @@ class OutputTable:
         """
         output_rows = []
         for row in [self._headers] + self._rows:
-            output_rows.append(self._row_to_string(row, column_width))
+            output_rows.append(
+                self._row_to_string(row, column_width, separator))
         return '\n'.join(output_rows)
 
-    def _row_to_string(self, row, column_width=12):
+    def _row_to_string(self, row, column_width, separator):
         """
         Converts a single row to 
         its string representation
         """
-        return ''.join(
-            [self._pad_or_trunc(str(val), column_width) for val in row])
+        return separator.join([
+            self._pad_or_trunc(str(val), column_width)
+            if column_width else str(val) for val in row
+        ])
 
     def _pad_or_trunc(self, string, length):
         """

--- a/model_analyzer/perf_analyzer/perf_config.py
+++ b/model_analyzer/perf_analyzer/perf_config.py
@@ -124,9 +124,9 @@ class PerfAnalyzerConfig:
         if key in self._args:
             return self._args[key]
         elif key in self._input_to_options:
-            self._options[self._input_to_options[key]] = value
+            return self._options[self._input_to_options[key]]
         elif key in self._input_to_verbose:
-            self._verbose[self._input_to_verbose[key]] = value
+            return self._verbose[self._input_to_verbose[key]]
         else:
             raise TritonModelAnalyzerException(
                 f"'{key}' Key not found in config")
@@ -154,7 +154,7 @@ class PerfAnalyzerConfig:
             self._args[key] = value
         elif key in self._input_to_options:
             self._options[self._input_to_options[key]] = value
-        elif key in self._verbose:
+        elif key in self._input_to_verbose:
             self._verbose[self._input_to_verbose[key]] = value
         else:
             raise TritonModelAnalyzerException(

--- a/tests/test_output_table.py
+++ b/tests/test_output_table.py
@@ -43,6 +43,19 @@ TEST_TABLE_STR = (
     "value 80    value 81    value 82    value 83    value 84    value 85    value 86    value 89    \n"
     "value 90    value 91    value 92    value 93    value 94    value 95    value 96    value 99    "
 )
+TEST_CSV_STR = (
+    "Column 0,Column 1,Column 2,Column 3,Column 4,Column 5,Column 6,Column 9\n"
+    "value 00,value 01,value 02,value 03,value 04,value 05,value 06,value 09\n"
+    "value 10,value 11,value 12,value 13,value 14,value 15,value 16,value 19\n"
+    "value 20,value 21,value 22,value 23,value 24,value 25,value 26,value 29\n"
+    "value 30,value 31,value 32,value 33,value 34,value 35,value 36,value 39\n"
+    "value 40,value 41,value 42,value 43,value 44,value 45,value 46,value 49\n"
+    "value 50,value 51,value 52,value 53,value 54,value 55,value 56,value 59\n"
+    "value 60,value 61,value 62,value 63,value 64,value 65,value 66,value 69\n"
+    "value 70,value 71,value 72,value 73,value 74,value 75,value 76,value 79\n"
+    "value 80,value 81,value 82,value 83,value 84,value 85,value 86,value 89\n"
+    "value 90,value 91,value 92,value 93,value 94,value 95,value 96,value 99")
+TEST_COLUMN_WIDTH = 12
 
 
 class TestOutputTableMethods(unittest.TestCase):
@@ -118,7 +131,11 @@ class TestOutputTableMethods(unittest.TestCase):
         table = OutputTable(headers=TEST_HEADERS)
         for row in TEST_ROWS:
             table.add_row(row)
-        self.assertEqual(table.to_formatted_string(), TEST_TABLE_STR)
+        self.assertEqual(
+            table.to_formatted_string(column_width=TEST_COLUMN_WIDTH),
+            TEST_TABLE_STR)
+        self.assertEqual(table.to_formatted_string(separator=','),
+                         TEST_CSV_STR)
 
 
 if __name__ == '__main__':

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -28,8 +28,8 @@ import unittest
 
 from model_analyzer.triton.server.server_config import TritonServerConfig
 from model_analyzer.triton.server.server_factory import TritonServerFactory
-from model_analyzer.analyzer.perf_analyzer.perf_analyzer import PerfAnalyzer
-from model_analyzer.analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
+from model_analyzer.perf_analyzer.perf_analyzer import PerfAnalyzer
+from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 from model_analyzer.record.perf_throughput import PerfThroughput
 from model_analyzer.record.perf_latency import PerfLatency
@@ -39,6 +39,7 @@ MODEL_LOCAL_PATH = '/model_analyzer/models'
 MODEL_REPOSITORY_PATH = '/model_analyzer/models'
 TRITON_VERSION = '20.09'
 TEST_MODEL_NAME = 'classification_chestxray_v1'
+TEST_CONCURRENCY_RANGE = '1:16:2'
 CONFIG_TEST_ARG = 'sync'
 TEST_RUN_PARAMS = {'batch-size': [1, 2], 'concurrency-range': [2, 4]}
 
@@ -70,6 +71,17 @@ class TestPerfAnalyzerMethods(unittest.TestCase):
                                "unsupported argument in perf_analyzer"
                                "config"):
             self.config['dummy'] = 1
+
+        # set and get value for each subtype of arguments
+        self.config['model-name'] = TEST_MODEL_NAME
+        self.assertEqual(self.config['model-name'], TEST_MODEL_NAME)
+
+        self.config['concurrency-range'] = TEST_CONCURRENCY_RANGE
+        self.assertEqual(self.config['concurrency-range'],
+                         TEST_CONCURRENCY_RANGE)
+
+        self.config['extra-verbose'] = True
+        self.assertTrue(self.config['extra-verbose'])
 
     def test_run(self):
         # Now create a server config


### PR DESCRIPTION
Columns of table can now be separated with commas or any other string. Default column padding also changed to None.