### PR TITLE
Add GPUUtilization

### DIFF
--- a/model_analyzer/monitor/dcgm/dcgm_monitor.py
+++ b/model_analyzer/monitor/dcgm/dcgm_monitor.py
@@ -46,7 +46,7 @@ class DCGMMonitor(Monitor):
     """
 
     # Mapping between the DCGM Fields and Model Analyzer Records
-    MODEL_ANALYZER_TO_DCGM_FIELD = {
+    model_analyzer_to_dcgm_field = {
         GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
         GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL
@@ -84,8 +84,8 @@ class DCGMMonitor(Monitor):
         frequency = int(self._frequency * 1000)
         fields = []
         for tag in tags:
-            if tag in self.MODEL_ANALYZER_TO_DCGM_FIELD:
-                dcgm_field = self.MODEL_ANALYZER_TO_DCGM_FIELD[tag]
+            if tag in self.model_analyzer_to_dcgm_field:
+                dcgm_field = self.model_analyzer_to_dcgm_field[tag]
                 fields.append(dcgm_field)
             else:
                 dcgm_agent.dcgmShutdown()
@@ -114,7 +114,7 @@ class DCGMMonitor(Monitor):
             num_metrics = len(metrics[first_key].values)
             for i in range(num_metrics):
                 for tag in self._tags:
-                    dcgm_field = self.MODEL_ANALYZER_TO_DCGM_FIELD[tag]
+                    dcgm_field = self.model_analyzer_to_dcgm_field[tag]
 
                     # DCGM timestamp is in nanoseconds
                     records.append(

--- a/model_analyzer/monitor/dcgm/dcgm_monitor.py
+++ b/model_analyzer/monitor/dcgm/dcgm_monitor.py
@@ -26,6 +26,7 @@
 
 from model_analyzer.record.gpu_free_memory import GPUFreeMemory
 from model_analyzer.record.gpu_used_memory import GPUUsedMemory
+from model_analyzer.record.gpu_utilization import GPUUtilization
 from model_analyzer.monitor.monitor import Monitor
 from model_analyzer.model_analyzer_exceptions import \
     TritonModelAnalyzerException
@@ -47,7 +48,8 @@ class DCGMMonitor(Monitor):
     # Mapping between the DCGM Fields and Model Analyzer Records
     MODEL_ANALYZER_TO_DCGM_FIELD = {
         GPUUsedMemory: dcgm_fields.DCGM_FI_DEV_FB_USED,
-        GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE
+        GPUFreeMemory: dcgm_fields.DCGM_FI_DEV_FB_FREE,
+        GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL
     }
 
     def __init__(self, frequency, tags, dcgmPath=None):
@@ -86,6 +88,7 @@ class DCGMMonitor(Monitor):
                 dcgm_field = self.MODEL_ANALYZER_TO_DCGM_FIELD[tag]
                 fields.append(dcgm_field)
             else:
+                dcgm_agent.dcgmShutdown()
                 raise TritonModelAnalyzerException(
                     f'{tag} is not supported by Model Analyzer DCGM Monitor')
 

--- a/model_analyzer/record/gpu_utilization.py
+++ b/model_analyzer/record/gpu_utilization.py
@@ -56,4 +56,4 @@ class GPUUtilization(GPURecord):
             The full name of the metric.
         """
 
-        return "GPU Utilization[%]"
+        return "GPU Utilization(%)"

--- a/model_analyzer/record/gpu_utilization.py
+++ b/model_analyzer/record/gpu_utilization.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+from model_analyzer.record.gpu_record import GPURecord
+
+
+class GPUUtilization(GPURecord):
+    """
+    GPU utilization record
+    """
+
+    def __init__(self, device, gpu_utilization, timestamp):
+        """
+        Parameters
+        ----------
+        device : GPUDevice
+            The  GPU device this metric is associated
+            with.
+        gpu_utilization : float
+            The GPU utilization value
+        timestamp : int
+            The timestamp for the record in nanoseconds
+        """
+
+        super().__init__(device, gpu_utilization, timestamp)
+
+    def header(self):
+        """
+        Returns
+        -------
+        str
+            The full name of the metric.
+        """
+
+        return "GPU Utilization[%]"


### PR DESCRIPTION
```
python3 -m unittest discover -v                                                    

test_record_memory (tests.test_dcgm_monitor.TestDCGMMonitor) ... lib/python3.8/multiprocessing/pool.py:265: ResourceWarning: unclosed running multiprocessing pool <multiprocessing.pool.ThreadPool state=RUN pool_size=1>
  _warn(f"unclosed running multiprocessing pool {selfrm TEST_LOG}",
ResourceWarning: Enable tracemalloc to get the object allocation traceback
ok
test_record_utilization (tests.test_dcgm_monitor.TestDCGMMonitor) ... ok
test_write (tests.test_file_writer.TestFileWriterMethods) ... ok
test_add_get_methods (tests.test_output_table.TestOutputTableMethods) ... ok
test_create_headers (tests.test_output_table.TestOutputTableMethods) ... ok
test_remove_methods (tests.test_output_table.TestOutputTableMethods) ... ok
test_to_formatted_string (tests.test_output_table.TestOutputTableMethods) ... ok
test_perf_analyzer_config (tests.test_perf_analyzer.TestPerfAnalyzerMethods) ... ok
test_run (tests.test_perf_analyzer.TestPerfAnalyzerMethods) ... ok
test_aggregate (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_filter_records_default (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_filter_records_filtered (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_headers (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_insert (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_client_config (tests.test_triton_client.TestTritonClientMethods) ... ok
test_create_client (tests.test_triton_client.TestTritonClientMethods) ... ok
test_load_unload_model (tests.test_triton_client.TestTritonClientMethods) ... ok
test_create_server (tests.test_triton_server.TestTritonServerMethods) ... ok
test_server_config (tests.test_triton_server.TestTritonServerMethods) ... ok
test_start_wait_stop_gpus (tests.test_triton_server.TestTritonServerMethods) ... ok

----------------------------------------------------------------------
Ran 20 tests in 26.512s
```