### PR TITLE
Add --gpus flag

### DIFF
--- a/model_analyzer/cli/cli.py
+++ b/model_analyzer/cli/cli.py
@@ -111,8 +111,9 @@ class CLI:
             default='local',
             help="The method by which to launch Triton Server. "
                  "'local' assumes tritonserver binary is available locally. "
-                 "'docker' pulls and launches a triton docker container with the specified version. "
-                 "'remote' connects to a running server using given http, grpc and metrics endpoints. "
+                 "'docker' pulls and launches a triton docker container with "
+                 "the specified version. 'remote' connects to a running "
+                 "server using given http, grpc and metrics endpoints. "
         )
         self._parser.add_argument(
             '--triton-version',
@@ -132,10 +133,22 @@ class CLI:
             help="Triton Server HTTP endpoint url used by Model Analyzer client. "
                  "Will be ignored if server-launch-mode is not 'remote'")
         self._parser.add_argument(
+            '--triton-metrics-url',
+            type=str,
+            default='http://localhost:8002/metrics',
+            help="Triton Server Metrics endpoint url. "
+                 "Will be ignored if server-launch-mode is not 'remote'")
+        self._parser.add_argument(
             '--triton-server-path',
             type=str,
-            default='/opt/tritonserver/bin/tritonserver',
+            default='tritonserver',
             help='The full path to the tritonserver binary executable')
+        self._parser.add_argument(
+            '--gpus',
+            type=str,
+            default='all',
+            help="List of GPU UUIDs to be used for the profiling. "
+                 "Use 'all' to profile all the GPUs visible by CUDA.")
         # yapf:enable
 
     def _preprocess_and_verify_arguments(self, args):
@@ -186,6 +199,7 @@ class CLI:
                     "triton-launch-mode is 'docker'. Must specify triton-version "
                     "if launching server docker container or change launch mode using "
                     "--triton-launch-mode.")
+        args.gpus = args.gpus.split(',')
 
     def parse(self):
         """

--- a/model_analyzer/monitor/dcgm/dcgm_monitor.py
+++ b/model_analyzer/monitor/dcgm/dcgm_monitor.py
@@ -40,7 +40,7 @@ class DCGMMonitor(Monitor):
         GPUUtilization: dcgm_fields.DCGM_FI_DEV_GPU_UTIL
     }
 
-    def __init__(self, frequency, tags, dcgmPath=None):
+    def __init__(self, gpus, frequency, tags, dcgmPath=None):
         """
         Parameters
         ----------
@@ -52,7 +52,7 @@ class DCGMMonitor(Monitor):
             DCGM installation path
         """
 
-        super().__init__(frequency, tags)
+        super().__init__(gpus, frequency, tags)
         structs._dcgmInit(dcgmPath)
         dcgm_agent.dcgmInit()
 
@@ -98,16 +98,18 @@ class DCGMMonitor(Monitor):
 
             # Find the first key in the metrics dictionary to find the
             # dictionary length
-            first_key = list(metrics)[0]
-            num_metrics = len(metrics[first_key].values)
-            for i in range(num_metrics):
-                for tag in self._tags:
-                    dcgm_field = self.model_analyzer_to_dcgm_field[tag]
+            if len(list(metrics)) > 0:
+                first_key = list(metrics)[0]
+                num_metrics = len(metrics[first_key].values)
+                for i in range(num_metrics):
+                    for tag in self._tags:
+                        dcgm_field = self.model_analyzer_to_dcgm_field[tag]
 
-                    # DCGM timestamp is in nanoseconds
-                    records.append(
-                        tag(gpu, float(metrics[dcgm_field].values[i].value),
-                            metrics[dcgm_field].values[i].ts))
+                        # DCGM timestamp is in nanoseconds
+                        records.append(
+                            tag(gpu,
+                                float(metrics[dcgm_field].values[i].value),
+                                metrics[dcgm_field].values[i].ts))
 
         return records
 

--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -57,7 +57,7 @@ class PerfAnalyzer:
         Returns
         -------
         List of Records
-            List of the metrics obtained from this 
+            List of the metrics obtained from this
             run of perf_analyzer
 
         Raises

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -20,9 +20,8 @@ class TritonServerFactory:
     """
     A factory for creating TritonServer instances
     """
-
     @staticmethod
-    def create_server_docker(model_path, image, config):
+    def create_server_docker(model_path, image, config, gpus):
         """
         Parameters
         ----------
@@ -34,13 +33,16 @@ class TritonServerFactory:
             The tritonserver docker image to pull and run
         config : TritonServerConfig
             the config object containing arguments for this server instance
-        
+        gpus : list
+            List of GPUs to be mounted in the container.
+
         Returns
         -------
         TritonServerDocker
         """
 
-        return TritonServerDocker(model_path=model_path,
+        return TritonServerDocker(gpus=gpus,
+                                  model_path=model_path,
                                   image=image,
                                   config=config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,7 @@
 # limitations under the License.
 
 docker>=4.3.1
-numba>=0.51.2
 distro>=1.5.0
+numba>=0.51.2
+prometheus_client>=0.9.0
+requests>=2.24.0

--- a/tests/test_triton_client.py
+++ b/tests/test_triton_client.py
@@ -40,6 +40,10 @@ TEST_MODEL_NAME = 'test_model'
 
 class TestTritonClientMethods(trc.TestResultCollector):
     def setUp(self):
+
+        # GPUs
+        gpus = ['all']
+
         # Mocks
         self.mock_server_docker = MockServerDockerMethods()
         self.tritonclient_mock = MockTritonClientMethods()
@@ -54,6 +58,7 @@ class TestTritonClientMethods(trc.TestResultCollector):
 
         # Create and start the server
         self.server = TritonServerFactory.create_server_docker(
+            gpus=gpus,
             model_path=MODEL_LOCAL_PATH,
             image=TRITON_IMAGE,
             config=self.server_config)

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -31,7 +31,7 @@ import test_result_collector as trc
 MODEL_LOCAL_PATH = 'test_local_path'
 MODEL_REPOSITORY_PATH = 'test_repo'
 TRITON_LOCAL_BIN_PATH = 'test_bin_path/tritonserver'
-TRITON_DOCKER_BIN_PATH = '/opt/tritonserver/bin/tritonserver'
+TRITON_DOCKER_BIN_PATH = 'tritonserver'
 TRITON_IMAGE = 'test_image'
 CONFIG_TEST_ARG = 'exit-on-error'
 CLI_TO_STRING_TEST_ARGS = {
@@ -105,9 +105,11 @@ class TestTritonServerMethods(trc.TestResultCollector):
         # Create a TritonServerConfig
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
+        gpus = ['all']
 
         # Run for both types of environments
         self.server = TritonServerFactory.create_server_docker(
+            gpus=gpus,
             model_path=MODEL_LOCAL_PATH,
             image=TRITON_IMAGE,
             config=server_config)
@@ -123,6 +125,7 @@ class TestTritonServerMethods(trc.TestResultCollector):
                 msg="Expected AssertionError for trying to create"
                 "server without specifying model repository."):
             self.server = TritonServerFactory.create_server_docker(
+                gpus=gpus,
                 model_path=MODEL_LOCAL_PATH,
                 image=TRITON_IMAGE,
                 config=server_config)
@@ -138,9 +141,11 @@ class TestTritonServerMethods(trc.TestResultCollector):
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
         os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+        gpus = ['all']
 
         # Create server in docker, start , wait, and stop
         self.server = TritonServerFactory.create_server_docker(
+            gpus=gpus,
             model_path=MODEL_LOCAL_PATH,
             image=TRITON_IMAGE,
             config=server_config)


### PR DESCRIPTION
* Adds a `--gpus` flag to control the GPUs being used for analysis.
* Adds checks to make sure that Model Analyzer and Triton are using the same GPUs
* Fixes minor bug if the `start_monitoring_metrics` and `stop_monitoring_metrics` are called without any delay.
```
test_gpu_id (tests.test_dcgm_monitor.TestDCGMMonitor) ... ok
test_immediate_start_stop (tests.test_dcgm_monitor.TestDCGMMonitor) ... ok
test_record_memory (tests.test_dcgm_monitor.TestDCGMMonitor) ... /home/itabrizian/miniconda3/envs/nvml-py/lib/python3.8/multiprocessing/pool.py:265: ResourceWarning: unclosed running multiprocessing pool <multiprocessing.pool.ThreadPool state=RUN pool_size=1>
  _warn(f"unclosed running multiprocessing pool {self!r}",
ResourceWarning: Enable tracemalloc to get the object allocation traceback
ok
test_record_utilization (tests.test_dcgm_monitor.TestDCGMMonitor) ... ok
{"total": 4, "errors": 0, "failures": 0}
test_write (tests.test_file_writer.TestFileWriterMethods) ... ok
{"total": 5, "errors": 0, "failures": 0}
test_add_get_methods (tests.test_output_table.TestOutputTableMethods) ... ok
test_create_headers (tests.test_output_table.TestOutputTableMethods) ... ok
test_remove_methods (tests.test_output_table.TestOutputTableMethods) ... ok
test_set_width_methods (tests.test_output_table.TestOutputTableMethods) ... ok
test_to_formatted_string (tests.test_output_table.TestOutputTableMethods) ... ok
{"total": 10, "errors": 0, "failures": 0}
test_perf_analyzer_config (tests.test_perf_analyzer.TestPerfAnalyzerMethods) ... ok
test_run (tests.test_perf_analyzer.TestPerfAnalyzerMethods) ... ok
{"total": 12, "errors": 0, "failures": 0}
test_aggregate (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_filter_records_default (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_filter_records_filtered (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_insert (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
test_record_types (tests.test_record_aggregator.TestRecordAggregatorMethods) ... ok
{"total": 17, "errors": 0, "failures": 0}
test_create_client (tests.test_triton_client.TestTritonClientMethods) ... ok
test_load_unload_model (tests.test_triton_client.TestTritonClientMethods) ... ok
test_wait_for_model_ready (tests.test_triton_client.TestTritonClientMethods) ... ok
test_wait_for_server_ready (tests.test_triton_client.TestTritonClientMethods) ... ok
{"total": 21, "errors": 0, "failures": 0}
test_create_server (tests.test_triton_server.TestTritonServerMethods) ... ok
test_server_config (tests.test_triton_server.TestTritonServerMethods) ... ok
test_start_stop_gpus (tests.test_triton_server.TestTritonServerMethods) ... ok
{"total": 24, "errors": 0, "failures": 0}
```