### PR TITLE
Add logging and support for graceful termination

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import logging
 
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 from .monitor.dcgm.dcgm_monitor import DCGMMonitor
@@ -24,6 +25,8 @@ from .record.gpu_used_memory import GPUUsedMemory
 from .record.perf_throughput import PerfThroughput
 from .record.perf_latency import PerfLatency
 from .output.output_table import OutputTable
+
+logger = logging.getLogger(__name__)
 
 
 class Analyzer:
@@ -81,6 +84,7 @@ class Analyzer:
         TritonModelAnalyzerException
         """
 
+        logging.info('Profiling server only metrics...')
         dcgm_monitor = DCGMMonitor(self._gpus, self._monitoring_interval,
                                    self.dcgm_tags)
         server_only_metrics = self._profile(perf_analyzer=None,
@@ -117,6 +121,7 @@ class Analyzer:
         TritonModelAnalyzerException
         """
 
+        logging.info(f"Profiling model {run_config['model-name']}...")
         dcgm_monitor = DCGMMonitor(self._gpus, self._monitoring_interval,
                                    self.dcgm_tags)
         perf_analyzer = PerfAnalyzer(

--- a/model_analyzer/device/gpu_device.py
+++ b/model_analyzer/device/gpu_device.py
@@ -31,6 +31,7 @@ class GPUDevice(Device):
             device_uuid : bytes
                 Device UUID
         """
+
         assert type(device_id) is int
         assert type(pci_bus_id) is bytes
         assert type(device_uuid) is bytes
@@ -46,6 +47,7 @@ class GPUDevice(Device):
         int
             device id of this GPU
         """
+
         return self._device_id
 
     def pci_bus_id(self):
@@ -55,13 +57,15 @@ class GPUDevice(Device):
         bytes
             PCI bus id of this GPU
         """
+
         return self._pci_bus_id
 
     def device_uuid(self):
         """
         Returns
         -------
-        str
+        bytes
             UUID of this GPU
         """
+
         return self._device_uuid

--- a/model_analyzer/monitor/monitor.py
+++ b/model_analyzer/monitor/monitor.py
@@ -16,9 +16,12 @@ from abc import ABC, abstractmethod
 from multiprocessing.pool import ThreadPool
 import numba.cuda
 import time
+import logging
 
 from model_analyzer.device.gpu_device_factory import GPUDeviceFactory
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+
+logger = logging.getLogger(__name__)
 
 
 class Monitor(ABC):
@@ -63,6 +66,12 @@ class Monitor(ABC):
             for gpu in gpus:
                 gpu_device = GPUDeviceFactory.create_device_by_uuid(gpu)
                 self._gpus.append(gpu_device)
+
+        gpu_uuids = []
+        for gpu in self._gpus:
+            gpu_uuids.append(str(gpu.device_uuid(), encoding='ascii'))
+        gpu_uuids_str = ','.join(gpu_uuids)
+        logger.info(f'Using GPU(s) with UUID(s) = {{ {gpu_uuids_str} }} for the analysis.')
 
         # Is the background thread active
         self._thread_active = False

--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -72,6 +72,7 @@ class PerfAnalyzer:
             cmd += self._config.to_cli_string().replace('=', ' ').split()
             try:
                 self._output = check_output(cmd,
+                                            start_new_session=True,
                                             stderr=STDOUT,
                                             encoding='utf-8')
             except CalledProcessError as e:

--- a/model_analyzer/record/perf_throughput.py
+++ b/model_analyzer/record/perf_throughput.py
@@ -23,7 +23,6 @@ class PerfThroughput(Record):
     A record for perf_analyzer
     metric 'Throughput'
     """
-
     def __init__(self, perf_output, timestamp=0):
         """
         Parameters
@@ -39,6 +38,10 @@ class PerfThroughput(Record):
             # Get first word after Throughput
             if 'Throughput:' in line:
                 throughput = float(line.split()[1])
+                break
+        else:
+            raise TritonModelAnalyzerException(
+                'perf_analyzer output was not as expected.')
 
         super().__init__(throughput, timestamp)
 

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import time
+import logging
 
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+
+logger = logging.getLogger(__name__)
 
 
 class TritonClient:
@@ -71,11 +74,13 @@ class TritonClient:
         TritonModelAnalyzerException
             If server throws Exception
         """
+
         try:
             self._client.load_model(model.name())
         except Exception as e:
             raise TritonModelAnalyzerException(
                 f"Unable to load the model : {e}")
+        logger.info(f'Model {model.name()} loaded.')
 
     def unload_model(self, model):
         """
@@ -93,11 +98,13 @@ class TritonClient:
         TritonModelAnalyzerException
             If server throws Exception
         """
+
         try:
             self._client.unload_model(model.name())
         except Exception as e:
             raise TritonModelAnalyzerException(
                 f"Unable to unload the model : {e}")
+        logger.info(f'Model {model.name()} unloaded.')
 
     def wait_for_model_ready(self, model, num_retries):
         """

--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -14,12 +14,15 @@
 
 import os
 import docker
+import logging
 
 from .server import TritonServer
 
 LOCAL_HTTP_PORT = 8000
 LOCAL_GRPC_PORT = 8001
 LOCAL_METRICS_PORT = 8002
+
+logger = logging.getLogger(__name__)
 
 
 class TritonServerDocker(TritonServer):
@@ -106,6 +109,8 @@ class TritonServerDocker(TritonServer):
         Stops the tritonserver docker container
         and cleans up docker client
         """
+
+        logger.info('Stopping triton server.')
 
         if self._tritonserver_container is not None:
             self._tritonserver_container.stop()

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -49,7 +49,7 @@ class TritonServerFactory:
             The absolute path to the tritonserver executable
         config : TritonServerConfig
             the config object containing arguments for this server instance
-        
+
         Returns
         -------
         TritonServerLocal

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
+import logging
 
 from .server import TritonServer
 
 SERVER_OUTPUT_TIMEOUT_SECS = 5
+logger = logging.getLogger(__name__)
 
 
 class TritonServerLocal(TritonServer):
@@ -52,9 +54,11 @@ class TritonServerLocal(TritonServer):
         cmd += self._server_config.to_cli_string().replace('=', ' ').split()
 
         self._tritonserver_process = Popen(cmd,
+                                           start_new_session=True,
                                            stdout=PIPE,
                                            stderr=STDOUT,
                                            universal_newlines=True)
+        logger.info('Triton Server started.')
 
     def stop(self):
         """
@@ -71,3 +75,4 @@ class TritonServerLocal(TritonServer):
                 self._tritonserver_process.kill()
                 output, _ = self._tritonserver_process.communicate()
             self._tritonserver_process = None
+            logger.info('Triton Server stopped.')


### PR DESCRIPTION
```
model-analyzer -m /home/.../Code/triton/model_analyzer/examples/quick-start/ -n add_sub --triton-launch-mode docker --log=INFO
2020-11-25 21:00:56.308 INFO[entrypoint.py:317] Triton Model Analyzer started Namespace(batch_sizes='1', client_protocol='grpc', concurrency='1', duration_seconds=5, export=False, export_path='.', filename_model='metrics-model.csv', filename_server_only='metrics-server-only.csv', gpus=['all'], log_level='INFO', max_retries=100, model_names='add_sub', model_repository='/home/itabrizian/Code/triton/model_analyzer/examples/quick-start/', monitoring_interval=0.01, perf_analyzer_path='perf_analyzer', triton_grpc_endpoint='localhost:8001', triton_http_endpoint='localhost:8000', triton_launch_mode='docker', triton_metrics_url='http://localhost:8002/metrics', triton_server_path='tritonserver', triton_version='20.11-py3') arguments
2020-11-25 21:00:56.308 INFO[entrypoint.py:320] Starting Triton Server...
2020-11-25 21:00:56.310 INFO[driver.py:238] init
2020-11-25 21:00:59.142 INFO[entrypoint.py:322] Triton Server launched.
2020-11-25 21:01:00.177 INFO[entrypoint.py:333] Starting perf_analyzer...
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 9818
    Throughput: 1963.6 infer/sec
    Avg latency: 508 usec (standard deviation 67 usec)
    p50 latency: 509 usec
    p90 latency: 589 usec
    p95 latency: 646 usec
    p99 latency: 714 usec
    Avg HTTP time: 505 usec (send/recv 53 usec + response wait 452 usec)
  Server: 
    Inference count: 11764
    Execution count: 11764
    Successful request count: 11764
    Avg request latency: 177 usec (overhead 2 usec + queue 17 usec + compute input 42 usec + compute infer 71 usec + compute output 45 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 1963.6 infer/sec, latency 508 usec

Server Only:
Model           Batch   Concurrency   Throughput(infer/sec)   Max GPU Utilization(%)   Max GPU Used Memory(MB)   Max GPU Free Memory(MB)  
triton-server   0       0             0                       0.0                      228.0                     23991.0                  

Models:
Model           Batch   Concurrency   Throughput(infer/sec)   Max GPU Utilization(%)   Max GPU Used Memory(MB)   Max GPU Free Memory(MB)  
add_sub         1       1             1963.6                  2.0                      730.0                     23991.0                  

2020-11-25 21:01:33.332 INFO[server_docker.py:113] Stopping triton server.
```