### PR TITLE
Build model-analyzer as a manylinux1_x86_64.whl

### DIFF
--- a/build_wheel.sh
+++ b/build_wheel.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHON=${PYTHON:=`which python3`}
+
+if [[ $# -lt 2 ]] ; then
+    echo "usage: $0 <perf-analyzer-binary> <linux-specific>"
+    exit 1
+fi
+
+if [[ ! -f "VERSION" ]]; then
+    echo "Could not find VERSION"
+    exit 1
+fi
+
+if [[ ! -f "LICENSE" ]]; then
+    echo "Could not find LICENSE"
+    exit 1
+fi
+
+if [[ ! -f "$1" ]]; then
+    echo "Could not find perf_analyzer binary"
+    exit 1
+fi
+
+WHLDIR="`pwd`/wheels"
+mkdir -p ${WHLDIR}
+
+# Copy required files into WHEELDIR temporarily
+cp $1 "${WHLDIR}"
+cp VERSION "${WHLDIR}"
+cp LICENSE "${WHLDIR}"
+cp requirements.txt "${WHLDIR}"
+
+# Set platform and build wheel
+echo $(date) : "=== Building wheel"
+if [ "$2" = true ] ; then
+    PLATFORM=`uname -m`
+    if [ "$PLATFORM" = "aarch64" ] ; then
+        PLATFORM_NAME="linux_aarch64"
+    else
+        PLATFORM_NAME="manylinux1_x86_64"
+    fi
+    ${PYTHON} setup.py  bdist_wheel --plat-name $PLATFORM_NAME --dependency-dir $WHLDIR
+else
+    ${PYTHON} setup.py bdist_wheel --dependency-dir $WHLDIR
+fi
+rm -f $WHLDIR/* && cp dist/* $WHLDIR
+rm -rf build dist model_analyzer.egg-info
+touch ${WHLDIR}/stamp.whl
+echo $(date) : "=== Output wheel file is in: ${WHLDIR}"


### PR DESCRIPTION
Build process:
```
asramesh@asramesh-dt:~/model_analyzer$ ./build_wheel.sh perf_analyzer true
Thu Nov 26 00:31:34 PST 2020 : === Building wheel
...
adding 'model_analyzer-1.0.0.dev0.dist-info/*'
removing build/bdist.linux-x86_64/wheel
Thu Nov 26 00:31:38 PST 2020 : === Output wheel file is in: /home/asramesh/model_analyzer/wheels
asramesh@asramesh-dt:~/model_analyzer$ ls -l wheels
total 2852
-rw------- 1 asramesh hardware 2905629 Nov 26 00:31 model_analyzer-1.0.0.dev0-py3-none-manylinux1_x86_64.whl
-rw------- 1 asramesh hardware       0 Nov 26 00:31 stamp.whl
```

Install process:  (Inside build container)
```
root@asramesh-dt:/opt/triton-model-analyzer# which model-analyzer
root@asramesh-dt:/opt/triton-model-analyzer# which perf_analyzer                                             
root@asramesh-dt:/opt/triton-model-analyzer# pip install wheels/model_analyzer-1.0.0.dev0-py3-none-manylinux1_x86_64.whl 
Processing ./wheels/model_analyzer-1.0.0.dev0-py3-none-manylinux1_x86_64.whl
Requirement already satisfied: prometheus-client>=0.9.0 in /usr/local/lib/python3.6/dist-packages/prometheus_client-0.9.0-py3.6.egg (from model-analyzer==1.0.0.dev0) (0.9.0)
Requirement already satisfied: distro>=1.5.0 in /usr/local/lib/python3.6/dist-packages/distro-1.5.0-py3.6.egg (from model-analyzer==1.0.0.dev0) (1.5.0)
Requirement already satisfied: numba>=0.51.2 in /usr/local/lib/python3.6/dist-packages/numba-0.52.0rc3-py3.6-linux-x86_64.egg (from model-analyzer==1.0.0.dev0) (0.52.0rc3)
Requirement already satisfied: requests>=2.24.0 in /usr/local/lib/python3.6/dist-packages/requests-2.25.0-py3.6.egg (from model-analyzer==1.0.0.dev0) (2.25.0)
Requirement already satisfied: docker>=4.3.1 in /usr/local/lib/python3.6/dist-packages/docker-4.4.0-py3.6.egg (from model-analyzer==1.0.0.dev0) (4.4.0)
Requirement already satisfied: llvmlite<0.36,>=0.35.0rc3 in /usr/local/lib/python3.6/dist-packages/llvmlite-0.35.0rc3-py3.6-linux-x86_64.egg (from numba>=0.51.2->model-analyzer==1.0.0.dev0) (0.35.0rc3)
Requirement already satisfied: numpy>=1.15 in /usr/local/lib/python3.6/dist-packages (from numba>=0.51.2->model-analyzer==1.0.0.dev0) (1.19.2)
Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from numba>=0.51.2->model-analyzer==1.0.0.dev0) (50.3.1)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests>=2.24.0->model-analyzer==1.0.0.dev0) (2020.11.8)
Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.6/dist-packages/chardet-3.0.4-py3.6.egg (from requests>=2.24.0->model-analyzer==1.0.0.dev0) (3.0.4)
Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.6/dist-packages/idna-2.10-py3.6.egg (from requests>=2.24.0->model-analyzer==1.0.0.dev0) (2.10)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.6/dist-packages/urllib3-1.26.2-py3.6.egg (from requests>=2.24.0->model-analyzer==1.0.0.dev0) (1.26.2)
Requirement already satisfied: six>=1.4.0 in /usr/local/lib/python3.6/dist-packages (from docker>=4.3.1->model-analyzer==1.0.0.dev0) (1.15.0)
Requirement already satisfied: websocket-client>=0.32.0 in /usr/local/lib/python3.6/dist-packages/websocket_client-0.57.0-py3.6.egg (from docker>=4.3.1->model-analyzer==1.0.0.dev0) (0.57.0)
Installing collected packages: model-analyzer
Successfully installed model-analyzer-1.0.0.dev0
root@asramesh-dt:/opt/triton-model-analyzer# which perf_analyzer 
/usr/local/bin/perf_analyzer
root@asramesh-dt:/opt/triton-model-analyzer# model-analyzer -m /qa_model_repository/ -n classification_chestxray_v1 
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 225
    Throughput: 45 infer/sec
    Avg latency: 22198 usec (standard deviation 4519 usec)
    p50 latency: 24578 usec
    p90 latency: 26545 usec
    p95 latency: 26912 usec
    p99 latency: 27837 usec
    Avg HTTP time: 22043 usec (send/recv 267 usec + response wait 21776 usec)
  Server: 
    Inference count: 273
    Execution count: 273
    Successful request count: 273
    Avg request latency: 20226 usec (overhead 49 usec + queue 72 usec + compute input 196 usec + compute infer 19887 usec + compute output 22 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 45 infer/sec, latency 22198 usec

Server Only:
Model                         Batch   Concurrency   Throughput(infer/sec)   Max GPU Utilization(%)   Max GPU Used Memory(MB)   Max GPU Free Memory(MB)  
triton-server                 0       0             0                       0.0                      279.0                     23940.0                  

Models:
Model                         Batch   Concurrency   Throughput(infer/sec)   Max GPU Utilization(%)   Max GPU Used Memory(MB)   Max GPU Free Memory(MB)  
classification_chestxray_v1   1       1             45.0                    33.0                     5049.0                    23362.0                  

root@asramesh-dt:/opt/triton-model-analyzer#
```