### PR TITLE
Fix minor issues when launching using Docker

### DIFF
--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -321,9 +321,11 @@ def main():
         args = CLI().parse()
     except TritonModelAnalyzerException as e:
         logging.error(f'Model Analyzer encountered an error: {e}')
+        sys.exit(1)
 
     logging.info(f'Triton Model Analyzer started {args} arguments')
     analyzer = Analyzer(args, monitoring_metrics)
+    server = None
     try:
         client, server = get_triton_handles(args)
 
@@ -342,7 +344,8 @@ def main():
     except TritonModelAnalyzerException as e:
         logging.error(f'Model Analyzer encountered an error: {e}')
     finally:
-        server.stop()
+        if server is not None:
+            server.stop()
 
 
 if __name__ == '__main__':

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -67,6 +67,7 @@ class TritonServerLocal(TritonServer):
 
         # Terminate process, capture output
         if self._tritonserver_process is not None:
+            logger.info('Triton Server stopped.')
             self._tritonserver_process.terminate()
             try:
                 output, _ = self._tritonserver_process.communicate(
@@ -75,4 +76,3 @@ class TritonServerLocal(TritonServer):
                 self._tritonserver_process.kill()
                 output, _ = self._tritonserver_process.communicate()
             self._tritonserver_process = None
-            logger.info('Triton Server stopped.')

--- a/qa/L0_server_launch_modes/test.sh
+++ b/qa/L0_server_launch_modes/test.sh
@@ -15,7 +15,6 @@
 source ../common/util.sh
 
 rm -f *.log
-python3 ../common/cleanup.py $CONTAINER_NAME || true
 
 # Set test parameters
 MODEL_ANALYZER="`which model-analyzer`"
@@ -84,8 +83,6 @@ for PROTOCOL in $CLIENT_PROTOCOLS; do
         if [ "$LAUNCH_MODE" == "remote" ]; then
             kill $SERVER_PID
             wait $SERVER_PID
-        elif [ "$LAUNCH_MODE" == "docker" ]; then
-            python3 ../common/cleanup.py $CONTAINER_NAME || true
         fi
     done
 done

--- a/tests/mock_api_error.py
+++ b/tests/mock_api_error.py
@@ -11,18 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-A cleanup script to run after
-docker server launches.
-"""
-import sys
-import docker
 
-docker_client = docker.from_env()
-try:
-    server_container = docker_client.containers.get('triton-server')
-    server_container.stop()
-    server_container.remove()
-except (docker.errors.NotFound, docker.errors.APIError) as e:
-    pass
-docker_client.close()
+class MockAPIError(Exception):
+    """
+    Mock for Docker API errors
+    """
+
+    def __init__(self):
+        self.explanation = 'port is already allocated'

--- a/tests/mock_perf_analyzer.py
+++ b/tests/mock_perf_analyzer.py
@@ -63,6 +63,7 @@ class MockPerfAnalyzerMethods:
         """
 
         self.check_output_mock.assert_called_with(cmd,
+                                                  start_new_session=True,
                                                   stderr=self.stdout_mock,
                                                   encoding='utf-8')
 

--- a/tests/mock_server_docker.py
+++ b/tests/mock_server_docker.py
@@ -18,11 +18,10 @@ from unittest.mock import patch, Mock, MagicMock
 
 class MockServerDockerMethods(MockServerMethods):
     """
-    Mocks the docker module as used in 
-    model_analyzer/triton/server/server_docker.py.
-    Provides functions to check operation.
+    Mocks the docker module as used in
+    model_analyzer/triton/server/server_docker.py. Provides functions to
+    check operation.
     """
-
     def __init__(self):
         docker_container_attrs = {'exec_run': MagicMock()}
         docker_client_attrs = {
@@ -85,7 +84,6 @@ class MockServerDockerMethods(MockServerMethods):
         mock_ports = {http_port: 8000, grpc_port: 8001, metrics_port: 8002}
         self.mock.from_env.return_value.containers.run.assert_called_once_with(
             image=triton_image,
-            name='triton-server',
             device_requests=[0],
             volumes=mock_volumes,
             ports=mock_ports,
@@ -98,8 +96,7 @@ class MockServerDockerMethods(MockServerMethods):
 
     def assert_server_process_terminate_called(self):
         """
-        Asserts that stop was called on 
-        the return value of containers.run
+        Asserts that stop was called on the return value of containers.run
         """
 
         self.mock.from_env.return_value.containers.run.return_value.stop.assert_called(

--- a/tests/mock_server_docker.py
+++ b/tests/mock_server_docker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .mock_server import MockServerMethods
+from .mock_api_error import MockAPIError
 from unittest.mock import patch, Mock, MagicMock
 
 
@@ -93,6 +94,25 @@ class MockServerDockerMethods(MockServerMethods):
             detach=True)
 
         self._assert_docker_exec_run_with_args(cmd=cmd, stream=True)
+
+    def raise_exception_on_container_run(self):
+        """
+        Raises MockAPIError on container run
+        """
+        self.exception_on_run_patcher = patch(
+            'model_analyzer.triton.server.server_docker.docker.errors.APIError',
+            MockAPIError)
+        self.api_error_mock = self.exception_on_run_patcher.start()
+        self.mock.from_env.return_value.containers.run.side_effect = \
+            self.api_error_mock
+
+    def stop_raise_exception_on_container_run(self):
+        """
+        Stop raising exception on container run
+        """
+        ...
+        self.mock.from_env.return_value.containers.run.side_effect = None
+        self.exception_on_run_patcher.stop()
 
     def assert_server_process_terminate_called(self):
         """

--- a/tests/mock_server_local.py
+++ b/tests/mock_server_local.py
@@ -55,6 +55,7 @@ class MockServerLocalMethods(MockServerMethods):
         self.popen_mock.assert_called_once_with(cmd,
                                                 stdout=self.pipe_mock,
                                                 stderr=self.stdout_mock,
+                                                start_new_session=True,
                                                 universal_newlines=True)
 
     def assert_server_process_terminate_called(self):

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -16,6 +16,7 @@ import os
 import unittest
 import subprocess
 import sys
+from unittest import mock
 sys.path.append('../common')
 
 from unittest.mock import patch, MagicMock
@@ -145,6 +146,11 @@ class TestTritonServerMethods(trc.TestResultCollector):
         self.server_docker_mock.assert_server_process_start_called_with(
             TRITON_DOCKER_BIN_PATH + ' ' + server_config.to_cli_string(),
             MODEL_REPOSITORY_PATH, TRITON_IMAGE, 8000, 8001, 8002)
+
+        self.server_docker_mock.raise_exception_on_container_run()
+        with self.assertRaises(TritonModelAnalyzerException):
+            self.server.start()
+        self.server_docker_mock.stop_raise_exception_on_container_run()
 
         # Stop container and check api calls
         self.server.stop()


### PR DESCRIPTION
Some minor issues were fixed when launching Model Analyzer using Docker:
1. Container name already exists
2. Better error printing when the port is already allocated