### PR TITLE
Add Model Analyzer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <!--
-Copyright 2020, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -33,29 +33,27 @@ logger = logging.getLogger(__name__)
 
 class Analyzer:
     """
-    A class responsible for coordinating
-    the various components of the model_analyzer.
-    Configured with metrics to monitor,
-    exposes profiling and result writing
-    methods.
+    A class responsible for coordinating the various components of the
+    model_analyzer. Configured with metrics to monitor, exposes profiling and
+    result writing methods.
     """
-    def __init__(self, args, monitoring_metrics):
+    def __init__(self, config, monitoring_metrics):
         """
         Parameters
         ----------
-        args : namespace
-            The arguments passed into the CLI
+        config : Config
+            Model Analyzer config
         monitoring_metrics : List of Record types
             The list of metric types to monitor.
         """
 
-        self._perf_analyzer_path = args.perf_analyzer_path
-        self._duration_seconds = args.duration_seconds
-        self._monitoring_interval = args.monitoring_interval
+        self._perf_analyzer_path = config.perf_analyzer_path
+        self._duration_seconds = config.duration_seconds
+        self._monitoring_interval = config.monitoring_interval
         self._monitoring_metrics = monitoring_metrics
         self._param_inference_headers = ['Model', 'Batch', 'Concurrency']
         self._param_gpu_headers = ['Model', 'GPU ID', 'Batch', 'Concurrency']
-        self._gpus = args.gpus
+        self._gpus = config.gpus
 
         # Separates metric tags into perf_analyzer related and DCGM related tags
         self.dcgm_tags = []

--- a/model_analyzer/cli/cli.py
+++ b/model_analyzer/cli/cli.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import logging
+import argparse
 from argparse import ArgumentParser
-
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
 logger = logging.getLogger(__name__)
 
@@ -26,227 +24,52 @@ class CLI:
     """
     CLI class to parse the commandline arguments
     """
-
-    def __init__(self):
+    def __init__(self, config):
         self._parser = ArgumentParser()
-        self._add_arguments()
+        self._config = config
+        self._add_arguments(config)
 
-    def _add_arguments(self):
-        # yapf:disable
-        self._parser.add_argument(
-            '-m',
-            '--model-repository',
-            type=str,
-            required=True,
-            help='Model repository location')
-        self._parser.add_argument(
-            '-n',
-            '--model-names',
-            type=str,
-            required=True,
-            help='Comma-delimited list of the model names to be profiled')
-        self._parser.add_argument(
-            '-b',
-            '--batch-sizes',
-            type=str,
-            default='1',
-            help='Comma-delimited list of batch sizes to use for the profiling')
-        self._parser.add_argument(
-            '-c',
-            '--concurrency',
-            type=str,
-            default='1',
-            help='Comma-delimited list of concurrency values'
-                 'to be used during profiling')
-        self._parser.add_argument(
-            '--export',
-            action='store_true',
-            help='Enables exporting metrics to a file')
-        self._parser.add_argument(
-            '-e',
-            '--export-path',
-            type=str,
-            default='.',
-            help='Full path to directory in which to store the results')
-        self._parser.add_argument(
-            '--filename-model-inference',
-            type=str,
-            default='metrics-model-inference.csv',
-            help='Specifies filename for storing model inference metrics')
-        self._parser.add_argument(
-            '--filename-model-gpu',
-            type=str,
-            default='metrics-model-gpu.csv',
-            help='Specifies filename for storing model GPU metrics')
-        self._parser.add_argument(
-            '--filename-server-only',
-            type=str,
-            default='metrics-server-only.csv',
-            help='Specifies filename for server-only metrics')
-        self._parser.add_argument(
-            '-r',
-            '--max-retries',
-            type=int,
-            default=100,
-            help='Specifies the max number of retries for any retry attempt')
-        self._parser.add_argument(
-            '-d',
-            '--duration-seconds',
-            type=float,
-            default=5,
-            help='Specifies how long (seconds) to gather server-only metrics')
-        self._parser.add_argument(
-            '-i',
-            '--monitoring-interval',
-            type=float,
-            default=0.01,
-            help='Interval of time between DGCM measurements in seconds')
-        self._parser.add_argument(
-            '--client-protocol',
-            type=str,
-            choices=['http', 'grpc'],
-            default='grpc',
-            help='The protocol used to communicate with the Triton Inference Server')
-        self._parser.add_argument(
-            '--perf-analyzer-path',
-            type=str,
-            default='perf_analyzer',
-            help='The full path to the perf_analyzer binary executable')
-        self._parser.add_argument(
-            '--perf-measurement-window',
-            type=int,
-            default=5000,
-            help='Time interval in milliseconds between perf_analyzer measurements. perf_analyzer will take '
-                 'measurements over all the requests completed within this time interval.')
-        self._parser.add_argument(
-            '--no-perf-output',
-            action='store_true',
-            help='Writes the output from the perf_analyze to stdout'
-        )
-        self._parser.add_argument(
-            '--triton-launch-mode',
-            type=str,
-            choices=['local', 'docker', 'remote'],
-            default='local',
-            help="The method by which to launch Triton Server. "
-                 "'local' assumes tritonserver binary is available locally. "
-                 "'docker' pulls and launches a triton docker container with "
-                 "the specified version. 'remote' connects to a running "
-                 "server using given http, grpc and metrics endpoints. "
-        )
-        self._parser.add_argument(
-            '--triton-version',
-            default='20.11-py3',
-            type=str,
-            help='Triton Server version')
-        self._parser.add_argument(
-            '--log-level',
-            default='INFO',
-            type=str,
-            choices=['INFO', 'DEBUG', 'ERROR', 'WARNING'],
-            help='Logging levels')
-        self._parser.add_argument(
-            '--triton-http-endpoint',
-            type=str,
-            default='localhost:8000',
-            help="Triton Server HTTP endpoint url used by Model Analyzer client. "
-                 "Will be ignored if server-launch-mode is not 'remote'")
-        self._parser.add_argument(
-            '--triton-grpc-endpoint',
-            type=str,
-            default='localhost:8001',
-            help="Triton Server HTTP endpoint url used by Model Analyzer client. "
-                 "Will be ignored if server-launch-mode is not 'remote'")
-        self._parser.add_argument(
-            '--triton-metrics-url',
-            type=str,
-            default='http://localhost:8002/metrics',
-            help="Triton Server Metrics endpoint url. "
-                 "Will be ignored if server-launch-mode is not 'remote'")
-        self._parser.add_argument(
-            '--triton-server-path',
-            type=str,
-            default='tritonserver',
-            help='The full path to the tritonserver binary executable')
-        self._parser.add_argument(
-            '--triton-output-path',
-            type=str,
-            help='The full path to a file to write the Triton Server log output to.')
-        self._parser.add_argument(
-            '--gpus',
-            type=str,
-            default='all',
-            help="List of GPU UUIDs to be used for the profiling. "
-                 "Use 'all' to profile all the GPUs visible by CUDA.")
-        # yapf:enable
-
-    def _preprocess_and_verify_arguments(self, args):
+    def _add_arguments(self, config):
         """
-        Enforces some rules on input
-        arguments. Sets some defaults.
+        Add the CLI arguments from the config
 
         Parameters
         ----------
-        args : argparse.Namespace
-            containing all the parsed arguments
-
-        Raises
-        ------
-        TritonModelAnalyzerException
-            If arguments are passed in incorrectly
+        config : Config
+            Model Analyzer config object.
         """
 
-        if args.export:
-            if not args.export_path:
-                logger.warning(
-                    "--export-path specified without --export flag: skipping exporting metrics."
+        configs = config.get_config()
+        for config in configs.values():
+            parser_args = config.parser_args()
+            # 'store_true' and 'store_false' does not
+            # allow 'type' or 'choices' parameters
+            if 'action' in parser_args and (
+                    parser_args['action'] == 'store_true'
+                    or parser_args['action'] == 'store_false'):
+                self._parser.add_argument(
+                    *config.flags(),
+                    default=argparse.SUPPRESS,
+                    help=config.description(),
+                    **config.parser_args(),
                 )
-                args.export_path = None
-            elif args.export_path and not os.path.isdir(args.export_path):
-                raise TritonModelAnalyzerException(
-                    f"Export path {args.export_path} is not a directory.")
-        if args.triton_launch_mode == 'remote':
-            if args.client_protocol == 'http' and not args.triton_http_endpoint:
-                raise TritonModelAnalyzerException(
-                    "client-protocol is 'http'. Must specify triton-http-endpoint "
-                    "if connecting to already running server or change protocol using "
-                    "--client-protocol.")
-            if args.client_protocol == 'grpc' and not args.triton_grpc_endpoint:
-                raise TritonModelAnalyzerException(
-                    "client-protocol is 'grpc'. Must specify triton-grpc-endpoint "
-                    "if connecting to already running server or change protocol using "
-                    "--client-protocol.")
-        args.gpus = args.gpus.split(',')
-
-    def _setup_logger(self, args):
-        """
-        Setup logger format
-        """
-        log_level = logging.getLevelName(args.log_level)
-        logging.basicConfig(level=log_level,
-                            format="%(asctime)s.%(msecs)d %(levelname)-4s"
-                            "[%(filename)s:%(lineno)d] %(message)s",
-                            datefmt="%Y-%m-%d %H:%M:%S")
+            else:
+                self._parser.add_argument(
+                    *config.flags(),
+                    default=argparse.SUPPRESS,
+                    choices=config.choices(),
+                    help=config.description(),
+                    type=config.field_type(),
+                    **config.parser_args(),
+                )
 
     def parse(self):
         """
         Retrieves the arguments from the command line and loads them into an
-        ArgumentParser Also does some sanity checks for arguments.
-
-        Returns
-        -------
-        argparse.Namespace
-            containing all the parsed arguments
-
-        Raises
-        ------
-        TritonModelAnalyzerException
-            For arguments passed incorrectly
+        ArgumentParser. It will also configure the Model Analyzer config
+        accordingly.
         """
 
         # Remove the first argument which is the program name
         args = self._parser.parse_args(sys.argv[1:])
-        self._preprocess_and_verify_arguments(args)
-        self._setup_logger(args)
-
-        return args
+        self._config.set_config_values(args)

--- a/model_analyzer/config/__init__.py
+++ b/model_analyzer/config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,28 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-TEST_LOG='test.log'
-source ../common/util.sh
-
-rm -f test.log
-
-MODEL_ANALYZER=`which model-analyzer`
-
-RET=0
-
-set +e
-run_analyzer
-if [ $? != 1 ]; then
-    echo -e "\n***\n*** Failed to run model-analyzer. \n***"
-    cat $ANALYZER_LOG
-    RET=1
-fi
-set -e
-
-if [ $RET -eq 0 ]; then
-    echo -e "\n***\n*** Test PASSED\n***"
-else
-    echo -e "\n***\n*** Test FAILED\n***"
-fi
-exit $RET

--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -1,0 +1,364 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+import logging
+import os
+from .config_field import ConfigField
+from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+
+
+class Config:
+    """
+    Model Analyzer config object.
+    """
+    def __init__(self):
+        """
+        Create a new config.
+        """
+
+        self._fields = {}
+        self._fill_config()
+
+    def _add_config(self, config_field):
+        """
+        Add a new config field.
+
+        Parameters
+        ----------
+        config_field : ConfigField
+            Config field to be added
+
+        Raises
+        ------
+        KeyError
+            If the field already exists, it will raise this exception.
+        """
+
+        if config_field.name() not in self._fields:
+            self._fields[config_field.name()] = config_field
+        else:
+            raise KeyError
+
+    def _fill_config(self):
+        self._add_config(
+            ConfigField('model_repository',
+                        flags=['--model-repository', '-m'],
+                        required=True,
+                        description='Model repository location'))
+        self._add_config(
+            ConfigField(
+                'model_names',
+                flags=['--model-names', '-n'],
+                required=True,
+                description=
+                'Comma-delimited list of the model names to be profiled'))
+        self._add_config(
+            ConfigField(
+                'batch_sizes',
+                flags=['--batch-sizes', '-b'],
+                description=
+                'Comma-delimited list of batch sizes to use for the profiling')
+        )
+        self._add_config(
+            ConfigField(
+                'concurrency',
+                flags=['-c', '--concurrency'],
+                description=
+                "Comma-delimited list of concurrency values or ranges <start:end:step>"
+                " to be used during profiling"))
+        self._add_config(
+            ConfigField('export',
+                        flags=['--export'],
+                        parser_args={'action': 'store_true'},
+                        description="Enables exporting metrics to a file"))
+        self._add_config(
+            ConfigField(
+                'export_path',
+                flags=['--export-path', '-e'],
+                default_value='.',
+                description=
+                "Full path to directory in which to store the results"))
+        self._add_config(
+            ConfigField(
+                'filename_model_inference',
+                flags=['--filename-model-inference'],
+                default_value='metrics-model-inference.csv',
+                description=
+                'Specifies filename for storing model inference metrics'))
+        self._add_config(
+            ConfigField(
+                'filename_model_gpu',
+                flags=['--filename-model-gpu'],
+                default_value='metrics-model-gpu.csv',
+                description='Specifies filename for storing model GPU metrics')
+        )
+        self._add_config(
+            ConfigField(
+                'filename_server_only',
+                flags=['--filename-server-only'],
+                default_value='metrics-server-only.csv',
+                description='Specifies filename for server-only metrics'))
+        self._add_config(
+            ConfigField(
+                'max_retries',
+                flags=['-r', '--max-retries'],
+                field_type=int,
+                default_value=100,
+                description=
+                'Specifies the max number of retries for any retry attempt'))
+        self._add_config(
+            ConfigField(
+                'duration_seconds',
+                flags=['-d', '--duration-seconds'],
+                default_value=5,
+                field_type=float,
+                description=
+                'Specifies how long (seconds) to gather server-only metrics'))
+        self._add_config(
+            ConfigField(
+                'monitoring_interval',
+                flags=['-i', '--monitoring-interval'],
+                default_value=0.01,
+                field_type=float,
+                description=
+                'Interval of time between DGCM measurements in seconds'))
+        self._add_config(
+            ConfigField(
+                'client_protocol',
+                flags=['--client-protocol'],
+                choices=['http', 'grpc'],
+                default_value='grpc',
+                description=
+                'The protocol used to communicate with the Triton Inference Server'
+            ))
+        self._add_config(
+            ConfigField(
+                'perf_analyzer_path',
+                flags=['--perf-analyzer-path'],
+                default_value='perf_analyzer',
+                description=
+                'The full path to the perf_analyzer binary executable'))
+        self._add_config(
+            ConfigField(
+                'perf_measurement_window',
+                flags=['--perf-measurement-window'],
+                field_type=int,
+                default_value=5000,
+                description=
+                'Time interval in milliseconds between perf_analyzer measurements. perf_analyzer will take '
+                'measurements over all the requests completed within this time interval.'
+            ))
+        self._add_config(
+            ConfigField(
+                'no_perf_output',
+                flags=['--no-perf-output'],
+                parser_args={'action': 'store_true'},
+                description='Writes the output from the perf_analyze to stdout'
+            ))
+        self._add_config(
+            ConfigField(
+                'triton_launch_mode',
+                flags=['--triton-launch-mode'],
+                default_value='local',
+                choices=['local', 'docker', 'remote'],
+                description="The method by which to launch Triton Server. "
+                "'local' assumes tritonserver binary is available locally. "
+                "'docker' pulls and launches a triton docker container with "
+                "the specified version. 'remote' connects to a running "
+                "server using given http, grpc and metrics endpoints. "))
+        self._add_config(
+            ConfigField('triton_version',
+                        flags=['--triton-version'],
+                        default_value='20.11-py3',
+                        description='Triton Server Docker version'))
+        self._add_config(
+            ConfigField('log_level',
+                        flags=['--log-level'],
+                        default_value='INFO',
+                        choices=['INFO', 'DEBUG', 'ERROR', 'WARNING'],
+                        description='Logging levels'))
+        self._add_config(
+            ConfigField(
+                'triton_http_endpoint',
+                default_value='localhost:8000',
+                flags=['--triton-http-endpoint'],
+                description=
+                "Triton Server HTTP endpoint url used by Model Analyzer client. "
+                "Will be ignored if server-launch-mode is not 'remote'"))
+        self._add_config(
+            ConfigField(
+                'triton_grpc_endpoint',
+                flags=['--triton-grpc-endpoint'],
+                default_value='localhost:8001',
+                description=
+                "Triton Server HTTP endpoint url used by Model Analyzer client. "
+                "Will be ignored if server-launch-mode is not 'remote'"))
+        self._add_config(
+            ConfigField(
+                'triton_metrics_url',
+                flags=['--triton-metrics-url'],
+                default_value='http://localhost:8002/metrics',
+                description="Triton Server Metrics endpoint url. "
+                "Will be ignored if server-launch-mode is not 'remote'"))
+        self._add_config(
+            ConfigField('triton_server_path',
+                        flags=['--triton-server-path'],
+                        default_value='tritonserver',
+                        description=
+                        'The full path to the tritonserver binary executable'))
+        self._add_config(
+            ConfigField(
+                'triton_output_path',
+                flags=['--triton-output-path'],
+                description=
+                'The full path to a file to write the Triton Server log output to.'
+            ))
+        self._add_config(
+            ConfigField(
+                'gpus',
+                flags=['--gpus'],
+                preprocess=lambda value: value.split(','),
+                default_value='all',
+                description="List of GPU UUIDs to be used for the profiling. "
+                "Use 'all' to profile all the GPUs visible by CUDA."))
+        self._add_config(
+            ConfigField('config_file',
+                        flags=['-f', '--config-file'],
+                        description="Path to Model Analyzer Config File."))
+
+    def _preprocess_and_verify_arguments(self):
+        """
+        Enforces some rules on the config.
+
+        Raises
+        ------
+        TritonModelAnalyzerException
+            If there is a problem with arguments or config.
+        """
+
+        if self.export:
+            if not self.export_path:
+                logger.warning(
+                    "--export-path specified without --export flag: skipping exporting metrics."
+                )
+                self.export_path = None
+            elif self.export_path and not os.path.isdir(self.export_path):
+                raise TritonModelAnalyzerException(
+                    f"Export path {self.export_path} is not a directory.")
+        if self.triton_launch_mode == 'remote':
+            if self.client_protocol == 'http' and not self.triton_http_endpoint:
+                raise TritonModelAnalyzerException(
+                    "client-protocol is 'http'. Must specify triton-http-endpoint "
+                    "if connecting to already running server or change protocol using "
+                    "--client-protocol.")
+            if self.client_protocol == 'grpc' and not self.triton_grpc_endpoint:
+                raise TritonModelAnalyzerException(
+                    "client-protocol is 'grpc'. Must specify triton-grpc-endpoint "
+                    "if connecting to already running server or change protocol using "
+                    "--client-protocol.")
+
+    def _load_config_file(self, file_path):
+        """
+        Load YAML config
+
+        Parameters
+        ----------
+        file_path : str
+            Path to the Model Analyzer config file
+        """
+
+        with open(file_path, 'r') as config_file:
+            config = yaml.load(config_file, Loader=yaml.FullLoader)
+            return config
+
+    def _setup_logger(self):
+        """
+        Setup logger format
+        """
+        log_level = logging.getLevelName(self.log_level)
+        logging.basicConfig(level=log_level,
+                            format="%(asctime)s.%(msecs)d %(levelname)-4s"
+                            "[%(filename)s:%(lineno)d] %(message)s",
+                            datefmt="%Y-%m-%d %H:%M:%S")
+
+    def set_config_values(self, args):
+        """
+        Set the config values. This function sets all the values for the
+        config. CLI arguments have the highest priority, then YAML config
+        values and then default values.
+
+        Parameters
+        ----------
+        args : argparse.Namespace
+            Parsed arguments from the CLI
+
+        Raises
+        ------
+        TritonModelAnalyzerException
+            If the required fields are not specified, it will raise
+            this exception
+        """
+
+        # Config file has been specified
+        if 'config_file' in args:
+            yaml_config = self._load_config_file(args.config_file)
+        else:
+            yaml_config = None
+        for key, value in self._fields.items():
+            if key in args:
+                self._fields[key].set_value(getattr(args, key))
+            elif yaml_config is not None and key in yaml_config:
+                self._fields[key].set_value(yaml_config[key])
+            elif value.default_value() is not None:
+                self._fields[key].set_value(value.default_value())
+            elif value.required():
+                flags = ', '.join(value.flags())
+                raise TritonModelAnalyzerException(
+                    f'Config for {value.name()} is not specified. You need to specify it using the YAML config file or using the {flags} flags in CLI.'
+                )
+        self._setup_logger()
+        self._preprocess_and_verify_arguments()
+
+    def get_config(self):
+        """
+        Get the config dictionary.
+
+        Returns
+        -------
+        dict
+            Returns a dictionary where the keys are the
+            configuration name and the values are ConfigField objects.
+        """
+
+        return self._fields
+
+    def get_all_config(self):
+        """
+        Get a dictionary containing all the configurations.
+
+        Returns
+        -------
+        dict
+            A dictionary containing all the configurations.
+        """
+
+        config_dict = {}
+        for config in self._fields.values():
+            config_dict[config.name()] = config.value()
+
+        return config_dict
+
+    def __getattr__(self, name):
+        return self._fields[name].value()

--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -19,7 +19,7 @@ from .config_field import ConfigField
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
 
-class Config:
+class AnalyzerConfig:
     """
     Model Analyzer config object.
     """

--- a/model_analyzer/config/config_field.py
+++ b/model_analyzer/config/config_field.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ConfigField:
+    def __init__(self,
+                 name=None,
+                 description=None,
+                 flags=None,
+                 field_type=str,
+                 choices=None,
+                 preprocess=None,
+                 default_value=None,
+                 required=False,
+                 parser_args={}):
+        """
+        Create a configuration field.
+
+        Parameters
+        ----------
+        name : str
+            Configuration name.
+        description : str
+            Description of the config.
+        flags : list
+            List of the flags to be used for the CLI.
+        field_type : type
+            Type of the config field.
+        choices : list or None
+            List of the choices to be used.
+        preprocess : callable
+            Function be called before setting new values.
+        default_value : object
+            Default value used for the config field.
+        required : bool
+            Whether a given config is required or not.
+        parser_args : dict
+            Additionaly arguments to be passed to ArgumentParser.
+        """
+
+        self._description = description
+        self._default_value = default_value
+        self._name = name
+        self._field_type = field_type
+        self._flags = flags
+        self._value = None
+        self._choices = choices
+        self._parser_args = parser_args
+        self._preprocess = preprocess
+        self._required = required
+
+    def choices(self):
+        """
+        List of choices that are allowed
+        """
+
+        return self._choices
+
+    def parser_args(self):
+        """
+        Get the additional arguments to be passed to ArgumentParser.
+
+        Returns
+        -------
+        dict or None
+            A dictionary where the keys are arguments and the values are
+            the argument values
+        """
+
+        return self._parser_args
+
+    def description(self):
+        """
+        Get the field description.
+
+        Returns
+        -------
+        str or None
+            Description of the config field
+        """
+
+        return self._description
+
+    def field_type(self):
+        """
+        Get the field type.
+
+        Returns
+        -------
+        type
+            Type of the config field
+        """
+
+        return self._field_type
+
+    def name(self):
+        """
+        Get the name of the config field.
+
+        Returns
+        -------
+        str
+            Name of the config field
+        """
+
+        return self._name
+
+    def default_value(self):
+        """
+        Get the value for this config field.
+
+        Returns
+        -------
+        object
+            The default value of the config field
+        """
+
+        return self._default_value
+
+    def flags(self):
+        """
+        Get the CLI flags.
+
+        Returns
+        -------
+        list
+            A list of the CLI flags used
+        """
+
+        return self._flags
+
+    def set_value(self, value):
+        """
+        Set the value for the config field.
+        """
+
+        self._value = self._field_type(value)
+        if self._preprocess is not None:
+            self._value = self._preprocess(value)
+
+    def value(self):
+        """
+        Get the value for the config field.
+
+        Returns
+        -------
+        object
+            The value of the config field.
+        """
+
+        return self._value
+
+    def required(self):
+        """
+        Get the required field value
+
+        Returns
+        -------
+        bool
+            Whether the config field is required or not.
+        """
+
+        return self._required

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -37,98 +37,99 @@ from .record.perf_throughput import PerfThroughput
 from .record.perf_latency import PerfLatency
 from .output.file_writer import FileWriter
 from .device.gpu_device_factory import GPUDeviceFactory
+from .config.config import Config
 
 logger = logging.getLogger(__name__)
 MAX_NUMBER_OF_INTERRUPTS = 3
 
 
-def get_client_handle(args):
+def get_client_handle(config):
     """
     Creates and returns a TritonClient
     with specified arguments
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         Arguments parsed from the CLI
     """
 
-    if args.client_protocol == 'http':
+    if config.client_protocol == 'http':
         client = TritonClientFactory.create_http_client(
-            server_url=args.triton_http_endpoint)
-    elif args.client_protocol == 'grpc':
+            server_url=config.triton_http_endpoint)
+    elif config.client_protocol == 'grpc':
         client = TritonClientFactory.create_grpc_client(
-            server_url=args.triton_grpc_endpoint)
+            server_url=config.triton_grpc_endpoint)
     else:
         raise TritonModelAnalyzerException(
-            f"Unrecognized client-protocol : {args.client_protocol}")
+            f"Unrecognized client-protocol : {config.client_protocol}")
 
     return client
 
 
-def get_server_handle(args):
+def get_server_handle(config):
     """
     Creates and returns a TritonServer
     with specified arguments
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         Arguments parsed from the CLI
     """
 
-    if args.triton_launch_mode == 'remote':
+    if config.triton_launch_mode == 'remote':
         triton_config = TritonServerConfig()
         triton_config['model-repository'] = 'remote-model-repository'
         logger.info('Using remote Triton Server...')
         server = TritonServerFactory.create_server_local(path=None,
                                                          config=triton_config)
-    elif args.triton_launch_mode == 'local':
+    elif config.triton_launch_mode == 'local':
         triton_config = TritonServerConfig()
-        triton_config['model-repository'] = args.model_repository
-        triton_config['http-port'] = args.triton_http_endpoint.split(':')[-1]
-        triton_config['grpc-port'] = args.triton_grpc_endpoint.split(':')[-1]
-        triton_config['metrics-port'] = urlparse(args.triton_metrics_url).port
+        triton_config['model-repository'] = config.model_repository
+        triton_config['http-port'] = config.triton_http_endpoint.split(':')[-1]
+        triton_config['grpc-port'] = config.triton_grpc_endpoint.split(':')[-1]
+        triton_config['metrics-port'] = urlparse(config.triton_metrics_url).port
         triton_config['model-control-mode'] = 'explicit'
         logger.info('Starting a local Triton Server...')
         server = TritonServerFactory.create_server_local(
-            path=args.triton_server_path, config=triton_config)
+            path=config.triton_server_path, config=triton_config)
         server.start()
-    elif args.triton_launch_mode == 'docker':
+    elif config.triton_launch_mode == 'docker':
         triton_config = TritonServerConfig()
-        triton_config['model-repository'] = args.model_repository
-        triton_config['http-port'] = args.triton_http_endpoint.split(':')[-1]
-        triton_config['grpc-port'] = args.triton_grpc_endpoint.split(':')[-1]
-        triton_config['metrics-port'] = urlparse(args.triton_metrics_url).port
+        triton_config['model-repository'] = config.model_repository
+        triton_config['http-port'] = config.triton_http_endpoint.split(':')[-1]
+        triton_config['grpc-port'] = config.triton_grpc_endpoint.split(':')[-1]
+        triton_config['metrics-port'] = urlparse(config.triton_metrics_url).port
         triton_config['model-control-mode'] = 'explicit'
         logger.info('Starting a Triton Server using docker...')
         server = TritonServerFactory.create_server_docker(
-            image='nvcr.io/nvidia/tritonserver:' + args.triton_version,
+            image='nvcr.io/nvidia/tritonserver:' + config.triton_version,
             config=triton_config,
-            gpus=get_analyzer_gpus(args))
+            gpus=get_analyzer_gpus(config))
         server.start()
     else:
         raise TritonModelAnalyzerException(
-            f"Unrecognized triton-launch-mode : {args.triton_launch_mode}")
+            f"Unrecognized triton-launch-mode : {config.triton_launch_mode}")
 
     return server
 
 
-def get_analyzer_gpus(args):
+def get_analyzer_gpus(config):
     """
     Creates a list of GPU UUIDs corresponding to the GPUs visible to
     model_analyzer.
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
     """
 
-    if len(args.gpus) == 1 and args.gpus[0] == 'all':
+    if len(config.gpus) == 1 and config.gpus[0] == 'all':
         devices = numba.cuda.list_devices()
     else:
-        devices = args.gpus
+        devices = config.gpus
 
     model_analyzer_gpus = []
     for device in devices:
@@ -139,18 +140,18 @@ def get_analyzer_gpus(args):
     return model_analyzer_gpus
 
 
-def get_triton_metrics_gpus(args):
+def get_triton_metrics_gpus(config):
     """
     Uses prometheus to request a list of GPU UUIDs corresponding to the GPUs
     visible to Triton Inference Server
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
     """
 
-    triton_prom_str = str(requests.get(args.triton_metrics_url).content,
+    triton_prom_str = str(requests.get(config.triton_metrics_url).content,
                           encoding='ascii')
     metrics = text_string_to_metric_families(triton_prom_str)
 
@@ -163,13 +164,13 @@ def get_triton_metrics_gpus(args):
     return triton_gpus
 
 
-def check_triton_and_model_analyzer_gpus(args):
+def check_triton_and_model_analyzer_gpus(config):
     """
     Check whether Triton Server and Model Analyzer are using the same GPUs
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
 
     Raises
@@ -178,8 +179,8 @@ def check_triton_and_model_analyzer_gpus(args):
         If they are using different GPUs this exception will be raised.
     """
 
-    model_analyzer_gpus = get_analyzer_gpus(args)
-    triton_gpus = get_triton_metrics_gpus(args)
+    model_analyzer_gpus = get_analyzer_gpus(config)
+    triton_gpus = get_triton_metrics_gpus(config)
     if set(model_analyzer_gpus) != set(triton_gpus):
         raise TritonModelAnalyzerException(
             "'Triton Server is not using the same GPUs as Model Analyzer: '"
@@ -187,13 +188,13 @@ def check_triton_and_model_analyzer_gpus(args):
         )
 
 
-def get_triton_handles(args):
+def get_triton_handles(config):
     """
     Creates a TritonServer and starts it. Creates a TritonClient
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
 
     Returns
@@ -202,19 +203,19 @@ def get_triton_handles(args):
         Handles for triton client/server pair.
     """
 
-    client = get_client_handle(args)
-    server = get_server_handle(args)
-    client.wait_for_server_ready(num_retries=args.max_retries)
+    client = get_client_handle(config)
+    server = get_server_handle(config)
+    client.wait_for_server_ready(num_retries=config.max_retries)
     logger.info('Triton Server is ready.')
 
     return client, server
 
 
-def create_run_configs(args):
+def create_run_configs(config):
     """
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
 
     Returns
@@ -225,15 +226,15 @@ def create_run_configs(args):
     """
 
     sweep_params = {
-        'model-name': [name.strip() for name in args.model_names.split(',')],
-        'batch-size': [batch.strip() for batch in args.batch_sizes.split(',')],
-        'concurrency-range': [c.strip() for c in args.concurrency.split(',')],
-        'protocol': [args.client_protocol],
+        'model-name': [name.strip() for name in config.model_names.split(',')],
+        'batch-size': [batch.strip() for batch in config.batch_sizes.split(',')],
+        'concurrency-range': [c.strip() for c in config.concurrency.split(',')],
+        'protocol': [config.client_protocol],
         'url': [
-            args.triton_http_endpoint
-            if args.client_protocol == 'http' else args.triton_grpc_endpoint
+            config.triton_http_endpoint
+            if config.client_protocol == 'http' else config.triton_grpc_endpoint
         ],
-        'measurement-interval': [args.perf_measurement_window]
+        'measurement-interval': [config.perf_measurement_window]
     }
     param_combinations = list(product(*tuple(sweep_params.values())))
     run_params = [
@@ -243,7 +244,7 @@ def create_run_configs(args):
     return run_params
 
 
-def write_results(args, analyzer):
+def write_results(config, analyzer):
     """
     Makes calls to the analyzer to write results out to streams or files. If
     exporting results is requested, uses a FileWriter for specified output
@@ -251,7 +252,7 @@ def write_results(args, analyzer):
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
     analyzer : Analyzer
         The instance being used to profile
@@ -259,23 +260,23 @@ def write_results(args, analyzer):
     """
 
     analyzer.write_results(writer=FileWriter(), column_separator=' ')
-    if args.export:
-        server_metrics_path = os.path.join(args.export_path,
-                                           args.filename_server_only)
+    if config.export:
+        server_metrics_path = os.path.join(config.export_path,
+                                           config.filename_server_only)
         analyzer.export_server_only_csv(
             writer=FileWriter(filename=server_metrics_path),
             column_separator=',')
-        metrics_inference_path = os.path.join(args.export_path,
-                                              args.filename_model_inference)
-        metrics_gpu_path = os.path.join(args.export_path,
-                                        args.filename_model_gpu)
+        metrics_inference_path = os.path.join(config.export_path,
+                                              config.filename_model_inference)
+        metrics_gpu_path = os.path.join(config.export_path,
+                                        config.filename_model_gpu)
         analyzer.export_model_csv(
             inference_writer=FileWriter(filename=metrics_inference_path),
             gpu_metrics_writer=FileWriter(filename=metrics_gpu_path),
             column_separator=',')
 
 
-def write_server_logs(args, server):
+def write_server_logs(config, server):
     """
     Checks if server logs have been
     requested, and writes them
@@ -283,26 +284,26 @@ def write_server_logs(args, server):
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
     server : TritonServer
         The triton server instance whose logs
         we may want to write out.
     """
 
-    if args.triton_output_path:
-        server_log_writer = FileWriter(filename=args.triton_output_path)
+    if config.triton_output_path:
+        server_log_writer = FileWriter(filename=config.triton_output_path)
         server_log_writer.write(server.logs())
 
 
-def run_analyzer(args, analyzer, client, run_configs):
+def run_analyzer(config, analyzer, client, run_configs):
     """
     Makes a single call to profile the server only Then for each run
     configurations, it profiles model inference.
 
     Parameters
     ----------
-    args : namespace
+    config : namespace
         The arguments passed into the CLI
     analyzer : Analyzer
         The instance being used to profile server inferencing.
@@ -320,9 +321,9 @@ def run_analyzer(args, analyzer, client, run_configs):
     for run_config in run_configs:
         model = Model(name=run_config['model-name'])
         client.load_model(model=model)
-        client.wait_for_model_ready(model=model, num_retries=args.max_retries)
+        client.wait_for_model_ready(model=model, num_retries=config.max_retries)
         try:
-            perf_output_writer = None if args.no_perf_output else FileWriter()
+            perf_output_writer = None if config.no_perf_output else FileWriter()
             analyzer.profile_model(run_config=run_config,
                                    perf_output_writer=perf_output_writer)
         finally:
@@ -357,35 +358,37 @@ def main():
     signal.signal(signal.SIGINT, interrupt_handler)
 
     try:
-        args = CLI().parse()
+        config = Config()
+        cli = CLI(config)
+        cli.parse()
     except TritonModelAnalyzerException as e:
         logging.error(f'Model Analyzer encountered an error: {e}')
         sys.exit(1)
 
-    logging.info(f'Triton Model Analyzer started {args} arguments')
-    analyzer = Analyzer(args, monitoring_metrics)
+    logging.info(f'Triton Model Analyzer started: config={config.get_all_config()}')
+    analyzer = Analyzer(config, monitoring_metrics)
     server = None
     try:
-        client, server = get_triton_handles(args)
+        client, server = get_triton_handles(config)
 
         # Only check for exit after the events that take a long time.
         if exiting:
             return
 
-        check_triton_and_model_analyzer_gpus(args)
-        run_configs = create_run_configs(args)
+        check_triton_and_model_analyzer_gpus(config)
+        run_configs = create_run_configs(config)
         if exiting:
             return
 
         logging.info('Starting perf_analyzer...')
-        run_analyzer(args, analyzer, client, run_configs)
-        write_results(args, analyzer)
+        run_analyzer(config, analyzer, client, run_configs)
+        write_results(config, analyzer)
     except TritonModelAnalyzerException as e:
         logging.exception(f'Model Analyzer encountered an error: {e}')
     finally:
         if server is not None:
             server.stop()
-            write_server_logs(args, server)
+            write_server_logs(config, server)
 
 
 if __name__ == '__main__':

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ from .record.perf_throughput import PerfThroughput
 from .record.perf_latency import PerfLatency
 from .output.file_writer import FileWriter
 from .device.gpu_device_factory import GPUDeviceFactory
-from .config.config import Config
+from .config.config import AnalyzerConfig
 
 logger = logging.getLogger(__name__)
 MAX_NUMBER_OF_INTERRUPTS = 3
@@ -358,7 +358,7 @@ def main():
     signal.signal(signal.SIGINT, interrupt_handler)
 
     try:
-        config = Config()
+        config = AnalyzerConfig()
         cli = CLI(config)
         cli.parse()
     except TritonModelAnalyzerException as e:

--- a/qa/L0_doa/test.sh
+++ b/qa/L0_doa/test.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qa/L0_unit_tests/test.sh
+++ b/qa/L0_unit_tests/test.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,4 +40,3 @@ else
 fi
 
 exit $RET
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ distro>=1.5.0
 numba>=0.51.2
 prometheus_client>=0.9.0
 requests>=2.24.0
+pyyaml>=5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/mocks/mock_config.py
+++ b/tests/mocks/mock_config.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .mock_base import MockBase
+from unittest.mock import patch, MagicMock, mock_open
+import io
+
+
+class MockConfig(MockBase):
+    def __init__(self, args, yaml_file_content):
+        self.args = args
+        self.yaml_file_content = yaml_file_content
+        super().__init__()
+
+    def _fill_patchers(self):
+        patchers = self._patchers
+
+        patchers.append(
+            patch(
+                "builtins.open",
+                mock_open(
+                    read_data=self.yaml_file_content)))
+        patchers.append(
+            patch("model_analyzer.cli.cli.sys.argv", self.args)
+        )

--- a/tests/test_triton_config.py
+++ b/tests/test_triton_config.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import sys
+from unittest.mock import MagicMock
+sys.path.append('../common')
+
+import test_result_collector as trc
+from model_analyzer.config.config import Config
+from model_analyzer.cli.cli import CLI
+from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from .mocks.mock_config import MockConfig
+
+
+class TestConfig(trc.TestResultCollector):
+    def test_config(self):
+        args = [
+            'model-analyzer', '--model-repository', 'cli_repository', '-f',
+            'path-to-config-file', '--model-names', 'vgg11'
+        ]
+        yaml_content = 'model_repository: yaml_repository'
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = Config()
+        cli = CLI(config)
+        cli.parse()
+
+        # CLI flag has the highest priority
+        self.assertTrue(
+            config.get_all_config()['model_repository'] == 'cli_repository')
+        mock_config.stop()
+
+        args = [
+            'model-analyzer', '-f', 'path-to-config-file', '--model-names',
+            'vgg11'
+        ]
+        yaml_content = 'model_repository: yaml_repository'
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = Config()
+        cli = CLI(config)
+        cli.parse()
+
+        # If CLI flag doesn't exist, YAML config has the highest priority
+        self.assertTrue(
+            config.get_all_config()['model_repository'] == 'yaml_repository')
+        mock_config.stop()
+
+        args = ['model-analyzer', '-f', 'path-to-config-file']
+        yaml_content = 'model_repository: yaml_repository'
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = Config()
+        cli = CLI(config)
+
+        # When a required field is not specified, parse will lead to an exception
+        with self.assertRaises(TritonModelAnalyzerException):
+            cli.parse()
+
+        # If CLI flag doesn't exist, YAML config has the highest priority
+        self.assertTrue(
+            config.get_all_config()['model_repository'] == 'yaml_repository')
+        mock_config.stop()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_triton_config.py
+++ b/tests/test_triton_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 sys.path.append('../common')
 
 import test_result_collector as trc
-from model_analyzer.config.config import Config
+from model_analyzer.config.config import AnalyzerConfig
 from model_analyzer.cli.cli import CLI
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 from .mocks.mock_config import MockConfig
@@ -33,7 +33,7 @@ class TestConfig(trc.TestResultCollector):
         yaml_content = 'model_repository: yaml_repository'
         mock_config = MockConfig(args, yaml_content)
         mock_config.start()
-        config = Config()
+        config = AnalyzerConfig()
         cli = CLI(config)
         cli.parse()
 
@@ -49,7 +49,7 @@ class TestConfig(trc.TestResultCollector):
         yaml_content = 'model_repository: yaml_repository'
         mock_config = MockConfig(args, yaml_content)
         mock_config.start()
-        config = Config()
+        config = AnalyzerConfig()
         cli = CLI(config)
         cli.parse()
 
@@ -62,7 +62,7 @@ class TestConfig(trc.TestResultCollector):
         yaml_content = 'model_repository: yaml_repository'
         mock_config = MockConfig(args, yaml_content)
         mock_config.start()
-        config = Config()
+        config = AnalyzerConfig()
         cli = CLI(config)
 
         # When a required field is not specified, parse will lead to an exception


### PR DESCRIPTION
Added Model Analyzer Config.  Currently, supports all the flags supported by the current version of Model Analyzer. The priority is with the CLI and then with the Config file as mentioned in the engineering doc.

An example configuration looks like below:

```yaml
model_repository: /data/inferenceserver/20.11dev/tf_model_store/
export: true
triton_launch_mode: docker
model_names: vgg_16_graphdef
concurrency: 1
triton_http_endpoint: localhost:8030
triton_grpc_endpoint: localhost:8040
triton_metrics_url: http://localhost:8090/metrics
batch_sizes: 2
```