### PR TITLE
Improve the support for custom types in Model Analyzer Config

### DIFF
--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -16,6 +16,9 @@ import yaml
 import logging
 import os
 from .config_field import ConfigField
+from .config_primitive import ConfigPrimitive
+from .config_list_string import ConfigListString
+from .config_list_numeric import ConfigListNumeric
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
 
@@ -56,18 +59,22 @@ class AnalyzerConfig:
             ConfigField('model_repository',
                         flags=['--model-repository', '-m'],
                         required=True,
+                        field_type=ConfigPrimitive(str),
                         description='Model repository location'))
         self._add_config(
             ConfigField(
                 'model_names',
                 flags=['--model-names', '-n'],
                 required=True,
+                field_type=ConfigListString(),
                 description=
                 'Comma-delimited list of the model names to be profiled'))
         self._add_config(
             ConfigField(
                 'batch_sizes',
                 flags=['--batch-sizes', '-b'],
+                field_type=ConfigListNumeric(int),
+                default_value=1,
                 description=
                 'Comma-delimited list of batch sizes to use for the profiling')
         )
@@ -75,12 +82,15 @@ class AnalyzerConfig:
             ConfigField(
                 'concurrency',
                 flags=['-c', '--concurrency'],
+                field_type=ConfigListNumeric(int),
+                default_value=1,
                 description=
                 "Comma-delimited list of concurrency values or ranges <start:end:step>"
                 " to be used during profiling"))
         self._add_config(
             ConfigField('export',
                         flags=['--export'],
+                        field_type=ConfigPrimitive(bool),
                         parser_args={'action': 'store_true'},
                         description="Enables exporting metrics to a file"))
         self._add_config(
@@ -88,6 +98,7 @@ class AnalyzerConfig:
                 'export_path',
                 flags=['--export-path', '-e'],
                 default_value='.',
+                field_type=ConfigPrimitive(str),
                 description=
                 "Full path to directory in which to store the results"))
         self._add_config(
@@ -95,12 +106,14 @@ class AnalyzerConfig:
                 'filename_model_inference',
                 flags=['--filename-model-inference'],
                 default_value='metrics-model-inference.csv',
+                field_type=ConfigPrimitive(str),
                 description=
                 'Specifies filename for storing model inference metrics'))
         self._add_config(
             ConfigField(
                 'filename_model_gpu',
                 flags=['--filename-model-gpu'],
+                field_type=ConfigPrimitive(str),
                 default_value='metrics-model-gpu.csv',
                 description='Specifies filename for storing model GPU metrics')
         )
@@ -108,30 +121,31 @@ class AnalyzerConfig:
             ConfigField(
                 'filename_server_only',
                 flags=['--filename-server-only'],
+                field_type=ConfigPrimitive(str),
                 default_value='metrics-server-only.csv',
                 description='Specifies filename for server-only metrics'))
         self._add_config(
             ConfigField(
                 'max_retries',
                 flags=['-r', '--max-retries'],
-                field_type=int,
+                field_type=ConfigPrimitive(int),
                 default_value=100,
                 description=
                 'Specifies the max number of retries for any retry attempt'))
         self._add_config(
             ConfigField(
                 'duration_seconds',
+                field_type=ConfigPrimitive(int),
                 flags=['-d', '--duration-seconds'],
                 default_value=5,
-                field_type=float,
                 description=
                 'Specifies how long (seconds) to gather server-only metrics'))
         self._add_config(
             ConfigField(
                 'monitoring_interval',
                 flags=['-i', '--monitoring-interval'],
+                field_type=ConfigPrimitive(float),
                 default_value=0.01,
-                field_type=float,
                 description=
                 'Interval of time between DGCM measurements in seconds'))
         self._add_config(
@@ -139,6 +153,7 @@ class AnalyzerConfig:
                 'client_protocol',
                 flags=['--client-protocol'],
                 choices=['http', 'grpc'],
+                field_type=ConfigPrimitive(str),
                 default_value='grpc',
                 description=
                 'The protocol used to communicate with the Triton Inference Server'
@@ -147,6 +162,7 @@ class AnalyzerConfig:
             ConfigField(
                 'perf_analyzer_path',
                 flags=['--perf-analyzer-path'],
+                field_type=ConfigPrimitive(str),
                 default_value='perf_analyzer',
                 description=
                 'The full path to the perf_analyzer binary executable'))
@@ -154,7 +170,7 @@ class AnalyzerConfig:
             ConfigField(
                 'perf_measurement_window',
                 flags=['--perf-measurement-window'],
-                field_type=int,
+                field_type=ConfigPrimitive(int),
                 default_value=5000,
                 description=
                 'Time interval in milliseconds between perf_analyzer measurements. perf_analyzer will take '
@@ -164,12 +180,14 @@ class AnalyzerConfig:
             ConfigField(
                 'no_perf_output',
                 flags=['--no-perf-output'],
+                field_type=ConfigPrimitive(bool),
                 parser_args={'action': 'store_true'},
                 description='Writes the output from the perf_analyze to stdout'
             ))
         self._add_config(
             ConfigField(
                 'triton_launch_mode',
+                field_type=ConfigPrimitive(str),
                 flags=['--triton-launch-mode'],
                 default_value='local',
                 choices=['local', 'docker', 'remote'],
@@ -181,12 +199,14 @@ class AnalyzerConfig:
         self._add_config(
             ConfigField('triton_version',
                         flags=['--triton-version'],
+                        field_type=ConfigPrimitive(str),
                         default_value='20.11-py3',
                         description='Triton Server Docker version'))
         self._add_config(
             ConfigField('log_level',
                         flags=['--log-level'],
                         default_value='INFO',
+                        field_type=ConfigPrimitive(str),
                         choices=['INFO', 'DEBUG', 'ERROR', 'WARNING'],
                         description='Logging levels'))
         self._add_config(
@@ -194,6 +214,7 @@ class AnalyzerConfig:
                 'triton_http_endpoint',
                 default_value='localhost:8000',
                 flags=['--triton-http-endpoint'],
+                field_type=ConfigPrimitive(str),
                 description=
                 "Triton Server HTTP endpoint url used by Model Analyzer client. "
                 "Will be ignored if server-launch-mode is not 'remote'"))
@@ -201,6 +222,7 @@ class AnalyzerConfig:
             ConfigField(
                 'triton_grpc_endpoint',
                 flags=['--triton-grpc-endpoint'],
+                field_type=ConfigPrimitive(str),
                 default_value='localhost:8001',
                 description=
                 "Triton Server HTTP endpoint url used by Model Analyzer client. "
@@ -208,12 +230,14 @@ class AnalyzerConfig:
         self._add_config(
             ConfigField(
                 'triton_metrics_url',
+                field_type=ConfigPrimitive(str),
                 flags=['--triton-metrics-url'],
                 default_value='http://localhost:8002/metrics',
                 description="Triton Server Metrics endpoint url. "
                 "Will be ignored if server-launch-mode is not 'remote'"))
         self._add_config(
             ConfigField('triton_server_path',
+                        field_type=ConfigPrimitive(str),
                         flags=['--triton-server-path'],
                         default_value='tritonserver',
                         description=
@@ -221,6 +245,7 @@ class AnalyzerConfig:
         self._add_config(
             ConfigField(
                 'triton_output_path',
+                field_type=ConfigPrimitive(str),
                 flags=['--triton-output-path'],
                 description=
                 'The full path to a file to write the Triton Server log output to.'
@@ -229,12 +254,14 @@ class AnalyzerConfig:
             ConfigField(
                 'gpus',
                 flags=['--gpus'],
+                field_type=ConfigListString(),
                 preprocess=lambda value: value.split(','),
                 default_value='all',
                 description="List of GPU UUIDs to be used for the profiling. "
                 "Use 'all' to profile all the GPUs visible by CUDA."))
         self._add_config(
             ConfigField('config_file',
+                        field_type=ConfigPrimitive(str),
                         flags=['-f', '--config-file'],
                         description="Path to Model Analyzer Config File."))
 

--- a/model_analyzer/config/config_field.py
+++ b/model_analyzer/config/config_field.py
@@ -23,7 +23,7 @@ class ConfigField:
                  preprocess=None,
                  default_value=None,
                  required=False,
-                 parser_args={}):
+                 parser_args=None):
         """
         Create a configuration field.
 
@@ -54,9 +54,8 @@ class ConfigField:
         self._name = name
         self._field_type = field_type
         self._flags = flags
-        self._value = None
         self._choices = choices
-        self._parser_args = parser_args
+        self._parser_args = {} if parser_args is None else parser_args
         self._preprocess = preprocess
         self._required = required
 
@@ -98,11 +97,11 @@ class ConfigField:
 
         Returns
         -------
-        type
+        ConfigValue
             Type of the config field
         """
 
-        return self._field_type
+        return self._field_type.cli_type()
 
     def name(self):
         """
@@ -145,9 +144,7 @@ class ConfigField:
         Set the value for the config field.
         """
 
-        self._value = self._field_type(value)
-        if self._preprocess is not None:
-            self._value = self._preprocess(value)
+        self._field_type.set_value(value)
 
     def value(self):
         """
@@ -159,7 +156,7 @@ class ConfigField:
             The value of the config field.
         """
 
-        return self._value
+        return self._field_type.value()
 
     def required(self):
         """

--- a/model_analyzer/config/config_list_numeric.py
+++ b/model_analyzer/config/config_list_numeric.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_value import ConfigValue
+
+
+class ConfigListNumeric(ConfigValue):
+    """
+    A list of numeric values.
+    """
+    def __init__(self, type_):
+        """
+        Create a new list of numeric values.
+
+        Parameters
+        ----------
+        type_ : type
+            The type of elements in the list
+        """
+
+        self._type = type_
+        self._value = []
+
+    def set_value(self, value):
+        """
+        Set the value for this field.
+
+        Parameters
+        ----------
+        value : object
+            The value for this field. It can be comma delimited list, or an
+            array, or a range
+        """
+
+        type_ = self._type
+
+        # Is a comma delimited list?
+        if type(value) is str:
+            self._value = []
+            value = value.split(',')
+            for item in value:
+                self._value.append(type_(item))
+        # Is a list of values?
+        elif type(value) is list:
+            self._value = []
+            for item in value:
+                self._value.append(type_(item))
+        # Is a range?
+        elif type(value) is dict:
+            if 'start' in value and 'end' in value:
+                step = 1
+                start = value['start']
+                end = value['end']
+                if 'step' in value:
+                    step = value['step']
+                self._value = list(range(start, end, step))
+        else:
+            self._value = type_(value)
+
+    def cli_type(self):
+        """
+        Get the type of this field for CLI.
+
+        Returns
+        -------
+        type
+            str
+        """
+
+        return str

--- a/model_analyzer/config/config_list_string.py
+++ b/model_analyzer/config/config_list_string.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_value import ConfigValue
+
+
+class ConfigListString(ConfigValue):
+    """
+    A list of string values.
+    """
+    def __init__(self):
+        """
+        Instantiate a new ConfigListString
+        """
+
+        self._type = str
+        self._value = []
+
+    def set_value(self, value):
+        """
+        Set the value for this field.
+
+        Parameters
+        ----------
+        value : object
+            The value for this field. It can be a string of comma-delimited
+            items or a list.
+        """
+
+        # If the value is string, it should be a comma delimited list of values
+        if type(value) is str:
+            self._value = value.split(',')
+        elif type(value) is list:
+            self._value = value
+        else:
+            self._value = str(value)

--- a/model_analyzer/config/config_primitive.py
+++ b/model_analyzer/config/config_primitive.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_value import ConfigValue
+
+
+class ConfigPrimitive(ConfigValue):
+    """
+    A wrapper class for the primitive datatypes.
+    """
+
+    def __init__(self, type_):
+        """
+        Create a new primitive config.
+
+        type_ : type
+            Type of the field.
+        """
+
+        self._type = type_
+        self._value = None
+
+    def set_value(self, value):
+        """
+        Set the value for this field.
+
+        value : object
+            The value for this field.
+        """
+
+        self._value = self._type(value)

--- a/model_analyzer/config/config_value.py
+++ b/model_analyzer/config/config_value.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+from abc import abstractmethod
+
+
+class ConfigValue(abc.ABC):
+    """
+    Parent class for all the types used in the ConfigField.
+    """
+    @abstractmethod
+    def set_value(self, value):
+        """
+        Set the value for this field. This method must be implemented in each
+        subclass.
+        """
+
+        pass
+
+    def value(self):
+        """
+        Get the value of the config field.
+
+        Returns
+        -------
+        object
+            The value of the config field.
+        """
+
+        return self._value
+
+    def cli_type(self):
+        """
+        Get the corresponding CLI type for this field.
+
+        Returns
+        -------
+        type
+            Type to be used for the CLI.
+        """
+
+        return self._type

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -226,9 +226,9 @@ def create_run_configs(config):
     """
 
     sweep_params = {
-        'model-name': [name.strip() for name in config.model_names.split(',')],
-        'batch-size': [batch.strip() for batch in config.batch_sizes.split(',')],
-        'concurrency-range': [c.strip() for c in config.concurrency.split(',')],
+        'model-name': config.model_names,
+        'batch-size': config.batch_sizes,
+        'concurrency-range': config.concurrency,
         'protocol': [config.client_protocol],
         'url': [
             config.triton_http_endpoint

--- a/tests/test_triton_config.py
+++ b/tests/test_triton_config.py
@@ -74,6 +74,83 @@ class TestConfig(trc.TestResultCollector):
             config.get_all_config()['model_repository'] == 'yaml_repository')
         mock_config.stop()
 
+    def test_range_values(self):
+        args = [
+            'model-analyzer', '--model-repository', 'cli_repository', '-f',
+            'path-to-config-file'
+        ]
+        yaml_content = 'model_names: model_1,model_2'
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+
+        self.assertTrue(
+            config.get_all_config()['model_names'] == ['model_1', 'model_2'])
+        mock_config.stop()
+
+        yaml_content = """
+model_names:
+    - model_1
+    - model_2
+"""
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+        self.assertTrue(
+            config.get_all_config()['model_names'] == ['model_1', 'model_2'])
+        mock_config.stop()
+
+        args = [
+            'model-analyzer', '--model-repository', 'cli_repository', '-f',
+            'path-to-config-file', '--model-names', 'model_1,model_2'
+        ]
+        yaml_content = """
+batch_sizes:
+    - 2
+    - 3
+"""
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+        self.assertTrue(
+            config.get_all_config()['batch_sizes'] == [2, 3])
+        mock_config.stop()
+
+        yaml_content = """
+batch_sizes:
+    start: 2
+    end: 6
+"""
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+        self.assertTrue(
+            config.get_all_config()['batch_sizes'] == [2, 3, 4, 5])
+        mock_config.stop()
+
+        yaml_content = """
+batch_sizes:
+    start: 2
+    end: 6
+    step: 2
+"""
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+        self.assertTrue(
+            config.get_all_config()['batch_sizes'] == [2, 4])
+        mock_config.stop()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now Model Analyzer Config can support arrays and ranges.

For example, all the configurations below are now supported:

```yaml
batch_sizes:
    - 2
    - 3
```

```yaml
batch_sizes:
    start: 2
    end: 10
```

```yaml
batch_sizes:
    start: 2
    end: 10
    step: 2
```

By default, `step` value is equal to 1.

This is based on the design pattern below:

https://refactoring.guru/replace-data-value-with-object