### PR TITLE
Add validation to Model Analyzer config

### DIFF
--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -107,23 +107,20 @@ class AnalyzerConfig:
                         required=True),
                     ConfigListString(),
                 ],
-                description=
-                'Comma-delimited list of the model names to be profiled'))
+                description='Comma-delimited list of the model names to be profiled'))
 
         self._add_config(
             ConfigField(
                 'objectives',
                 field_types=[ConfigListString()],
-                description=
-                'Model Analyzer uses the objectives described here to find the best configuration for each model.'
+                description='Model Analyzer uses the objectives described here to find the best configuration for each model.'
             ))
 
         self._add_config(
             ConfigField(
                 'constraints',
                 field_types=[constraints_scheme],
-                description=
-                'Constraints on the objectives specified in the "objectives" field of the config.'
+                description='Constraints on the objectives specified in the "objectives" field of the config.'
             ))
         self._add_config(
             ConfigField(
@@ -131,8 +128,7 @@ class AnalyzerConfig:
                 flags=['--batch-sizes', '-b'],
                 field_types=[ConfigListNumeric(int)],
                 default_value=1,
-                description=
-                'Comma-delimited list of batch sizes to use for the profiling')
+                description='Comma-delimited list of batch sizes to use for the profiling')
         )
         self._add_config(
             ConfigField(
@@ -140,8 +136,7 @@ class AnalyzerConfig:
                 flags=['-c', '--concurrency'],
                 field_types=[ConfigListNumeric(int)],
                 default_value=1,
-                description=
-                "Comma-delimited list of concurrency values or ranges <start:end:step>"
+                description="Comma-delimited list of concurrency values or ranges <start:end:step>"
                 " to be used during profiling"))
         self._add_config(
             ConfigField('export',
@@ -155,16 +150,14 @@ class AnalyzerConfig:
                 flags=['--export-path', '-e'],
                 default_value='.',
                 field_types=[ConfigPrimitive(str)],
-                description=
-                "Full path to directory in which to store the results"))
+                description="Full path to directory in which to store the results"))
         self._add_config(
             ConfigField(
                 'filename_model_inference',
                 flags=['--filename-model-inference'],
                 default_value='metrics-model-inference.csv',
                 field_types=[ConfigPrimitive(str)],
-                description=
-                'Specifies filename for storing model inference metrics'))
+                description='Specifies filename for storing model inference metrics'))
         self._add_config(
             ConfigField(
                 'filename_model_gpu',
@@ -186,24 +179,21 @@ class AnalyzerConfig:
                 flags=['-r', '--max-retries'],
                 field_types=[ConfigPrimitive(int)],
                 default_value=100,
-                description=
-                'Specifies the max number of retries for any retry attempt'))
+                description='Specifies the max number of retries for any retry attempt'))
         self._add_config(
             ConfigField(
                 'duration_seconds',
                 field_types=[ConfigPrimitive(int)],
                 flags=['-d', '--duration-seconds'],
                 default_value=5,
-                description=
-                'Specifies how long (seconds) to gather server-only metrics'))
+                description='Specifies how long (seconds) to gather server-only metrics'))
         self._add_config(
             ConfigField(
                 'monitoring_interval',
                 flags=['-i', '--monitoring-interval'],
                 field_types=[ConfigPrimitive(float)],
                 default_value=0.01,
-                description=
-                'Interval of time between DGCM measurements in seconds'))
+                description='Interval of time between DGCM measurements in seconds'))
         self._add_config(
             ConfigField(
                 'client_protocol',
@@ -211,8 +201,7 @@ class AnalyzerConfig:
                 choices=['http', 'grpc'],
                 field_types=[ConfigPrimitive(str)],
                 default_value='grpc',
-                description=
-                'The protocol used to communicate with the Triton Inference Server'
+                description='The protocol used to communicate with the Triton Inference Server'
             ))
         self._add_config(
             ConfigField(
@@ -220,16 +209,14 @@ class AnalyzerConfig:
                 flags=['--perf-analyzer-path'],
                 field_types=[ConfigPrimitive(str)],
                 default_value='perf_analyzer',
-                description=
-                'The full path to the perf_analyzer binary executable'))
+                description='The full path to the perf_analyzer binary executable'))
         self._add_config(
             ConfigField(
                 'perf_measurement_window',
                 flags=['--perf-measurement-window'],
                 field_types=[ConfigPrimitive(int)],
                 default_value=5000,
-                description=
-                'Time interval in milliseconds between perf_analyzer measurements. perf_analyzer will take '
+                description='Time interval in milliseconds between perf_analyzer measurements. perf_analyzer will take '
                 'measurements over all the requests completed within this time interval.'
             ))
         self._add_config(
@@ -238,8 +225,7 @@ class AnalyzerConfig:
                 flags=['--no-perf-output'],
                 field_types=[ConfigPrimitive(bool)],
                 parser_args={'action': 'store_true'},
-                description=
-                'Silences the output from the perf_analyzer to stdout'))
+                description='Silences the output from the perf_analyzer to stdout'))
         self._add_config(
             ConfigField(
                 'triton_launch_mode',
@@ -271,8 +257,7 @@ class AnalyzerConfig:
                 default_value='localhost:8000',
                 flags=['--triton-http-endpoint'],
                 field_types=[ConfigPrimitive(str)],
-                description=
-                "Triton Server HTTP endpoint url used by Model Analyzer client. "
+                description="Triton Server HTTP endpoint url used by Model Analyzer client. "
                 "Will be ignored if server-launch-mode is not 'remote'"))
         self._add_config(
             ConfigField(
@@ -280,8 +265,7 @@ class AnalyzerConfig:
                 flags=['--triton-grpc-endpoint'],
                 field_types=[ConfigPrimitive(str)],
                 default_value='localhost:8001',
-                description=
-                "Triton Server HTTP endpoint url used by Model Analyzer client. "
+                description="Triton Server HTTP endpoint url used by Model Analyzer client. "
                 "Will be ignored if server-launch-mode is not 'remote'"))
         self._add_config(
             ConfigField(
@@ -296,15 +280,13 @@ class AnalyzerConfig:
                         field_types=[ConfigPrimitive(str)],
                         flags=['--triton-server-path'],
                         default_value='tritonserver',
-                        description=
-                        'The full path to the tritonserver binary executable'))
+                        description='The full path to the tritonserver binary executable'))
         self._add_config(
             ConfigField(
                 'triton_output_path',
                 field_types=[ConfigPrimitive(str)],
                 flags=['--triton-output-path'],
-                description=
-                'The full path to a file to write the Triton Server log output to.'
+                description='The full path to a file to write the Triton Server log output to.'
             ))
         self._add_config(
             ConfigField(

--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -21,7 +21,9 @@ from .config_list_string import ConfigListString
 from .config_list_numeric import ConfigListNumeric
 from .config_object import ConfigObject
 from .config_list_generic import ConfigListGeneric
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from .config_model import ConfigModel
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
 
 
 class AnalyzerConfig:
@@ -76,10 +78,12 @@ class AnalyzerConfig:
                     'max': ConfigPrimitive(int),
                 }),
             })
+
         model_object_constraint = ConfigObject(
             required=True,
             schema={
-                # Any key is allowed, but the keys must follow the pattern below
+                # Any key is allowed, but the keys must follow the pattern
+                # below
                 '*':
                 ConfigObject(
                     schema={
@@ -94,7 +98,7 @@ class AnalyzerConfig:
                         'constraints':
                         constraints_scheme
                     })
-            })
+            }, output_mapper=ConfigModel.model_object_to_config_model)
         self._add_config(
             ConfigField(
                 'model_names',
@@ -102,10 +106,16 @@ class AnalyzerConfig:
                 field_types=[
                     model_object_constraint,
                     ConfigListGeneric(
-                        [model_object_constraint,
-                         ConfigPrimitive(str)],
-                        required=True),
-                    ConfigListString(),
+                        [
+                            model_object_constraint,
+                            ConfigPrimitive(
+                                str,
+                                output_mapper=ConfigModel.model_str_to_config_model
+                            )],
+                        required=True,
+                        output_mapper=ConfigModel.model_mixed_to_config_model),
+                    ConfigListString(
+                        output_mapper=ConfigModel.model_list_to_config_model),
                 ],
                 description='Comma-delimited list of the model names to be profiled'))
 

--- a/model_analyzer/config/config_field.py
+++ b/model_analyzer/config/config_field.py
@@ -15,7 +15,7 @@
 from model_analyzer.model_analyzer_exceptions import \
     TritonModelAnalyzerException
 from model_analyzer.constants import \
-     MODEL_ANALYZER_SUCCESS
+    MODEL_ANALYZER_SUCCESS
 
 
 class ConfigField:
@@ -145,7 +145,7 @@ class ConfigField:
         Set the value for the config field.
         """
 
-        # Trying setting the value for each type in the field. If it
+        # Try to set the value for each type in the field. If it
         # was not succesful for any of the types, raise an exception.
         for i, config_type in enumerate(self._field_types):
             status = config_type.set_value(value)
@@ -154,7 +154,7 @@ class ConfigField:
                 break
         else:
             raise TritonModelAnalyzerException(
-                f'Can\'t set value {{ {value} }} for field {self._name}')
+                f'Can\'t set value {value} for field {self._name}.')
 
     def value(self):
         """

--- a/model_analyzer/config/config_list_generic.py
+++ b/model_analyzer/config/config_list_generic.py
@@ -14,7 +14,7 @@
 
 from .config_value import ConfigValue
 from model_analyzer.constants import \
-     MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
+    MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
 
 from copy import deepcopy
 
@@ -23,7 +23,8 @@ class ConfigListGeneric(ConfigValue):
     """
     A generic list.
     """
-    def __init__(self, types, preprocess=None, required=False):
+
+    def __init__(self, types, preprocess=None, required=False, validator=None, output_mapper=None):
         """
         Create a new list of numeric values.
 
@@ -35,13 +36,22 @@ class ConfigListGeneric(ConfigValue):
             Function be called before setting new values.
         required : bool
             Whether a given config is required or not.
+        output_mapper: callable
+            This callable unifies the output value of this field.
         """
 
-        super().__init__(preprocess, required)
+        # default validator
+        if validator is None:
+
+            def validator(x):
+                return type(x) is list and len(x) > 0
+
+        super().__init__(preprocess, required, validator)
 
         self._type = str
         self._allowed_types = types
         self._value = []
+        self._output_mapper = output_mapper
 
     def set_value(self, value):
         """
@@ -71,5 +81,4 @@ class ConfigListGeneric(ConfigValue):
         else:
             return MODEL_ANALYZER_FAILURE
 
-        self._value = new_value
-        return MODEL_ANALYZER_SUCCESS
+        return super().set_value(value)

--- a/model_analyzer/config/config_list_generic.py
+++ b/model_analyzer/config/config_list_generic.py
@@ -46,7 +46,7 @@ class ConfigListGeneric(ConfigValue):
             def validator(x):
                 return type(x) is list and len(x) > 0
 
-        super().__init__(preprocess, required, validator)
+        super().__init__(preprocess, required, validator, output_mapper)
 
         self._type = str
         self._allowed_types = types
@@ -81,4 +81,4 @@ class ConfigListGeneric(ConfigValue):
         else:
             return MODEL_ANALYZER_FAILURE
 
-        return super().set_value(value)
+        return super().set_value(new_value)

--- a/model_analyzer/config/config_list_numeric.py
+++ b/model_analyzer/config/config_list_numeric.py
@@ -22,7 +22,12 @@ class ConfigListNumeric(ConfigValue):
     A list of numeric values.
     """
 
-    def __init__(self, type_, preprocess=None, required=False, validator=None):
+    def __init__(self,
+                 type_,
+                 preprocess=None,
+                 required=False,
+                 validator=None,
+                 output_mapper=None):
         """
         Create a new list of numeric values.
 
@@ -36,6 +41,8 @@ class ConfigListNumeric(ConfigValue):
             Whether a given config is required or not.
         validator : callable or None
             A validator for the final value of the field.
+        output_mapper: callable or None
+            This callable unifies the output value of this field.
         """
 
         # default validator
@@ -47,7 +54,7 @@ class ConfigListNumeric(ConfigValue):
 
                 return False
 
-        super().__init__(preprocess, required, validator)
+        super().__init__(preprocess, required, validator, output_mapper)
         self._type = type_
         self._value = []
 

--- a/model_analyzer/config/config_list_numeric.py
+++ b/model_analyzer/config/config_list_numeric.py
@@ -14,14 +14,15 @@
 
 from .config_value import ConfigValue
 from model_analyzer.constants import \
-     MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
+    MODEL_ANALYZER_FAILURE
 
 
 class ConfigListNumeric(ConfigValue):
     """
     A list of numeric values.
     """
-    def __init__(self, type_, preprocess=None, required=False):
+
+    def __init__(self, type_, preprocess=None, required=False, validator=None):
         """
         Create a new list of numeric values.
 
@@ -33,9 +34,20 @@ class ConfigListNumeric(ConfigValue):
             Function be called before setting new values.
         required : bool
             Whether a given config is required or not.
+        validator : callable or None
+            A validator for the final value of the field.
         """
 
-        super().__init__(preprocess, required)
+        # default validator
+        if validator is None:
+
+            def validator(x):
+                if type(x) is list and len(x) > 0:
+                    return True
+
+                return False
+
+        super().__init__(preprocess, required, validator)
         self._type = type_
         self._value = []
 
@@ -51,30 +63,35 @@ class ConfigListNumeric(ConfigValue):
         """
 
         type_ = self._type
+        new_value = []
 
         if self._is_string(value):
             self._value = []
             value = value.split(',')
             for item in value:
-                self._value.append(type_(item))
+                new_value.append(type_(item))
         elif self._is_list(value):
-            self._value = []
             for item in value:
-                self._value.append(type_(item))
+                new_value.append(type_(item))
         elif self._is_dict(value):
-            if 'start' in value and 'stop' in value:
+            two_key_condition = len(
+                value) == 2 and 'start' in value and 'stop' in value
+            three_key_condition = len(
+                value) == 3 and 'start' in value and 'stop' in value\
+                and 'step' in value
+            if two_key_condition or three_key_condition:
                 step = 1
                 start = value['start']
                 stop = value['stop']
                 if 'step' in value:
                     step = value['step']
-                self._value = list(range(start, stop + 1, step))
+                new_value = list(range(start, stop + 1, step))
             else:
                 return MODEL_ANALYZER_FAILURE
         else:
-            self._value = [type_(value)]
+            new_value = [type_(value)]
 
-        return MODEL_ANALYZER_SUCCESS
+        return super().set_value(new_value)
 
     def cli_type(self):
         """

--- a/model_analyzer/config/config_list_string.py
+++ b/model_analyzer/config/config_list_string.py
@@ -22,7 +22,11 @@ class ConfigListString(ConfigValue):
     A list of string values.
     """
 
-    def __init__(self, preprocess=None, required=False, validator=None):
+    def __init__(self,
+                 preprocess=None,
+                 required=False,
+                 validator=None,
+                 output_mapper=None):
         """
         Instantiate a new ConfigListString
 
@@ -32,6 +36,8 @@ class ConfigListString(ConfigValue):
             Whether a given config is required or not.
         validator : callable or None
             A validator for the value of the field.
+        output_mapper: callable or None
+            This callable unifies the output value of this field.
         """
 
         # default validator
@@ -39,7 +45,7 @@ class ConfigListString(ConfigValue):
             def validator(x):
                 return type(x) is list and len(x) > 0
 
-        super().__init__(preprocess, required, validator)
+        super().__init__(preprocess, required, validator, output_mapper)
         self._type = str
         self._value = []
 

--- a/model_analyzer/config/config_model.py
+++ b/model_analyzer/config/config_model.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ConfigModel:
+    """
+    A class representing the configuration used for
+    a single model.
+    """
+
+    def __init__(self,
+                 model_name,
+                 objectives=None,
+                 constraints=None,
+                 parameters=None):
+        """
+        Parameters
+        ----------
+        model_name : str
+           Name used for the model
+        objectives : None or list
+           List of the objectives required by the model
+        constraints : None or dict
+            Constraints required by the model
+        parameters : None or dict
+            Constraints on batch_size and concurrency values need to be
+            specified here.
+        """
+
+        self._model_name = model_name
+        self._objectives = objectives
+        self._constraints = constraints
+        self._parameters = parameters
+
+    def objectives(self):
+        """
+        Returns
+        -------
+        list or None
+            A list containing the objectives.
+        """
+
+        return self._objectives
+
+    def constraints(self):
+        """
+        Returns
+        -------
+        dict or None
+            A dictionary containing the constraints
+        """
+
+        return self._constraints
+
+    def parameters(self):
+        """
+        Returns
+        -------
+        dict or None
+            A dictionary containing the parameters
+        """
+
+        return self._parameters
+
+    def model_name(self):
+        """
+        Returns
+        -------
+        str
+            The model name used for this config.
+        """
+
+        return self._model_name
+
+    @staticmethod
+    def model_object_to_config_model(value):
+        """
+        Converts a ConfigObject to ConfigModel.
+
+        Parameters
+        ----------
+        dict
+            A dictionary where the keys are model names
+            and the values are ConfigObjects.
+
+        Returns
+        -------
+        list
+            A list of ConfigModel objects.
+        """
+
+        models = []
+        for model_name, model_properties in value.items():
+            models.append(ConfigModel(model_name, **model_properties.value()))
+
+        return models
+
+    @staticmethod
+    def model_str_to_config_model(model_name):
+        """
+        Constructs a ConfigModel from a given
+        model_name.
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the model
+
+        Returns
+        -------
+        ConfigModel
+            ConfigModel object with the given model name.
+        """
+
+        return ConfigModel(model_name)
+
+    @staticmethod
+    def model_list_to_config_model(model_names):
+        """
+        Construct ConfigModel objects from a list of strings.
+
+        Parameters
+        ----------
+        model_names : list
+            A list of strings containing model names.
+
+        Returns
+        -------
+        list
+            A list of ConfigModel objects.
+        """
+
+        models = []
+        for model_name in model_names:
+            models.append(ConfigModel(model_name))
+        return models
+
+    @staticmethod
+    def model_mixed_to_config_model(models):
+        """
+        Unifies a mixed list of ConfigModel objects
+        and list of ConfigModel objects.
+
+        Parameters
+        ----------
+        list
+            A mixed list containing lists or ConfigModel objects.
+
+        Returns
+        -------
+        list
+            A list only containing ConfigModel objects.
+        """
+
+        new_models = []
+        for model in models:
+            if type(model.value()) is list:
+                for model_i in model.value():
+                    new_models.append(model_i)
+            else:
+                new_models.append(model.value())
+        return new_models
+
+    def __repr__(self):
+        model_object = {'model_name': self._model_name}
+        if self._objectives:
+            model_object['objectives'] = self._objectives
+
+        if self._parameters:
+            model_object['parameters'] = self._parameters
+
+        if self._constraints:
+            model_object['constraints'] = self._constraints
+
+        return str(model_object)

--- a/model_analyzer/config/config_object.py
+++ b/model_analyzer/config/config_object.py
@@ -27,7 +27,9 @@ class ConfigObject(ConfigValue):
                  schema,
                  preprocess=None,
                  required=False,
-                 validator=None):
+                 validator=None,
+                 output_mapper=None
+                 ):
         """
         schema : dict
             A dictionary where the keys are the object keys and the values
@@ -38,6 +40,8 @@ class ConfigObject(ConfigValue):
             Whether a given config is required or not.
         validator : callable or None
             A validator for the value of the field.
+        output_mapper: callable or None
+            This callable unifies the output value of this field.
         """
 
         # default validator
@@ -45,7 +49,7 @@ class ConfigObject(ConfigValue):
             def validator(x):
                 return type(x) is dict and len(x) > 0
 
-        super().__init__(preprocess, required, validator)
+        super().__init__(preprocess, required, validator, output_mapper)
         self._type = str
         self._value = {}
         self._schema = schema

--- a/model_analyzer/config/config_object.py
+++ b/model_analyzer/config/config_object.py
@@ -14,7 +14,7 @@
 
 from .config_value import ConfigValue
 from model_analyzer.constants import \
-     MODEL_ANALYZER_FAILURE, MODEL_ANALYZER_SUCCESS
+    MODEL_ANALYZER_FAILURE, MODEL_ANALYZER_SUCCESS
 from copy import deepcopy
 
 
@@ -22,7 +22,12 @@ class ConfigObject(ConfigValue):
     """
     Representation of dictionaries in Config
     """
-    def __init__(self, schema, preprocess=None, required=False):
+
+    def __init__(self,
+                 schema,
+                 preprocess=None,
+                 required=False,
+                 validator=None):
         """
         schema : dict
             A dictionary where the keys are the object keys and the values
@@ -31,8 +36,16 @@ class ConfigObject(ConfigValue):
             Function be called before setting new values.
         required : bool
             Whether a given config is required or not.
+        validator : callable or None
+            A validator for the value of the field.
         """
-        super().__init__(preprocess, required)
+
+        # default validator
+        if validator is None:
+            def validator(x):
+                return type(x) is dict and len(x) > 0
+
+        super().__init__(preprocess, required, validator)
         self._type = str
         self._value = {}
         self._schema = schema
@@ -78,9 +91,7 @@ class ConfigObject(ConfigValue):
                     return MODEL_ANALYZER_FAILURE
         else:
             return MODEL_ANALYZER_FAILURE
-        self._value = new_value
-
-        return MODEL_ANALYZER_SUCCESS
+        return super().set_value(new_value)
 
     def __getattr__(self, name):
         # We need to add this check, to prevent infinite

--- a/model_analyzer/config/config_primitive.py
+++ b/model_analyzer/config/config_primitive.py
@@ -28,6 +28,7 @@ class ConfigPrimitive(ConfigValue):
         preprocess=None,
         required=False,
         validator=None,
+        output_mapper=None
     ):
         """
         Parameters
@@ -40,6 +41,8 @@ class ConfigPrimitive(ConfigValue):
             Whether a given config is required or not.
         validator : callable or None
             A validator for the value of the field.
+        output_mapper: callable or None
+            This callable unifies the output value of this field.
         """
 
         # default validator
@@ -47,7 +50,7 @@ class ConfigPrimitive(ConfigValue):
             def validator(x):
                 return x is not None or x != ''
 
-        super().__init__(preprocess, required, validator)
+        super().__init__(preprocess, required, validator, output_mapper)
 
         self._type = type_
         self._value = None

--- a/model_analyzer/config/config_primitive.py
+++ b/model_analyzer/config/config_primitive.py
@@ -14,18 +14,20 @@
 
 from .config_value import ConfigValue
 from model_analyzer.constants import \
-     MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
+    MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
 
 
 class ConfigPrimitive(ConfigValue):
     """
     A wrapper class for the primitive datatypes.
     """
+
     def __init__(
         self,
         type_,
         preprocess=None,
         required=False,
+        validator=None,
     ):
         """
         Parameters
@@ -36,8 +38,16 @@ class ConfigPrimitive(ConfigValue):
             Function be called before setting new values.
         required : bool
             Whether a given config is required or not.
+        validator : callable or None
+            A validator for the value of the field.
         """
-        super().__init__(preprocess, required)
+
+        # default validator
+        if validator is None:
+            def validator(x):
+                return x is not None or x != ''
+
+        super().__init__(preprocess, required, validator)
 
         self._type = type_
         self._value = None
@@ -51,7 +61,7 @@ class ConfigPrimitive(ConfigValue):
         """
 
         if self._is_primitive(value):
-            self._value = self._type(value)
+            value = self._type(value)
+            return super().set_value(value)
         else:
             return MODEL_ANALYZER_FAILURE
-        return MODEL_ANALYZER_SUCCESS

--- a/model_analyzer/config/config_value.py
+++ b/model_analyzer/config/config_value.py
@@ -15,12 +15,16 @@
 import abc
 from abc import abstractmethod
 
+from model_analyzer.constants import \
+    MODEL_ANALYZER_SUCCESS, MODEL_ANALYZER_FAILURE
+
 
 class ConfigValue(abc.ABC):
     """
     Parent class for all the types used in the ConfigField.
     """
-    def __init__(self, preprocess=None, required=False):
+
+    def __init__(self, preprocess=None, required=False, validator=None):
         """
         Parameters
         ----------
@@ -30,10 +34,13 @@ class ConfigValue(abc.ABC):
             Function be called before setting new values.
         required : bool
             Whether a given config is required or not.
+        validator : callable or None
+            A validator for the value of the field.
         """
 
         self._preprocess = preprocess
         self._required = required
+        self._validator = validator
 
     @abstractmethod
     def set_value(self, value):
@@ -42,7 +49,14 @@ class ConfigValue(abc.ABC):
         subclass.
         """
 
-        pass
+        if self._validator:
+            if self._validator(value):
+                self._value = value
+                return MODEL_ANALYZER_SUCCESS
+            return MODEL_ANALYZER_FAILURE
+        else:
+            self._value = value
+            return MODEL_ANALYZER_SUCCESS
 
     def value(self):
         """

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -223,8 +223,9 @@ def create_run_configs(config):
         values are individual combinations of argument values
     """
 
+    model_names = [model.model_name() for model in config.model_names]
     sweep_params = {
-        'model-name': config.model_names,
+        'model-name': model_names,
         'batch-size': config.batch_sizes,
         'concurrency-range': config.concurrency,
         'protocol': [config.client_protocol],

--- a/tests/common/test_result_collector.py
+++ b/tests/common/test_result_collector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,41 +19,43 @@ from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 from model_analyzer.cli.cli import CLI
 from model_analyzer.config.config import AnalyzerConfig
+from model_analyzer.config.config_model import ConfigModel
 
 
 class TestConfig(trc.TestResultCollector):
+
+    def _evaluate_config(self, args, yaml_content):
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = AnalyzerConfig()
+        cli = CLI(config)
+        cli.parse()
+        mock_config.stop()
+
+        return config
+
     def test_config(self):
         args = [
             'model-analyzer', '--model-repository', 'cli_repository', '-f',
             'path-to-config-file', '--model-names', 'vgg11'
         ]
         yaml_content = 'model_repository: yaml_repository'
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
 
         # CLI flag has the highest priority
         self.assertTrue(
             config.get_all_config()['model_repository'] == 'cli_repository')
-        mock_config.stop()
 
         args = [
             'model-analyzer', '-f', 'path-to-config-file', '--model-names',
             'vgg11'
         ]
         yaml_content = 'model_repository: yaml_repository'
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
 
         # If CLI flag doesn't exist, YAML config has the highest priority
         self.assertTrue(
             config.get_all_config()['model_repository'] == 'yaml_repository')
-        mock_config.stop()
 
         args = ['model-analyzer', '-f', 'path-to-config-file']
         yaml_content = 'model_repository: yaml_repository'
@@ -67,9 +69,6 @@ class TestConfig(trc.TestResultCollector):
         with self.assertRaises(TritonModelAnalyzerException):
             cli.parse()
 
-        # If CLI flag doesn't exist, YAML config has the highest priority
-        self.assertTrue(
-            config.get_all_config()['model_repository'] == 'yaml_repository')
         mock_config.stop()
 
     def test_range_and_list_values(self):
@@ -78,30 +77,25 @@ class TestConfig(trc.TestResultCollector):
             'path-to-config-file'
         ]
         yaml_content = 'model_names: model_1,model_2'
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
-
-        self.assertTrue(
-            config.get_all_config()['model_names'] == ['model_1', 'model_2'])
-        mock_config.stop()
+        config = self._evaluate_config(args, yaml_content)
+        model_names = ['model_1', 'model_2']
+        for model_config, model_name in zip(
+                config.get_all_config()['model_names'],
+                model_names):
+            self.assertIsInstance(model_config, ConfigModel)
+            self.assertTrue(model_config.model_name() == model_name)
 
         yaml_content = """
 model_names:
     - model_1
     - model_2
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
-
-        self.assertTrue(
-            config.get_all_config()['model_names'] == ['model_1', 'model_2'])
-        mock_config.stop()
+        config = self._evaluate_config(args, yaml_content)
+        for model_config, model_name in zip(
+                config.get_all_config()['model_names'],
+                model_names):
+            self.assertIsInstance(model_config, ConfigModel)
+            self.assertTrue(model_config.model_name() == model_name)
 
         args = [
             'model-analyzer', '--model-repository', 'cli_repository', '-f',
@@ -112,50 +106,30 @@ batch_sizes:
     - 2
     - 3
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
         self.assertTrue(config.get_all_config()['batch_sizes'] == [2, 3])
-        mock_config.stop()
 
         yaml_content = """
 batch_sizes: 2
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
         self.assertTrue(config.get_all_config()['batch_sizes'] == [2])
-        mock_config.stop()
 
         yaml_content = """
 concurrency: 2
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
         self.assertTrue(config.get_all_config()['concurrency'] == [2])
         self.assertTrue(config.get_all_config()['batch_sizes'] == [1])
-        mock_config.stop()
 
         yaml_content = """
 batch_sizes:
     start: 2
     stop: 6
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
         self.assertTrue(
             config.get_all_config()['batch_sizes'] == [2, 3, 4, 5, 6])
-        mock_config.stop()
 
         yaml_content = """
 batch_sizes:
@@ -163,13 +137,8 @@ batch_sizes:
     stop: 6
     step: 2
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
         self.assertTrue(config.get_all_config()['batch_sizes'] == [2, 4, 6])
-        mock_config.stop()
 
     def test_object(self):
         args = [
@@ -188,20 +157,17 @@ model_names:
           - 4
   - vgg_19_graphdef
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
+        config = self._evaluate_config(args, yaml_content)
 
-        self.assertTrue(config.get_all_config()['model_names'] == [{
-            'vgg_16_graphdef': {
-                'parameters': {
-                    'concurrency': [1, 2, 3, 4]
-                }
-            }
-        }, 'vgg_19_graphdef'])
-        mock_config.stop()
+        expected_model_objects = [ConfigModel('vgg_16_graphdef', parameters={
+            'concurrency': [1, 2, 3, 4]
+        }), ConfigModel('vgg_19_graphdef')]
+        for model, expected_model in zip(
+                config.get_all_config()['model_names'],
+                expected_model_objects):
+            self.assertIsInstance(model, ConfigModel)
+            self.assertTrue(expected_model.model_name() == model.model_name())
+            self.assertTrue(expected_model.parameters() == model.parameters())
 
         yaml_content = """
 model_names:
@@ -224,27 +190,20 @@ model_names:
           stop: 6
           step: 2
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
-
-        self.assertTrue(
-            config.get_all_config()['model_names'] == {
-                'vgg_16_graphdef': {
-                    'parameters': {
-                        'concurrency': [1, 2, 3, 4]
-                    }
-                },
-                'vgg_19_graphdef': {
-                    'parameters': {
-                        'concurrency': [1, 2, 3, 4],
-                        'batch_sizes': [2, 4, 6]
-                    }
-                }
-            })
-        mock_config.stop()
+        expected_model_objects = [
+            ConfigModel('vgg_16_graphdef', parameters={
+                'concurrency': [1, 2, 3, 4]
+            }),
+            ConfigModel('vgg_19_graphdef',
+                        parameters={'concurrency': [1, 2, 3, 4],
+                                    'batch_sizes': [2, 4, 6]})]
+        config = self._evaluate_config(args, yaml_content)
+        for model, expected_model in zip(
+                config.get_all_config()['model_names'],
+                expected_model_objects):
+            self.assertIsInstance(model, ConfigModel)
+            self.assertTrue(expected_model.model_name() == model.model_name())
+            self.assertTrue(expected_model.parameters() == model.parameters())
 
     def test_constraints(self):
         args = [
@@ -269,26 +228,26 @@ model_names:
           max: 80
   - vgg_19_graphdef
 """
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-        cli.parse()
-
-        self.assertTrue(config.get_all_config()['model_names'] == [{
-            'vgg_16_graphdef': {
-                'parameters': {
-                    'concurrency': [1, 2, 3, 4]
-                },
-                'objectives': ['throughput', 'gpu_memory'],
-                'constraints': {
-                    'gpu_memory': {
-                        'max': 80,
-                    }
-                }
-            }
-        }, 'vgg_19_graphdef'])
-        mock_config.stop()
+        config = self._evaluate_config(args, yaml_content)
+        expected_model_objects = [
+            ConfigModel('vgg_16_graphdef',
+                        parameters={
+                            'concurrency': [1, 2, 3, 4]
+                        },
+                        objectives=['throughput', 'gpu_memory'],
+                        constraints={'gpu_memory': {
+                            'max': 80,
+                        }}),
+            ConfigModel('vgg_19_graphdef')]
+        for expected_model, model in zip(
+                config.get_all_config()['model_names'],
+                expected_model_objects):
+            self.assertIsInstance(model, ConfigModel)
+            self.assertTrue(expected_model.model_name() == model.model_name())
+            self.assertTrue(expected_model.parameters() == model.parameters())
+            self.assertTrue(expected_model.objectives() == model.objectives())
+            self.assertTrue(expected_model.constraints()
+                            == model.constraints())
 
         # GPU Memory shouldn't have min
         yaml_content = """
@@ -383,21 +342,6 @@ model_names:
         with self.assertRaises(TritonModelAnalyzerException):
             cli.parse()
             mock_config.stop()
-
-        yaml_content = """
-model_names:
-  -
-    vgg_16_graphdef:
-      parameters:
-        concurrency: [1]
-"""
-        mock_config = MockConfig(args, yaml_content)
-        mock_config.start()
-        config = AnalyzerConfig()
-        cli = CLI(config)
-
-        cli.parse()
-        mock_config.stop()
 
 
 if __name__ == '__main__':

--- a/tests/test_cpu_monitor.py
+++ b/tests/test_cpu_monitor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-sys.path.append("../common")
-
 import unittest
 import time
 
@@ -23,9 +20,10 @@ from model_analyzer.record.cpu_available_ram import CPUAvailableRAM
 from model_analyzer.record.cpu_used_ram import CPUUsedRAM
 from model_analyzer.triton.server.server_factory import TritonServerFactory
 from model_analyzer.triton.server.server_config import TritonServerConfig
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
 
-import test_result_collector as trc
+from .common import test_result_collector as trc
 from .mocks.mock_server_local import MockServerLocalMethods
 
 MODEL_REPOSITORY_PATH = 'test_repo'

--- a/tests/test_dcgm_monitor.py
+++ b/tests/test_dcgm_monitor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-sys.path.append("../common")
-
 import unittest
 import time
 
@@ -23,9 +20,10 @@ from model_analyzer.record.gpu_free_memory import GPUFreeMemory
 from model_analyzer.record.gpu_used_memory import GPUUsedMemory
 from model_analyzer.record.gpu_utilization import GPUUtilization
 from model_analyzer.device.gpu_device import GPUDevice
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
 
-import test_result_collector as trc
+from .common import test_result_collector as trc
 from .mocks.mock_dcgm import MockDCGM
 from .mocks.mock_numba import MockNumba
 from .mocks.mock_dcgm_agent import TEST_UUID

--- a/tests/test_file_writer.py
+++ b/tests/test_file_writer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-sys.path.append("../common")
-
-import unittest
-import os
-
-from .mocks.mock_io import MockIOMethods
-
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from .common import test_result_collector as trc
 from model_analyzer.output.file_writer import FileWriter
-import test_result_collector as trc
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
+from .mocks.mock_io import MockIOMethods
+import unittest
+
 
 TEST_FILENAME = 'test_filename'
 

--- a/tests/test_output_table.py
+++ b/tests/test_output_table.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import unittest
-import sys
-sys.path.append("../common")
 
 from model_analyzer.output.output_table import OutputTable
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
-import test_result_collector as trc
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
+from .common import test_result_collector as trc
 
 TEST_HEADERS = [f"Column {i}" for i in range(10)]
 TEST_COLUMN_WIDTH = 12

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import patch, MagicMock
-import sys
-sys.path.append('../common/')
 
 from .mocks.mock_server_local import MockServerLocalMethods
 from .mocks.mock_perf_analyzer import MockPerfAnalyzerMethods
@@ -26,10 +23,11 @@ from model_analyzer.triton.server.server_factory import TritonServerFactory
 from model_analyzer.triton.client.client_factory import TritonClientFactory
 from model_analyzer.perf_analyzer.perf_analyzer import PerfAnalyzer
 from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
 from model_analyzer.record.perf_throughput import PerfThroughput
 from model_analyzer.record.perf_latency import PerfLatency
-import test_result_collector as trc
+from .common import test_result_collector as trc
 
 # Test Parameters
 MODEL_LOCAL_PATH = '/model_analyzer/models'

--- a/tests/test_record_aggregator.py
+++ b/tests/test_record_aggregator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import unittest
-import sys
-sys.path.append('../common')
 
 from model_analyzer.record.record_aggregator import RecordAggregator
 from model_analyzer.record.perf_throughput import PerfThroughput
 from model_analyzer.record.perf_latency import PerfLatency
-from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
-import test_result_collector as trc
+from .common import test_result_collector as trc
 
 
 class TestRecordAggregatorMethods(trc.TestResultCollector):
@@ -152,7 +149,8 @@ class TestRecordAggregatorMethods(trc.TestResultCollector):
                                                reduce_func=max)
         min_vals = record_aggregator.aggregate(record_types=[PerfThroughput],
                                                reduce_func=min)
-        average = lambda seq: (sum(seq) * 1.0) / len(seq)
+
+        def average(seq): return (sum(seq) * 1.0) / len(seq)
         average_vals = record_aggregator.aggregate(
             record_types=[PerfThroughput], reduce_func=average)
 

--- a/tests/test_triton_client.py
+++ b/tests/test_triton_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
+from model_analyzer.triton.model.model import Model
+from model_analyzer.triton.server.server_config import TritonServerConfig
+from model_analyzer.triton.client.client_factory import TritonClientFactory
+from model_analyzer.triton.server.server_factory import TritonServerFactory
+from .mocks.mock_client import MockTritonClientMethods
+from .mocks.mock_server_docker import MockServerDockerMethods
+from .common import test_result_collector as trc
+
 import os
 import unittest
-import sys
-sys.path.append('../common')
 
-from .mocks.mock_server_docker import MockServerDockerMethods
-from .mocks.mock_client import MockTritonClientMethods
-
-from model_analyzer.triton.server.server_factory import TritonServerFactory
-from model_analyzer.triton.client.client_factory import TritonClientFactory
-from model_analyzer.triton.server.server_config import TritonServerConfig
-from model_analyzer.triton.model.model import Model
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
-import test_result_collector as trc
 
 # Test parameters
 MODEL_REPOSITORY_PATH = 'test_repo'

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import subprocess
-import sys
-from unittest import mock
-sys.path.append('../common')
 
-from unittest.mock import patch, MagicMock
 from .mocks.mock_server_docker import MockServerDockerMethods
 from .mocks.mock_server_local import MockServerLocalMethods
+from .common import test_result_collector as trc
 
 from model_analyzer.triton.server.server_factory import TritonServerFactory
 from model_analyzer.triton.server.server_config import TritonServerConfig
-from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
-import test_result_collector as trc
+from model_analyzer.model_analyzer_exceptions \
+    import TritonModelAnalyzerException
 
 # Test parameters
 MODEL_REPOSITORY_PATH = 'test_repo'


### PR DESCRIPTION
Previously the following problematic configs were accepted in the Model Analyzer Config:

```yaml
batch_sizes: []
```

```yaml
concurrency:
  start: 1
  stop: 10
  undefined_key: 12
```

Now an error stating that this is an invalid config is shown.

```
ERROR:root:Model Analyzer encountered an error: Can't set value { [] } for field batch_sizes.
```

I've also unified the output of model names. Model names can be represented in various different formats and parsing different variations could be difficult. Now, model_names will always be a list of `ConfigModel`.