### PR TITLE
Improve config error messages

### DIFF
--- a/model_analyzer/config/config.py
+++ b/model_analyzer/config/config.py
@@ -494,6 +494,7 @@ class AnalyzerConfig:
         else:
             yaml_config = None
         for key, value in self._fields.items():
+            self._fields[key].set_name(key)
             if key in args:
                 self._fields[key].set_value(getattr(args, key))
             elif yaml_config is not None and key in yaml_config:

--- a/model_analyzer/config/config_enum.py
+++ b/model_analyzer/config/config_enum.py
@@ -13,20 +13,22 @@
 # limitations under the License.
 
 from .config_value import ConfigValue
-from model_analyzer.constants import MODEL_ANALYZER_FAILURE
+from .config_status import ConfigStatus
+from model_analyzer.constants import \
+    CONFIG_PARSER_FAILURE
 
 
 class ConfigEnum(ConfigValue):
     """
     Enum type support for config.
     """
-
     def __init__(self,
                  choices,
                  preprocess=None,
                  required=False,
                  validator=None,
-                 output_mapper=None):
+                 output_mapper=None,
+                 name=None):
         """
         Create a new enum config field.
 
@@ -42,17 +44,23 @@ class ConfigEnum(ConfigValue):
             A validator for the final value of the field.
         output_mapper: callable
             This callable unifies the output value of this field.
+        name : str
+            Fully qualified name for this field.
         """
 
         self._choices = choices
         self._type = self
-        super().__init__(preprocess, required, validator, output_mapper)
+        super().__init__(preprocess, required, validator, output_mapper, name)
 
     def set_value(self, value):
         choices = self._choices
 
         if value not in choices:
-            return MODEL_ANALYZER_FAILURE
+            return ConfigStatus(
+                CONFIG_PARSER_FAILURE,
+                f'Value "{value}" for field "{self.name()}" is not acceptable.'
+                f' Value should be one of the following values: "{choices}".',
+                self)
 
         return super().set_value(value)
 

--- a/model_analyzer/config/config_field.py
+++ b/model_analyzer/config/config_field.py
@@ -15,7 +15,7 @@
 from model_analyzer.model_analyzer_exceptions import \
     TritonModelAnalyzerException
 from model_analyzer.constants import \
-    MODEL_ANALYZER_FAILURE
+    CONFIG_PARSER_FAILURE
 
 
 class ConfigField:
@@ -158,11 +158,13 @@ class ConfigField:
 
         field_type = self._field_type
 
-        status = field_type.set_value(value)
+        config_status = field_type.set_value(value)
 
-        if status == MODEL_ANALYZER_FAILURE:
+        if config_status.status() == CONFIG_PARSER_FAILURE:
             raise TritonModelAnalyzerException(
-                f'Can\'t set value {value} for field {self._name}.')
+                f'Can\'t set the value for field "{self._name}". '
+                'The error below occured when parsing the config:\n'
+                f'{config_status.message()}')
 
     def value(self):
         """
@@ -187,3 +189,6 @@ class ConfigField:
         """
 
         return self._field_type.required()
+
+    def set_name(self, name):
+        self._field_type.set_name(name)

--- a/model_analyzer/config/config_status.py
+++ b/model_analyzer/config/config_status.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ConfigStatus:
+    def __init__(self, status, message=None, config_object=None):
+        """
+        Create a new ConfigStatus
+
+        Parameters
+        ----------
+        status : int
+            Status of the config parsing. Accepted
+            values are CONFIG_PARSER_SUCCESS and
+            CONFIG_PARSER_FAILURE.
+
+        message : str
+            A string message containing the description.
+
+        config_object : ConfigValue
+            ConfigObject that is creating this status.
+        """
+
+        self._status = status
+        self._message = message
+        self._config_object = config_object
+
+    def status(self):
+        """
+        Get the config status.
+
+        Returns
+        -------
+        int
+            Config status
+        """
+
+        return self._status
+
+    def message(self):
+        """
+        Get the message.
+
+        Returns
+        -------
+        str
+            The message for the status.
+        """
+
+        return self._message
+
+    def config_object(self):
+        """
+        Get the config object for this status.
+
+        Returns
+        -------
+        ConfigValue or None
+            Config object that created this status.
+        """
+
+        return self._config_object

--- a/model_analyzer/config/config_union.py
+++ b/model_analyzer/config/config_union.py
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from model_analyzer.constants import \
-    MODEL_ANALYZER_FAILURE, MODEL_ANALYZER_SUCCESS
+from .config_status import ConfigStatus
 from .config_value import ConfigValue
+from model_analyzer.constants import \
+    CONFIG_PARSER_FAILURE, CONFIG_PARSER_SUCCESS
 
 
 class ConfigUnion(ConfigValue):
     """
     ConfigUnion allows the value to be any of multiple ConfigValue types.
     """
-
     def __init__(self,
                  types,
                  preprocess=None,
                  required=False,
                  validator=None,
-                 output_mapper=None
-                 ):
+                 output_mapper=None,
+                 name=None):
         """
         Create a new ConfigUnion.
 
@@ -44,11 +44,13 @@ class ConfigUnion(ConfigValue):
             A validator for the final value of the field.
         output_mapper: callable or None
             This callable unifies the output value of this field.
+        name : str
+            Fully qualified name for this field.
         """
 
         self._types = types
         self._used_type_index = 0
-        super().__init__(preprocess, required, validator, output_mapper)
+        super().__init__(preprocess, required, validator, output_mapper, name)
 
     def set_value(self, value):
         """
@@ -58,13 +60,44 @@ class ConfigUnion(ConfigValue):
             The value for this field.
         """
 
+        config_statuses = []
         for i, type_ in enumerate(self._types):
-            status = type_.set_value(value)
-            if status == MODEL_ANALYZER_SUCCESS:
+            config_status = type_.set_value(value)
+            config_statuses.append(config_status)
+            if config_status.status() == CONFIG_PARSER_SUCCESS:
                 self._used_type_index = i
                 return super().set_value(type_)
         else:
-            return MODEL_ANALYZER_FAILURE
+            message = f'Value "{value}" cannot be set for field "{self.name()}".'
+            message += ' This field allows multiple types of values.'
+            message += ' You only need to fix one of the errors below:\n'
+            for config_status in config_statuses:
+                message_lines = config_status.message().split('\n')
+
+                # ConfigUnion needs to repeat the same structure. The lines
+                # below make a couple of adjustments to ensure that
+                # lines are printed correctly.
+                if type(config_status.config_object()) is ConfigUnion:
+
+                    # Make sure that the line is not empty
+                    if not message_lines[0].strip() == '':
+                        message += '\t* ' + message_lines[0] + '\n'
+                        for message_line in message_lines[1:]:
+                            message += '\t ' + message_line + '\n'
+                else:
+                    for message_line in message_lines:
+                        message += '\t* ' + message_line + '\n'
+
+            return ConfigStatus(CONFIG_PARSER_FAILURE, message, self)
+
+    def set_name(self, name):
+        """
+        This function must be called before the set_value.
+        """
+
+        super().set_name(name)
+        for type_ in self._types:
+            type_.set_name(self.name())
 
     def cli_type(self):
         used_type_index = self._used_type_index

--- a/model_analyzer/config/config_union.py
+++ b/model_analyzer/config/config_union.py
@@ -69,8 +69,8 @@ class ConfigUnion(ConfigValue):
                 return super().set_value(type_)
         else:
             message = f'Value "{value}" cannot be set for field "{self.name()}".'
-            message += ' This field allows multiple types of values.'
-            message += ' You only need to fix one of the errors below:\n'
+            ' This field allows multiple types of values.'
+            ' You only need to fix one of the errors below:\n'
             for config_status in config_statuses:
                 message_lines = config_status.message().split('\n')
 
@@ -81,12 +81,12 @@ class ConfigUnion(ConfigValue):
 
                     # Make sure that the line is not empty
                     if not message_lines[0].strip() == '':
-                        message += '\t* ' + message_lines[0] + '\n'
+                        message += f"\t* ' + {message_lines[0]} + '\n'"
                         for message_line in message_lines[1:]:
-                            message += '\t ' + message_line + '\n'
+                            message += f"'\t ' + {message_line} + '\n'"
                 else:
                     for message_line in message_lines:
-                        message += '\t* ' + message_line + '\n'
+                        message += f"'\t* ' + {message_line} + '\n'"
 
             return ConfigStatus(CONFIG_PARSER_FAILURE, message, self)
 

--- a/model_analyzer/constants.py
+++ b/model_analyzer/constants.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Config constants
-MODEL_ANALYZER_SUCCESS = 1
-MODEL_ANALYZER_FAILURE = 0
+CONFIG_PARSER_SUCCESS = 1
+CONFIG_PARSER_FAILURE = 0
 
 # Result Table constants
 SERVER_ONLY_TABLE_DEFAULT_VALUE = '0'

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -23,25 +23,31 @@ from model_analyzer.model_analyzer_exceptions \
 
 
 class TestModelConfig(trc.TestResultCollector):
-
     def setUp(self):
         self._model_config = {
-            'name': 'classification_chestxray_v1',
-            'platform': 'tensorflow_graphdef',
-            'max_batch_size': 32,
-            'input': [
-                {'name': 'NV_MODEL_INPUT',
-                 'data_type': 'TYPE_FP32',
-                 'format': 'FORMAT_NHWC',
-                 'dims': ['256', '256', '3']}],
-            'output': [
-                {'name': 'NV_MODEL_OUTPUT',
-                 'data_type':
-                 'TYPE_FP32',
-                 'dims': ['15'],
-                 'label_filename':
-                 'chestxray_labels.txt'}],
-            'instance_group': [{'count': 1, 'kind': 'KIND_GPU'}]}
+            'name':
+            'classification_chestxray_v1',
+            'platform':
+            'tensorflow_graphdef',
+            'max_batch_size':
+            32,
+            'input': [{
+                'name': 'NV_MODEL_INPUT',
+                'data_type': 'TYPE_FP32',
+                'format': 'FORMAT_NHWC',
+                'dims': ['256', '256', '3']
+            }],
+            'output': [{
+                'name': 'NV_MODEL_OUTPUT',
+                'data_type': 'TYPE_FP32',
+                'dims': ['15'],
+                'label_filename': 'chestxray_labels.txt'
+            }],
+            'instance_group': [{
+                'count': 1,
+                'kind': 'KIND_GPU'
+            }]
+        }
 
         # Equivalent protobuf for the model config above.
         self._model_config_protobuf = """
@@ -84,9 +90,7 @@ instance_group [
         model_config = ModelConfig.create_from_dictionary(self._model_config)
         self.assertTrue(model_config.get_config() == self._model_config)
 
-        new_config = {'instance_group': [
-                {'count': 2, 'kind': 'KIND_CPU'}
-            ]}
+        new_config = {'instance_group': [{'count': 2, 'kind': 'KIND_CPU'}]}
         model_config.set_config(new_config)
         self.assertTrue(model_config.get_config() == new_config)
 
@@ -102,8 +106,8 @@ instance_group [
 
         model_config_from_file = \
             ModelConfig.create_from_file(model_output_path)
-        self.assertTrue(model_config_from_file.get_config()
-                        == self._model_config)
+        self.assertTrue(
+            model_config_from_file.get_config() == self._model_config)
 
         # output path is a file
         with self.assertRaises(TritonModelAnalyzerException):


### PR DESCRIPTION
Some example error messages:

 ```
 Value "{'a': 'b'}" cannot be set for field "my_field". This field allows multiple types of values. You only need to fix one of the errors below:
        * If a dictionary is used for field "my_field", it should only contain "start" and "stop" key with an optional "step" key. Currently, contains ['a'].
        * Value "{'a': 'b'}" for field "my_field" should be a primitive type.
 ```    
 
 ```
 The value for field "my_field" should be a list and the length must be larger than zero.
 ```
 
 
 ```
 Can't set the value for field "model_names". The error below occured when parsing the config:
Value "{'vgg_19_graphdef': {'model_config_parameters': {'instance_group': [{'kind': ['KIND_CPU', 'KIND_GPU', 'KIND_DPU'], 'count': 1}]}}}" cannot be set for field "model_names". This field allows multiple types of values. You only need to fix one of the errors below:
        * Value "[{'kind': ['KIND_CPU', 'KIND_GPU', 'KIND_DPU'], 'count': 1}]" cannot be set for field "model_names.vgg_19_graphdef.model_config_parameters.instance_group". This field allows multiple types of values. You only need to fix one of the errors below:
                * Value "['KIND_CPU', 'KIND_GPU', 'KIND_DPU']" cannot be set for field "model_names.vgg_19_graphdef.model_config_parameters.instance_group.kind". This field allows multiple types of values. You only need to fix one of the errors below:
                        * Value "['KIND_CPU', 'KIND_GPU', 'KIND_DPU']" for field "model_names.vgg_19_graphdef.model_config_parameters.instance_group.kind" is not acceptable. Value should be one of the following values: "['KIND_AUTO', 'KIND_GPU', 'KIND_CPU', 'KIND_MODEL']".
                        * Value "KIND_DPU" for field "model_names.vgg_19_graphdef.model_config_parameters.instance_group.kind" is not acceptable. Value should be one of the following values: "['KIND_AUTO', 'KIND_GPU', 'KIND_CPU', 'KIND_MODEL']".
                 
                * Value for field "model_names.vgg_19_graphdef.model_config_parameters.instance_group" must be a list, value is "{'kind': ['KIND_CPU', 'KIND_GPU', 'KIND_DPU'], 'count': 1}".
         
        * Value for field "model_names" must be a list, value is "{'vgg_19_graphdef': {'model_config_parameters': {'instance_group': [{'kind': ['KIND_CPU', 'KIND_GPU', 'KIND_DPU'], 'count': 1}]}}}".
        * The value for field "model_names" should not be a dictionary, current value is "{'vgg_19_graphdef': {'model_config_parameters': {'instance_group': [{'kind': ['KIND_CPU', 'KIND_GPU', 'KIND_DPU'], 'count': 1}]}}}".
 ```
I have included the field name in every error message too so that they can find it easier.
    