### PR TITLE
Corrected 5 test.sh scripts to check for the existence of config file(s) correctly

### DIFF
--- a/qa/L0_config/test.sh
+++ b/qa/L0_config/test.sh
@@ -50,7 +50,7 @@ LIST_OF_CONFIG_FILES=(`ls | grep .yml`)
 
 RET=0
 
-if [ ${#LIST_OF_CONFIG_FILES[@]} -lt 0 ]; then
+if [ ${#LIST_OF_CONFIG_FILES[@]} -le 0 ]; then
     echo -e "\n***\n*** Test Failed. No config file exists. \n***"
     RET=1
     exit $RET

--- a/qa/L0_config_range/test.sh
+++ b/qa/L0_config_range/test.sh
@@ -49,7 +49,7 @@ LIST_OF_CONFIG_FILES=(`ls | grep .yml`)
 
 RET=0
 
-if [ ${#LIST_OF_CONFIG_FILES[@]} -lt 0 ]; then
+if [ ${#LIST_OF_CONFIG_FILES[@]} -le 0 ]; then
     echo -e "\n***\n*** Test Failed. No config file exists. \n***"
     RET=1
     exit $RET

--- a/qa/L0_config_search/test.sh
+++ b/qa/L0_config_search/test.sh
@@ -46,7 +46,7 @@ LIST_OF_CONFIG_FILES=(`ls | grep .yml`)
 
 RET=0
 
-if [ ${#LIST_OF_CONFIG_FILES[@]} -lt 0 ]; then
+if [ ${#LIST_OF_CONFIG_FILES[@]} -le 0 ]; then
     echo -e "\n***\n*** Test Failed. No config file exists. \n***"
     exit 1
 fi

--- a/qa/L0_custom_flags/test.sh
+++ b/qa/L0_custom_flags/test.sh
@@ -46,7 +46,7 @@ python3 test_config_generator.py -m $MODEL_NAMES
 
 LIST_OF_CONFIG_FILES=(`ls | grep .yml`)
 
-if [ ${#LIST_OF_CONFIG_FILES[@]} -lt 0 ]; then
+if [ ${#LIST_OF_CONFIG_FILES[@]} -le 0 ]; then
     echo -e "\n***\n*** Test Failed. No config file exists. \n***"
     exit 1
 fi

--- a/qa/L0_output_fields/test.sh
+++ b/qa/L0_output_fields/test.sh
@@ -37,7 +37,7 @@ LIST_OF_CONFIG_FILES=(`ls | grep .yml`)
 
 RET=0
 
-if [ ${#LIST_OF_CONFIG_FILES[@]} -lt 0 ]; then
+if [ ${#LIST_OF_CONFIG_FILES[@]} -le 0 ]; then
     echo -e "\n***\n*** Test Failed. No config file exists. \n***"
     RET=1
     exit $RET


### PR DESCRIPTION
There was an off-by-one error in the 5 test.sh scripts which the number of .yml config files was checked incorrectly with < 0. The checks are updated to use <= 0.