### PR TITLE
Remove dependency dir being set to empty string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ if "--plat-name" in sys.argv:
 else:
     PLATFORM_FLAG = 'any'
 
-DEPENDENCY_DIR = ""
 
 
 def version(filename='VERSION'):


### PR DESCRIPTION
Not sure the intention of the original, but dependency dir was being set to an empty string rather than `pwd`/wheel as is specified by `build_wheel.sh`. This resulted in failure to copy over perf_analyzer binary in setup.py