### PR TITLE
Fix model analyzer to launch server with no GPU when empty gpus config is used

### DIFF
--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020,21 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ class TritonServerDocker(TritonServer):
             The tritonserver docker image to pull and run
         config : TritonServerConfig
             the config object containing arguments for this server instance
-        gpus : list
-            list of GPUs to be used
+        gpus : list of str
+            List of GPU UUIDs to be mounted in the container
         log_path: str
             Absolute path to the triton log file
         """
@@ -62,11 +62,9 @@ class TritonServerDocker(TritonServer):
         Starts the tritonserver docker container using docker-py
         """
 
-        if len(self._gpus) == 1 and self._gpus[0] == 'all':
-            devices = [
-                docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])
-            ]
-        else:
+        # List GPUs to be mounted inside docker container
+        devices = []
+        if len(self._gpus):
             devices = [
                 docker.types.DeviceRequest(device_ids=self._gpus,
                                            capabilities=[['gpu']])

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020,21 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from model_analyzer.device.gpu_device_factory import GPUDeviceFactory
+
 from .server_docker import TritonServerDocker
 from .server_local import TritonServerLocal
 
@@ -20,6 +22,7 @@ class TritonServerFactory:
     """
     A factory for creating TritonServer instances
     """
+
     @staticmethod
     def create_server_docker(image, config, gpus, log_path=None):
         """
@@ -29,8 +32,9 @@ class TritonServerFactory:
             The tritonserver docker image to pull and run
         config : TritonServerConfig
             the config object containing arguments for this server instance
-        gpus : list
-            List of GPUs to be mounted in the container.
+        gpus : list of str
+            List of GPU UUIDs to be mounted in the container
+            Use ["all"] to include all GPUs
         log_path: str
             Absolute path to the triton log file
 
@@ -39,10 +43,11 @@ class TritonServerFactory:
         TritonServerDocker
         """
 
-        return TritonServerDocker(image=image,
-                                  config=config,
-                                  gpus=gpus,
-                                  log_path=log_path)
+        return TritonServerDocker(
+            image=image,
+            config=config,
+            gpus=GPUDeviceFactory.verify_requested_gpus(gpus),
+            log_path=log_path)
 
     @staticmethod
     def create_server_local(path, config, gpus, log_path=None):
@@ -54,7 +59,8 @@ class TritonServerFactory:
         config : TritonServerConfig
             the config object containing arguments for this server instance
         gpus: list of str
-            List of strings of GPU UUIDs that should be made visible to Triton
+            List of GPU UUIDs to be made visible to Triton
+            Use ["all"] to include all GPUs
         log_path: str
             Absolute path to the triton log file
 
@@ -63,7 +69,8 @@ class TritonServerFactory:
         TritonServerLocal
         """
 
-        return TritonServerLocal(path=path,
-                                 config=config,
-                                 gpus=gpus,
-                                 log_path=log_path)
+        return TritonServerLocal(
+            path=path,
+            config=config,
+            gpus=GPUDeviceFactory.verify_requested_gpus(gpus),
+            log_path=log_path)

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -33,7 +33,7 @@ class TritonServerFactory:
         config : TritonServerConfig
             the config object containing arguments for this server instance
         gpus : list of str
-            List of GPU UUIDs to be mounted in the container
+            List of GPU UUIDs to be mounted and used in the container
             Use ["all"] to include all GPUs
         log_path: str
             Absolute path to the triton log file

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020,21 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from .server import TritonServer
-from model_analyzer.device.gpu_device_factory import GPUDeviceFactory
 from model_analyzer.constants import SERVER_OUTPUT_TIMEOUT_SECS
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
@@ -31,6 +30,7 @@ class TritonServerLocal(TritonServer):
     Concrete Implementation of TritonServer interface that runs
     tritonserver locally as as subprocess.
     """
+
     def __init__(self, path, config, gpus, log_path):
         """
         Parameters
@@ -40,7 +40,7 @@ class TritonServerLocal(TritonServer):
         config : TritonServerConfig
             the config object containing arguments for this server instance
         gpus: list of str
-            List of strings of GPU UUIDs that should be made visible to Triton
+            List of GPU UUIDs to be made visible to Triton
         log_path: str
             Absolute path to the triton log file
         """
@@ -62,13 +62,11 @@ class TritonServerLocal(TritonServer):
         if self._server_path:
             # Create command list and run subprocess
             cmd = [self._server_path]
-            cmd += self._server_config.to_cli_string().replace('=',
-                                                               ' ').split()
+            cmd += self._server_config.to_cli_string().replace('=', ' ').split()
+            # List GPUs to be used by tritonserver
             triton_env = os.environ.copy()
-            if len(self._gpus) >= 1 and self._gpus[0] != 'all':
-                visible_gpus = GPUDeviceFactory.get_cuda_visible_gpus()
-                triton_env['CUDA_VISIBLE_DEVICES'] = ','.join(
-                    [visible_gpus[uuid] for uuid in self._gpus])
+            triton_env['CUDA_VISIBLE_DEVICES'] = ','.join(
+                [uuid for uuid in self._gpus])
 
             if self._log_path:
                 try:

--- a/qa/L0_server_launch_modes/test.sh
+++ b/qa/L0_server_launch_modes/test.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020,21 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -154,6 +154,9 @@ CURRENT_GPUS=(${GPUS[2]})
 run_server_launch_modes "$CURRENT_GPUS"
 
 CURRENT_GPUS=${GPUS[@]:1}
+run_server_launch_modes "$CURRENT_GPUS"
+
+CURRENT_GPUS=""
 run_server_launch_modes "$CURRENT_GPUS"
 
 rm -rf $CHECKPOINT_DIRECTORY

--- a/qa/L0_server_launch_modes/test.sh
+++ b/qa/L0_server_launch_modes/test.sh
@@ -48,12 +48,13 @@ RET=0
 
 function convert_gpu_array_to_flag() {
     gpu_array=($@)
-    if [ ! -z "${gpu_array[0]}" ]; then
+    if [ "$gpu_array" == "empty_gpu_flag" ]; then
+        echo "--gpus []"
+    elif [ ! -z "${gpu_array[0]}" ]; then
         gpus_flag="--gpus "
         for gpu in ${gpu_array[@]}; do
             gpus_flag="${gpus_flag}${gpu},"
         done
-
         # Remove trailing comma
         gpus_flag=${gpus_flag::-1}
         echo $gpus_flag
@@ -115,7 +116,9 @@ function run_server_launch_modes() {
                 fi
             fi
 
-            if [ -z "$gpus" ]; then
+            if [ "$gpus" == "empty_gpu_flag" ]; then
+                python3 check_gpus.py --analyzer-log $ANALYZER_LOG --gpus ""
+            elif [ -z "$gpus" ]; then
                 python3 check_gpus.py --analyzer-log $ANALYZER_LOG --gpus `echo ${GPUS[@]} | sed "s/ /,/g"` --check-visible
             else
                 python3 check_gpus.py --analyzer-log $ANALYZER_LOG --gpus `echo ${gpus[@]} | sed "s/ /,/g"`
@@ -156,7 +159,7 @@ run_server_launch_modes "$CURRENT_GPUS"
 CURRENT_GPUS=${GPUS[@]:1}
 run_server_launch_modes "$CURRENT_GPUS"
 
-CURRENT_GPUS=""
+CURRENT_GPUS="empty_gpu_flag"
 run_server_launch_modes "$CURRENT_GPUS"
 
 rm -rf $CHECKPOINT_DIRECTORY

--- a/tests/mocks/mock_gpu_device_factory.py
+++ b/tests/mocks/mock_gpu_device_factory.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch, MagicMock, Mock
+from .mock_base import MockBase
+
+
+class MockGPUDeviceFactory(MockBase):
+
+    def __init__(self):
+        self._cuda_visible_gpus = ["GPU_1", "GPU_2"]
+        super().__init__()
+
+    def _fill_patchers(self):
+        self._patchers.append(patch("model_analyzer.device.gpu_device_factory.GPUDeviceFactory.get_cuda_visible_gpus", 
+                                    MagicMock(return_value=dict.fromkeys(self._cuda_visible_gpus))))
+    
+    def get_cuda_visible_gpus(self):
+        return self._cuda_visible_gpus[:]
+    
+    def verify_requested_gpus(self, requested_gpus):
+        if len(requested_gpus) == 1 and requested_gpus[0] == 'all':
+            return self._cuda_visible_gpus[:]
+        return list(set(self._cuda_visible_gpus) & set(requested_gpus))

--- a/tests/mocks/mock_gpu_device_factory.py
+++ b/tests/mocks/mock_gpu_device_factory.py
@@ -18,18 +18,12 @@ from .mock_base import MockBase
 
 class MockGPUDeviceFactory(MockBase):
 
-    def __init__(self):
-        self._cuda_visible_gpus = ["GPU_1", "GPU_2"]
+    def __init__(self, gpus):
+        self._cuda_visible_gpus = gpus
         super().__init__()
 
     def _fill_patchers(self):
-        self._patchers.append(patch("model_analyzer.device.gpu_device_factory.GPUDeviceFactory.get_cuda_visible_gpus", 
-                                    MagicMock(return_value=dict.fromkeys(self._cuda_visible_gpus))))
-    
-    def get_cuda_visible_gpus(self):
-        return self._cuda_visible_gpus[:]
-    
-    def verify_requested_gpus(self, requested_gpus):
-        if len(requested_gpus) == 1 and requested_gpus[0] == 'all':
-            return self._cuda_visible_gpus[:]
-        return list(set(self._cuda_visible_gpus) & set(requested_gpus))
+        self._patchers.append(
+            patch(
+                "model_analyzer.device.gpu_device_factory.GPUDeviceFactory.get_cuda_visible_gpus",
+                MagicMock(return_value=dict.fromkeys(self._cuda_visible_gpus))))

--- a/tests/mocks/mock_server_docker.py
+++ b/tests/mocks/mock_server_docker.py
@@ -30,15 +30,15 @@ class MockServerDockerMethods(MockServerMethods):
     def __init__(self):
         docker_container_attrs = {
             'exec_run':
-            MagicMock(return_value=(None, bytes(self.TEST_MEM, 'utf-8'))),
+                MagicMock(return_value=(None, bytes(self.TEST_MEM, 'utf-8'))),
             'stats':
-            Mock(return_value={
-                'memory_stats': {
-                    'usage': 0.0,
-                    'max_usage': 0.0,
-                    'limits': 0.0
-                }
-            })
+                Mock(return_value={
+                    'memory_stats': {
+                        'usage': 0.0,
+                        'max_usage': 0.0,
+                        'limits': 0.0
+                    }
+                })
         }
         docker_client_attrs = {
             'containers.run': Mock(return_value=Mock(**docker_container_attrs))
@@ -88,6 +88,7 @@ class MockServerDockerMethods(MockServerMethods):
                                                 cmd,
                                                 model_repository_path,
                                                 triton_image,
+                                                device_requests,
                                                 http_port=8000,
                                                 grpc_port=8001,
                                                 metrics_port=8002):
@@ -109,7 +110,7 @@ class MockServerDockerMethods(MockServerMethods):
             command=cmd,
             name='tritonserver',
             image=triton_image,
-            device_requests=[0],
+            device_requests=device_requests,
             volumes=mock_volumes,
             ports=mock_ports,
             publish_all_ports=True,

--- a/tests/mocks/mock_server_docker.py
+++ b/tests/mocks/mock_server_docker.py
@@ -89,6 +89,7 @@ class MockServerDockerMethods(MockServerMethods):
                                                 model_repository_path,
                                                 triton_image,
                                                 device_requests,
+                                                gpu_uuids,
                                                 http_port=8000,
                                                 grpc_port=8001,
                                                 metrics_port=8002):
@@ -99,6 +100,9 @@ class MockServerDockerMethods(MockServerMethods):
 
         self._assert_docker_initialized()
 
+        environment = {
+            'CUDA_VISIBLE_DEVICES': ','.join([uuid for uuid in gpu_uuids])
+        }
         mock_volumes = {
             model_repository_path: {
                 'bind': model_repository_path,
@@ -111,6 +115,7 @@ class MockServerDockerMethods(MockServerMethods):
             name='tritonserver',
             image=triton_image,
             device_requests=device_requests,
+            environment=environment,
             volumes=mock_volumes,
             ports=mock_ports,
             publish_all_ports=True,

--- a/tests/mocks/mock_server_local.py
+++ b/tests/mocks/mock_server_local.py
@@ -23,6 +23,7 @@ class MockServerLocalMethods(MockServerMethods):
     model_analyzer/triton/server/server_local.py.
     Provides functions to check operation.
     """
+
     def __init__(self):
         memory_full_attrs = {'uss': 0}
         virtual_memory_attrs = {'available': 0}
@@ -34,8 +35,7 @@ class MockServerLocalMethods(MockServerMethods):
             'virtual_memory': Mock(return_value=Mock(**virtual_memory_attrs))
         }
         Popen_attrs = {
-            'communicate.return_value':
-            ('Triton Server Test Log', 'Test Error')
+            'communicate.return_value': ('Triton Server Test Log', 'Test Error')
         }
         self.patcher_popen = patch(
             'model_analyzer.triton.server.server_local.Popen',
@@ -69,18 +69,21 @@ class MockServerLocalMethods(MockServerMethods):
         self._patchers.append(self.patcher_pipe)
         self._patchers.append(self.patcher_psutil)
 
-    def assert_server_process_start_called_with(self, cmd):
+    def assert_server_process_start_called_with(self, cmd, gpu_uuids):
         """
         Asserts that Popen was called
         with the cmd provided.
         """
+
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = ','.join([uuid for uuid in gpu_uuids])
 
         self.popen_mock.assert_called_once_with(cmd,
                                                 stdout=self.pipe_mock,
                                                 stderr=self.stdout_mock,
                                                 start_new_session=True,
                                                 universal_newlines=True,
-                                                env=os.environ.copy())
+                                                env=env)
 
     def assert_server_process_terminate_called(self):
         """

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -162,8 +162,8 @@ class TestTritonServerMethods(trc.TestResultCollector):
         self.server.start()
         self.server_docker_mock.assert_server_process_start_called_with(
             f"{TRITON_DOCKER_BIN_PATH} {server_config.to_cli_string()}",
-            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, 8000, 8001,
-            8002)
+            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, gpu_uuids,
+            8000, 8001, 8002)
 
         self.server_docker_mock.raise_exception_on_container_run()
         with self.assertRaises(TritonModelAnalyzerException):
@@ -249,8 +249,8 @@ class TestTritonServerMethods(trc.TestResultCollector):
         # The following needs to be called as it resets exec_run return value
         self.server_docker_mock.assert_server_process_start_called_with(
             f'{TRITON_DOCKER_BIN_PATH} {server_config.to_cli_string()}',
-            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, 8000, 8001,
-            8002)
+            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, gpu_uuids,
+            8000, 8001, 8002)
         _, _ = self.server.cpu_stats()
         self.server_docker_mock.assert_cpu_stats_called()
         self.server.stop()

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -15,6 +15,7 @@
 import unittest
 from unittest.case import skip
 
+from .mocks.mock_gpu_device_factory import MockGPUDeviceFactory
 from .mocks.mock_server_docker import MockServerDockerMethods
 from .mocks.mock_server_local import MockServerLocalMethods
 from .mocks.mock_os import MockOSMethods
@@ -40,14 +41,17 @@ CLI_TO_STRING_TEST_ARGS = {
 
 
 class TestTritonServerMethods(trc.TestResultCollector):
+
     def setUp(self):
         # Mock
+        self.gpu_device_factory_mock = MockGPUDeviceFactory()
         self.server_docker_mock = MockServerDockerMethods()
         self.server_local_mock = MockServerLocalMethods()
         self.os_mock = MockOSMethods(mock_paths=[
             'model_analyzer.triton.server.server_local',
             'tests.mocks.mock_server_local'
         ])
+        self.gpu_device_factory_mock.start()
         self.server_docker_mock.start()
         self.server_local_mock.start()
         self.os_mock.start()
@@ -100,23 +104,24 @@ class TestTritonServerMethods(trc.TestResultCollector):
 
             # Make sure parsed value is the one from dict, check type too
             test_value = CLI_TO_STRING_TEST_ARGS[arg]
-            self.assertEqual(
-                test_value,
-                type(test_value)(value),
-                msg=f"CLI string contained unknown value: {value}")
+            self.assertEqual(test_value,
+                             type(test_value)(value),
+                             msg=f"CLI string contained unknown value: {value}")
 
-    def test_create_server(self):
+    def test_create_server(self, gpus=None):
+        if gpus == None:
+            gpus = ["all"]  # Avoid strange default args behavior
+
         # Create a TritonServerConfig
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
-        gpus = ['all']
 
         # Run for both types of environments
         self.server = TritonServerFactory.create_server_docker(
             image=TRITON_IMAGE, config=server_config, gpus=gpus)
 
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=['all'])
+            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
 
         # Try to create a server without specifying model repository and expect
         # error
@@ -132,13 +137,28 @@ class TestTritonServerMethods(trc.TestResultCollector):
                 msg="Expected AssertionError for trying to create"
                 "server without specifying model repository."):
             self.server = TritonServerFactory.create_server_local(
-                path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=['all'])
+                path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
 
-    def test_start_stop_gpus(self):
+    def test_create_server_no_gpu(self):
+        self.test_create_server(gpus=[])
+
+    def test_create_server_select_gpu(self):
+        self.test_create_server(
+            gpus=self.gpu_device_factory_mock.get_cuda_visible_gpus()[:1])
+
+    def test_start_stop_gpus(self, gpus=None):
+        if gpus == None:
+            gpus = ["all"]  # Avoid strange default args behavior
+
+        # Device request for docker mode
+        device_requests = [0]
+        if len(gpus) == 0 or len(
+                self.gpu_device_factory_mock.get_cuda_visible_gpus()) == 0:
+            device_requests = []
+
         # Create a TritonServerConfig
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
-        gpus = ['all']
 
         # Create server in docker, start , wait, and stop
         self.server = TritonServerFactory.create_server_docker(
@@ -148,7 +168,8 @@ class TestTritonServerMethods(trc.TestResultCollector):
         self.server.start()
         self.server_docker_mock.assert_server_process_start_called_with(
             f"{TRITON_DOCKER_BIN_PATH} {server_config.to_cli_string()}",
-            MODEL_REPOSITORY_PATH, TRITON_IMAGE, 8000, 8001, 8002)
+            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, 8000, 8001,
+            8002)
 
         self.server_docker_mock.raise_exception_on_container_run()
         with self.assertRaises(TritonModelAnalyzerException):
@@ -161,23 +182,37 @@ class TestTritonServerMethods(trc.TestResultCollector):
 
         # Create local server which runs triton as a subprocess
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=['all'])
+            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
 
         # Check that API functions are called
         self.server.start()
 
-        self.server_local_mock.assert_server_process_start_called_with(cmd=[
-            TRITON_LOCAL_BIN_PATH, '--model-repository', MODEL_REPOSITORY_PATH
-        ])
+        self.server_local_mock.assert_server_process_start_called_with(
+            cmd=[
+                TRITON_LOCAL_BIN_PATH, '--model-repository',
+                MODEL_REPOSITORY_PATH
+            ],
+            gpu_uuids=self.gpu_device_factory_mock.verify_requested_gpus(gpus))
 
         self.server.stop()
         self.server_local_mock.assert_server_process_terminate_called()
 
+    def test_start_stop_gpus_no_gpu(self):
+        self.test_start_stop_gpus(gpus=[])
+
+    def test_start_stop_gpus_select_gpu(self):
+        self.test_start_stop_gpus(
+            gpus=self.gpu_device_factory_mock.get_cuda_visible_gpus()[:1])
+
+    # TODO: Add no gpu and select gpu cases if enabled
     @skip('May not be valid')
-    def test_get_logs(self):
+    def test_get_logs(self, gpus=None):
+        if gpus == None:
+            gpus = ["all"]  # Avoid strange default args behavior
+
+        # Create a TritonServerConfig
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
-        gpus = ['all']
 
         # Check docker server logs
         self.server = TritonServerFactory.create_server_docker(
@@ -189,20 +224,29 @@ class TestTritonServerMethods(trc.TestResultCollector):
 
         # Create local server logs
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=['all'])
+            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
         self.server.start()
         self.server.stop()
         self.server_local_mock.assert_server_process_terminate_called()
         self.assertEqual(self.server.logs(), "Triton Server Test Log")
 
-    def test_cpu_stats(self):
+    def test_cpu_stats(self, gpus=None):
+        if gpus == None:
+            gpus = ["all"]  # Avoid strange default args behavior
+
+        # Device request for docker mode
+        device_requests = [0]
+        if len(gpus) == 0 or len(
+                self.gpu_device_factory_mock.get_cuda_visible_gpus()) == 0:
+            device_requests = []
+
+        # Create a TritonServerConfig
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH
-        gpus = ['all']
 
         # Test local server cpu_stats
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=['all'])
+            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
         self.server.start()
         _, _ = self.server.cpu_stats()
         self.server_local_mock.assert_cpu_stats_called()
@@ -216,10 +260,18 @@ class TestTritonServerMethods(trc.TestResultCollector):
         # The following needs to be called as it resets exec_run return value
         self.server_docker_mock.assert_server_process_start_called_with(
             f'{TRITON_DOCKER_BIN_PATH} {server_config.to_cli_string()}',
-            MODEL_REPOSITORY_PATH, TRITON_IMAGE, 8000, 8001, 8002)
+            MODEL_REPOSITORY_PATH, TRITON_IMAGE, device_requests, 8000, 8001,
+            8002)
         _, _ = self.server.cpu_stats()
         self.server_docker_mock.assert_cpu_stats_called()
         self.server.stop()
+
+    def test_cpu_stats_no_gpu(self):
+        self.test_cpu_stats(gpus=[])
+
+    def test_cpu_stats_select_gpu(self):
+        self.test_cpu_stats(
+            gpus=self.gpu_device_factory_mock.get_cuda_visible_gpus()[:1])
 
     def tearDown(self):
         # In case test raises exception
@@ -227,6 +279,7 @@ class TestTritonServerMethods(trc.TestResultCollector):
             self.server.stop()
 
         # Stop mocking
+        self.gpu_device_factory_mock.stop()
         self.server_docker_mock.stop()
         self.server_local_mock.stop()
         self.os_mock.stop()


### PR DESCRIPTION
If the user sets the `gpus: []` config for model-analyzer, then this implies the model-analyzer should not use any GPU. This is a fix that the model-analyzer will launch the triton server without any GPU, when that config is present. 

This pull request also unifies how the `gpus` config is processed between local and docker mode. Previously, they are scattered across `entrypoint.py`, `server_local.py` and `server_docker.py`. This unification will process the `gpus` config inside `server_local.py` and `server_docker.py` using the `GPUDeviceFactory` class in `gpu_device_factory.py` which will return a list of GPU UUIDs that should be used based on the `gpus` config. Then, the `server_local.py` and `server_docker.py` will launch the server according to the returned list of GPU UUIDs.