### PR TITLE
Update quick_start.md

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -130,7 +130,7 @@ In order to generate tables and summary reports, use the `analyze` subcommand as
 follows.
 
 ```
-$ mkdir analysis results
+$ mkdir analysis_results
 $ model-analyzer analyze --analysis-models add_sub -e analysis_results
 ```
 


### PR DESCRIPTION
Fixed a typo in line 133 on the mkdir command to make the folder analysis_results not "mkdir analysis results"