### PR TITLE
Fix broken symlinks when using relative paths

### DIFF
--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -194,7 +194,7 @@ class ModelConfig:
                     if file == 'config.pbtxt':
                         continue
                     else:
-                        os.symlink(os.path.join(last_model_path, file),
+                        os.symlink(os.path.join(os.path.relpath(last_model_path,model_path), file),
                                    os.path.join(model_path, file))
 
         if not reusued_previous_model_dir:


### PR DESCRIPTION
Fix for ([#226](https://github.com/triton-inference-server/model_analyzer/issues/226))