### PR TITLE
Print help when no args

### DIFF
--- a/model_analyzer/cli/cli.py
+++ b/model_analyzer/cli/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -134,6 +134,9 @@ class CLI:
         """
 
         args = self._parser.parse_args()
+        if args.subcommand is None:
+            self._parser.print_help()
+            self._parser.exit()
         config = self._subcommand_configs[args.subcommand]
         config.set_config_values(args)
         return args, config

--- a/qa/L0_doa/test.sh
+++ b/qa/L0_doa/test.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ RET=0
 
 set +e
 run_analyzer
-if [ $? != 1 ]; then
+if [ $? != 0 ]; then
     echo -e "\n***\n*** Failed to run model-analyzer. \n***"
     cat $ANALYZER_LOG
     RET=1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from argparse import ArgumentParser
+
+from .common import test_result_collector as trc
+
+from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from model_analyzer.config.input.config_command_analyze import ConfigCommandAnalyze
+from model_analyzer.config.input.config_command_report import ConfigCommandReport
+from model_analyzer.cli.cli import CLI
+
+
+class ArgumentParserSubclass(ArgumentParser):
+
+    def print_help(self, file=None):
+        super().print_help(file)
+        self._did_print_help = True
+
+    _did_print_help = False
+
+
+class CLISubclass(CLI):
+
+    def __init__(self):
+        self._parser = ArgumentParserSubclass()
+        self._add_global_options()
+        self._subparsers = self._parser.add_subparsers(
+            help='Subcommands under Model Analyzer', dest='subcommand')
+
+        # Store subcommands, and their configs
+        self._subcommand_configs = {}
+
+
+class TestCLI(trc.TestResultCollector):
+
+    def test_help_message_no_args(self):
+        sys.argv = ['/usr/local/bin/model-analyzer']
+
+        config_profile = ConfigCommandProfile()
+        config_analyze = ConfigCommandAnalyze()
+        config_report = ConfigCommandReport()
+
+        cli = CLISubclass()
+        cli.add_subcommand(
+            cmd='profile',
+            help=
+            'Run model inference profiling based on specified CLI or config options.',
+            config=config_profile)
+        cli.add_subcommand(
+            cmd='analyze',
+            help=
+            'Collect and sort profiling results and generate data and summaries.',
+            config=config_analyze)
+        cli.add_subcommand(cmd='report',
+                           help='Generate detailed reports for a single config',
+                           config=config_report)
+
+        self.assertRaises(SystemExit, cli.parse)
+        self.assertTrue(cli._parser._did_print_help == True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,10 @@ from model_analyzer.cli.cli import CLI
 
 
 class ArgumentParserSubclass(ArgumentParser):
+    """
+    Custom subclass of the ArgumentParser class to change functionality to enable
+    testing
+    """
 
     def print_help(self, file=None):
         super().print_help(file)
@@ -34,6 +38,9 @@ class ArgumentParserSubclass(ArgumentParser):
 
 
 class CLISubclass(CLI):
+    """
+    Custom subclass of the CLI class to change functionality to enable testing
+    """
 
     def __init__(self):
         self._parser = ArgumentParserSubclass()
@@ -46,8 +53,16 @@ class CLISubclass(CLI):
 
 
 class TestCLI(trc.TestResultCollector):
+    """
+    Tests the methods of the CLI class
+    """
 
     def test_help_message_no_args(self):
+        """
+        Tests that model-analyzer prints the help message when no arguments are
+        given
+        """
+
         sys.argv = ['/usr/local/bin/model-analyzer']
 
         config_profile = ConfigCommandProfile()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,44 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
 import sys
-
-from argparse import ArgumentParser
 
 from .common import test_result_collector as trc
 
-from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
-from model_analyzer.config.input.config_command_analyze import ConfigCommandAnalyze
-from model_analyzer.config.input.config_command_report import ConfigCommandReport
 from model_analyzer.cli.cli import CLI
-
-
-class ArgumentParserSubclass(ArgumentParser):
-    """
-    Custom subclass of the ArgumentParser class to change functionality to enable
-    testing
-    """
-
-    def print_help(self, file=None):
-        super().print_help(file)
-        self._did_print_help = True
-
-    _did_print_help = False
-
-
-class CLISubclass(CLI):
-    """
-    Custom subclass of the CLI class to change functionality to enable testing
-    """
-
-    def __init__(self):
-        self._parser = ArgumentParserSubclass()
-        self._add_global_options()
-        self._subparsers = self._parser.add_subparsers(
-            help='Subcommands under Model Analyzer', dest='subcommand')
-
-        # Store subcommands, and their configs
-        self._subcommand_configs = {}
 
 
 class TestCLI(trc.TestResultCollector):
@@ -57,7 +25,8 @@ class TestCLI(trc.TestResultCollector):
     Tests the methods of the CLI class
     """
 
-    def test_help_message_no_args(self):
+    @patch('model_analyzer.cli.cli.ArgumentParser.print_help')
+    def test_help_message_no_args(self, mock_print_help):
         """
         Tests that model-analyzer prints the help message when no arguments are
         given
@@ -65,24 +34,7 @@ class TestCLI(trc.TestResultCollector):
 
         sys.argv = ['/usr/local/bin/model-analyzer']
 
-        config_profile = ConfigCommandProfile()
-        config_analyze = ConfigCommandAnalyze()
-        config_report = ConfigCommandReport()
-
-        cli = CLISubclass()
-        cli.add_subcommand(
-            cmd='profile',
-            help=
-            'Run model inference profiling based on specified CLI or config options.',
-            config=config_profile)
-        cli.add_subcommand(
-            cmd='analyze',
-            help=
-            'Collect and sort profiling results and generate data and summaries.',
-            config=config_analyze)
-        cli.add_subcommand(cmd='report',
-                           help='Generate detailed reports for a single config',
-                           config=config_report)
+        cli = CLI()
 
         self.assertRaises(SystemExit, cli.parse)
-        self.assertTrue(cli._parser._did_print_help == True)
+        mock_print_help.assert_called()


### PR DESCRIPTION
model analyzer should print the help message when no arguments are provided, rather than raising an exception like before

before:
```
$ model-analyzer
Traceback (most recent call last):
  File "/usr/local/bin/model-analyzer", line 33, in <module>
    sys.exit(load_entry_point('triton-model-analyzer', 'console_scripts', 'model-analyzer')())
  File "/opt/triton-model-analyzer/model_analyzer/entrypoint.py", line 274, in main
    args, config = get_cli_and_config_options()
  File "/opt/triton-model-analyzer/model_analyzer/entrypoint.py", line 211, in get_cli_and_config_options
    return cli.parse()
  File "/opt/triton-model-analyzer/model_analyzer/cli/cli.py", line 137, in parse
    config = self._subcommand_configs[args.subcommand]
KeyError: None
```

after:
```
$ model-analyzer
usage: model-analyzer [-h] [-q] [-v] [-m {online,offline}] {profile,analyze,report} ...

positional arguments:
  {profile,analyze,report}
                        Subcommands under Model Analyzer
    profile             Run model inference profiling based on specified CLI or config options.
    analyze             Collect and sort profiling results and generate data and summaries.
    report              Generate detailed reports for a single config

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           Suppress all output except for error messages.
  -v, --verbose         Show detailed logs, messags and status.
  -m {online,offline}, --mode {online,offline}
                        Choose a preset configuration mode.
```