### PR TITLE
Fix quick start error

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -33,7 +33,7 @@ $ docker build --pull -t model-analyzer .
 ```
 $ docker run -it --rm --gpus all \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $HOME/model_analyzer/examples/quick-start:/quick_start_repository \
+    -v $(pwd)/examples/quick-start:/quick_start_repository \
     --net=host --name model-analyzer \
     model-analyzer /bin/bash
 ```


### PR DESCRIPTION
There's an error in the quick start. The commands above the docker run command set the user's current working directory to be the repo root. The docker run command needs to be modified to work when user is cd'd to repo root