### PR TITLE
Update colors for detail report legend

### DIFF
--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -74,7 +74,7 @@ class DetailedPlot:
             'perf_server_queue': '#825D16',
             'perf_server_compute_input': '#0071C5',
             'perf_server_compute_infer': '#C5B600',
-            'perf_server_compute_output': '#F0D4BF',
+            'perf_server_compute_output': '#C55400',
             'perf_throughput': '#5E5E5E'
         }
 

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -69,12 +69,12 @@ class DetailedPlot:
         ]
 
         self._bar_colors = {
-            'perf_client_send_recv': '#4285f4',
-            'perf_client_response_wait': '#db4437',
-            'perf_server_queue': '#f4b400',
-            'perf_server_compute_input': '#0f9d58',
-            'perf_server_compute_infer': '#ff6d00',
-            'perf_server_compute_output': '#46bdc6',
+            'perf_client_send_recv': '#ff0000',
+            'perf_client_response_wait': '#008000',
+            'perf_server_queue': '#0000ff',
+            'perf_server_compute_input': '#00ffff',
+            'perf_server_compute_infer': '#ff00ff',
+            'perf_server_compute_output': '#c0c0c0',
             'perf_throughput': '#c1bc1f'
         }
 

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -69,12 +69,12 @@ class DetailedPlot:
         ]
 
         self._bar_colors = {
-            'perf_client_send_recv': '#018564',
-            'perf_client_response_wait': '#76B901',
-            'perf_server_queue': '#0171C5',
-            'perf_server_compute_input': '#890C58',
-            'perf_server_compute_infer': '#FAC201',
-            'perf_server_compute_output': '#5D1682',
+            'perf_client_send_recv': '#5D1682',
+            'perf_client_response_wait': '#165D82',
+            'perf_server_queue': '#825D16',
+            'perf_server_compute_input': '#0071C5',
+            'perf_server_compute_infer': '#C5B600',
+            'perf_server_compute_output': '#C55400',
             'perf_throughput': '#5E5E5E'
         }
 

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -70,8 +70,8 @@ class DetailedPlot:
 
         self._bar_colors = {
             'perf_client_send_recv': '#ffc372',
-            'perf_client_response_wait': '#baa496',
-            'perf_server_queue': '#e7938e',
+            'perf_client_response_wait': '#9daecc',
+            'perf_server_queue': '#addc91',
             'perf_server_compute_input': '#7eb7e8',
             'perf_server_compute_infer': '#0072ce',
             'perf_server_compute_output': '#254b87',

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -69,13 +69,13 @@ class DetailedPlot:
         ]
 
         self._bar_colors = {
-            'perf_client_send_recv': '#ff0000',
-            'perf_client_response_wait': '#008000',
-            'perf_server_queue': '#0000ff',
-            'perf_server_compute_input': '#00ffff',
-            'perf_server_compute_infer': '#ff00ff',
-            'perf_server_compute_output': '#c0c0c0',
-            'perf_throughput': '#c1bc1f'
+            'perf_client_send_recv': '#018564',
+            'perf_client_response_wait': '#76B901',
+            'perf_server_queue': '#0171C5',
+            'perf_server_compute_input': '#890C58',
+            'perf_server_compute_infer': '#FAC201',
+            'perf_server_compute_output': '#5D1682',
+            'perf_throughput': '#5E5E5E'
         }
 
         self._bar_width = bar_width

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -74,7 +74,7 @@ class DetailedPlot:
             'perf_server_queue': '#825D16',
             'perf_server_compute_input': '#0071C5',
             'perf_server_compute_infer': '#C5B600',
-            'perf_server_compute_output': '#C55400',
+            'perf_server_compute_output': '#F0D4BF',
             'perf_throughput': '#5E5E5E'
         }
 

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -69,12 +69,12 @@ class DetailedPlot:
         ]
 
         self._bar_colors = {
-            'perf_client_send_recv': '#5D1682',
-            'perf_client_response_wait': '#165D82',
-            'perf_server_queue': '#825D16',
-            'perf_server_compute_input': '#0071C5',
-            'perf_server_compute_infer': '#C5B600',
-            'perf_server_compute_output': '#C55400',
+            'perf_client_send_recv': '#ffc372',
+            'perf_client_response_wait': '#baa496',
+            'perf_server_queue': '#e7938e',
+            'perf_server_compute_input': '#7eb7e8',
+            'perf_server_compute_infer': '#0072ce',
+            'perf_server_compute_output': '#254b87',
             'perf_throughput': '#5E5E5E'
         }
 
@@ -185,9 +185,12 @@ class DetailedPlot:
         # Annotate inferences
         for x, y in zip(sorted_data['concurrency'],
                         sorted_data['perf_throughput']):
-            self._ax_throughput.annotate(str(round(y, 2)),
-                                         xy=(x, y),
-                                         ha='center')
+            self._ax_throughput.annotate(
+                str(round(y, 2)),
+                xy=(x, y),
+                textcoords="offset points",  # how to position the text
+                xytext=(0, 10),  # distance from text to points (x,y)
+                ha='center')
 
         self._ax_latency.grid()
         self._ax_latency.set_axisbelow(True)

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -350,6 +350,11 @@ class ResultManager:
         #
         model_name = model_config_name.rsplit('_', 2)[0]
 
+        # Remote mode has model_name == model_config_name
+        #
+        if model_name not in results:
+            model_name = model_config_name
+
         if model_name not in results or model_config_name not in results[
                 model_name]:
             raise TritonModelAnalyzerException(

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -346,10 +346,6 @@ class ResultManager:
         results = self._state_manager.get_state_variable(
             'ResultManager.results')
 
-        # Name format is <base_model_name>_config_<number_or_default>
-        #
-        model_name = model_config_name.rsplit('_', 2)[0]
-
         # Remote mode has model_name == model_config_name
         #
         if model_name not in results:

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -346,10 +346,9 @@ class ResultManager:
         results = self._state_manager.get_state_variable(
             'ResultManager.results')
 
-        # Remote mode has model_name == model_config_name
+        # Name format is <base_model_name>_config_<number_or_default>
         #
-        if model_name not in results:
-            model_name = model_config_name
+        model_name = model_config_name.rsplit('_', 2)[0]
 
         if model_name not in results or model_config_name not in results[
                 model_name]:


### PR DESCRIPTION
1) View the labels inside six of the colors below.
- Notice three colors of the 'server compute' co-related items are 1) from the same shade, and 2) in the cool palette
- The other three unrelated items are 1) not of the same shade, and 2) from the warm palette

![image](https://user-images.githubusercontent.com/35349680/157330874-83f84a93-b1fd-4de0-9cd8-83c2ab7e8932.png)

2) Resulting plot (for presentation purposes, some values were spoofed to show their contribution to the bar from a color perspective)
![image](https://user-images.githubusercontent.com/35349680/157507034-fec5d1c0-2826-4deb-93ff-239a5889f54e.png)

3) Fixed spacing
![image](https://user-images.githubusercontent.com/35349680/156231962-045e3533-2e64-4322-b541-0446c791b2c7.png)


- Old (starting point before this PR)
![image](https://user-images.githubusercontent.com/35349680/142518244-a10c278b-5821-44a8-83cb-d10e07de9fda.png)

