### PR TITLE
Add next commands to cli output

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -119,9 +119,17 @@ class Analyzer:
         profiled_model_list = list(
             self._state_manager.get_state_variable(
                 'ResultManager.results').keys())
+
+        num_profiled_configs = sum([
+            len(x) for x in self._state_manager.get_state_variable(
+                'ResultManager.results').values()
+        ])
         logger.info(
-            f"Finished profiling. Obtained measurements for models: {profiled_model_list}."
-        )
+            f"Profile complete. Profiled {num_profiled_configs} configurations "
+            f"for models: {profiled_model_list}. To analyze the profile "
+            f"results and find the best configurations, please run "
+            f"`model-analyzer analyze --analysis-models "
+            f"{','.join(profiled_model_list)}`.")
 
     def analyze(self, mode, quiet):
         """
@@ -164,6 +172,16 @@ class Analyzer:
         self._result_manager.export_results()
         if not quiet:
             self._result_manager.write_results()
+
+        top_3_model_config_names = [
+            x.model_config().get_config()['name']
+            for x in self._result_manager.top_n_results(n=3)
+        ]
+        logger.info(f"Run `model-analyzer report --report-model-configs "
+                    f"{','.join(top_3_model_config_names)} -e "
+                    f"{self._config.export_path}` to generate detailed reports "
+                    f"for the {len(top_3_model_config_names)} best "
+                    f"configurations.")
 
     def report(self, mode):
         """

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -119,17 +119,13 @@ class Analyzer:
         profiled_model_list = list(
             self._state_manager.get_state_variable(
                 'ResultManager.results').keys())
+        num_profiled_configs = self._get_num_profiled_configs()
 
-        num_profiled_configs = sum([
-            len(x) for x in self._state_manager.get_state_variable(
-                'ResultManager.results').values()
-        ])
-        logger.info(
-            f"Profile complete. Profiled {num_profiled_configs} configurations "
-            f"for models: {profiled_model_list}. To analyze the profile "
-            f"results and find the best configurations, please run "
-            f"`model-analyzer analyze --analysis-models "
-            f"{','.join(profiled_model_list)}`.")
+        logger.info(f"Profile complete. Profiled {num_profiled_configs} "
+                    f"configurations for models: {profiled_model_list}.")
+        logger.info(f"To analyze the profile results and find the best "
+                    f"configurations, please run `model-analyzer analyze "
+                    f"--analysis-models {','.join(profiled_model_list)}`.")
 
     def analyze(self, mode, quiet):
         """
@@ -173,15 +169,12 @@ class Analyzer:
         if not quiet:
             self._result_manager.write_results()
 
-        top_3_model_config_names = [
-            x.model_config().get_config()['name']
-            for x in self._result_manager.top_n_results(n=3)
-        ]
-        logger.info(f"Run `model-analyzer report --report-model-configs "
+        top_3_model_config_names = self._get_top_3_model_config_names()
+        logger.info(f"To generate detailed reports for the "
+                    f"{len(top_3_model_config_names)} best configurations, run "
+                    f"`model-analyzer report --report-model-configs "
                     f"{','.join(top_3_model_config_names)} -e "
-                    f"{self._config.export_path}` to generate detailed reports "
-                    f"for the {len(top_3_model_config_names)} best "
-                    f"configurations.")
+                    f"{self._config.export_path}`")
 
     def report(self, mode):
         """
@@ -212,3 +205,15 @@ class Analyzer:
 
         self._report_manager.create_detailed_reports()
         self._report_manager.export_detailed_reports()
+
+    def _get_num_profiled_configs(self):
+        return sum([
+            len(x) for x in self._state_manager.get_state_variable(
+                'ResultManager.results').values()
+        ])
+
+    def _get_top_3_model_config_names(self):
+        return [
+            x.model_config().get_config()['name']
+            for x in self._result_manager.top_n_results(n=3)
+        ]

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -24,6 +24,8 @@ from .config.input.config_command_report \
     import ConfigCommandReport
 from .config.input.config_command_profile \
     import ConfigCommandProfile
+from .config.input.config_defaults import \
+    DEFAULT_CHECKPOINT_DIRECTORY
 from .model_analyzer_exceptions \
     import TritonModelAnalyzerException
 
@@ -116,16 +118,8 @@ class Analyzer:
             finally:
                 self._state_manager.save_checkpoint()
 
-        profiled_model_list = list(
-            self._state_manager.get_state_variable(
-                'ResultManager.results').keys())
-        num_profiled_configs = self._get_num_profiled_configs()
-
-        logger.info(f"Profile complete. Profiled {num_profiled_configs} "
-                    f"configurations for models: {profiled_model_list}.")
-        logger.info(f"To analyze the profile results and find the best "
-                    f"configurations, please run `model-analyzer analyze "
-                    f"--analysis-models {','.join(profiled_model_list)}`.")
+        logger.info(self._get_profile_complete_string())
+        logger.info(self._get_analyze_command_help_string())
 
     def analyze(self, mode, quiet):
         """
@@ -169,12 +163,7 @@ class Analyzer:
         if not quiet:
             self._result_manager.write_results()
 
-        top_3_model_config_names = self._get_top_3_model_config_names()
-        logger.info(f"To generate detailed reports for the "
-                    f"{len(top_3_model_config_names)} best configurations, run "
-                    f"`model-analyzer report --report-model-configs "
-                    f"{','.join(top_3_model_config_names)} -e "
-                    f"{self._config.export_path}`")
+        logger.info(self._get_report_command_help_string())
 
     def report(self, mode):
         """
@@ -206,14 +195,73 @@ class Analyzer:
         self._report_manager.create_detailed_reports()
         self._report_manager.export_detailed_reports()
 
+    def _get_profile_complete_string(self):
+        profiled_model_list = list(
+            self._state_manager.get_state_variable(
+                'ResultManager.results').keys())
+        num_profiled_configs = self._get_num_profiled_configs()
+
+        return (f'Profile complete. Profiled {num_profiled_configs} '
+                f'configurations for models: {profiled_model_list}.')
+
     def _get_num_profiled_configs(self):
         return sum([
             len(x) for x in self._state_manager.get_state_variable(
                 'ResultManager.results').values()
         ])
 
-    def _get_top_3_model_config_names(self):
+    def _get_analyze_command_help_string(self):
+        return (f'To analyze the profile results and find the best '
+                f'configurations, run `{self._get_analyze_command_string()}`')
+
+    def _get_analyze_command_string(self):
+        profiled_model_list = list(
+            self._state_manager.get_state_variable(
+                'ResultManager.results').keys())
+
+        analyze_command_string = (f'model-analyzer analyze --analysis-models '
+                                  f'{",".join(profiled_model_list)}')
+
+        if self._config.config_file is not None:
+            analyze_command_string += (f' --config_file '
+                                       f'{self._config.config_file}')
+
+        if self._config.checkpoint_directory != DEFAULT_CHECKPOINT_DIRECTORY:
+            analyze_command_string += (f' --checkpoint-directory '
+                                       f'{self._config.checkpoint_directory}')
+
+        return analyze_command_string
+
+    def _get_report_command_help_string(self):
+        top_3_model_config_names = self._get_top_n_model_config_names(n=3)
+
+        return (f'To generate detailed reports for the '
+                f'{len(top_3_model_config_names)} best configurations, run '
+                f'`{self._get_report_command_string()}`')
+
+    def _get_report_command_string(self):
+        top_3_model_config_names = self._get_top_n_model_config_names(n=3)
+
+        report_command_string = (f'model-analyzer report '
+                                 f'--report-model-configs '
+                                 f'{",".join(top_3_model_config_names)}')
+
+        if self._config.export_path is not None:
+            report_command_string += (f' --export-path '
+                                      f'{self._config.export_path}')
+
+        if self._config.config_file is not None:
+            report_command_string += (f' --config-file '
+                                      f'{self._config.config_file}')
+
+        if self._config.checkpoint_directory != DEFAULT_CHECKPOINT_DIRECTORY:
+            report_command_string += (f' --checkpoint-directory '
+                                      f'{self._config.checkpoint_directory}')
+
+        return report_command_string
+
+    def _get_top_n_model_config_names(self, n=-1):
         return [
             x.model_config().get_config()['name']
-            for x in self._result_manager.top_n_results(n=3)
+            for x in self._result_manager.top_n_results(n=n)
         ]

--- a/qa/L0_custom_ops/test.sh
+++ b/qa/L0_custom_ops/test.sh
@@ -101,7 +101,7 @@ for CONFIG_FILE in ${LIST_OF_CONFIG_FILES[@]}; do
         fi
         ((WAIT_TIME_SECS--));
     done
-    if [[ -z `grep "Finished profiling" $ANALYZER_LOG` ]]; then
+    if [[ -z `grep "Profile complete" $ANALYZER_LOG` ]]; then
         echo -e "\n***\n*** Test Failed. model-analyzer hangs. \n***"
         cat $ANALYZER_LOG
         RET=1

--- a/qa/L0_custom_ops/test.sh
+++ b/qa/L0_custom_ops/test.sh
@@ -84,7 +84,7 @@ for CONFIG_FILE in ${LIST_OF_CONFIG_FILES[@]}; do
             cat $ANALYZER_LOG
             RET=1
             break
-        elif [[ ! -z `grep "Finished profiling" $ANALYZER_LOG` ]]; then
+        elif [[ ! -z `grep "Profile complete" $ANALYZER_LOG` ]]; then
             break
         # In the docker/local launch modes, triton log errors will be returned by triton client and printed in ANALYZER_LOG
         elif [[ ! -z `grep "This op may not exist or may not be currently supported" $ANALYZER_LOG` ]]; then

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+from model_analyzer.analyzer import Analyzer
+from model_analyzer.cli.cli import CLI
+from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from model_analyzer.result.model_result import ModelResult
+from model_analyzer.state.analyzer_state_manager import AnalyzerStateManager
+from model_analyzer.triton.model.model_config import ModelConfig
+
+from google.protobuf import json_format
+from tritonclient.grpc import model_config_pb2
+
+from .common import test_result_collector as trc
+
+from .mocks.mock_config import MockConfig
+
+
+class TestAnalyzer(trc.TestResultCollector):
+    """
+    Tests the methods of the Analyzer class
+    """
+
+    def _evaluate_config(self, args, yaml_content):
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = ConfigCommandProfile()
+        cli = CLI()
+        cli.add_subcommand(
+            cmd='profile',
+            help=
+            'Run model inference profiling based on specified CLI or config options.',
+            config=config)
+        cli.parse()
+        mock_config.stop()
+        return config
+
+    def mock_get_state_variable(self, name):
+        return {
+            'model': {
+                'config1': None,
+                'config2': None,
+                'config3': None,
+                'config4': None
+            }
+        }
+
+    @patch(
+        'model_analyzer.state.analyzer_state_manager.AnalyzerStateManager.get_state_variable',
+        mock_get_state_variable)
+    def test_get_num_profiled_configs(self):
+        """
+        Tests that the member function returning the number of profiled configs
+        works correctly.
+        """
+
+        args = [
+            "model-analyzer", "profile", "--model-repository", "/tmp",
+            "--profile-models", "test"
+        ]
+        config = self._evaluate_config(args, '')
+        state_manager = AnalyzerStateManager(config, None)
+        analyzer = Analyzer(config, None, state_manager)
+        self.assertEqual(analyzer._get_num_profiled_configs(), 4)
+
+    def mock_top_n_results(self, model_name=None, n=-1):
+        return [
+            ModelResult(
+                None,
+                ModelConfig(
+                    json_format.ParseDict({'name': 'config1'},
+                                          model_config_pb2.ModelConfig())),
+                None),
+            ModelResult(
+                None,
+                ModelConfig(
+                    json_format.ParseDict({'name': 'config3'},
+                                          model_config_pb2.ModelConfig())),
+                None),
+            ModelResult(
+                None,
+                ModelConfig(
+                    json_format.ParseDict({'name': 'config4'},
+                                          model_config_pb2.ModelConfig())),
+                None)
+        ]
+
+    @patch('model_analyzer.result.result_manager.ResultManager.top_n_results',
+           mock_top_n_results)
+    def test_get_top_3_model_config_names(self):
+        """
+        Tests that the member function returning the top 3 model config names
+        works correctly.
+        """
+
+        args = [
+            "model-analyzer", "profile", "--model-repository", "/tmp",
+            "--profile-models", "test"
+        ]
+        config = self._evaluate_config(args, '')
+        state_manager = AnalyzerStateManager(config, None)
+        analyzer = Analyzer(config, None, state_manager)
+        self.assertEqual(analyzer._get_top_3_model_config_names(),
+                         ['config1', 'config3', 'config4'])


### PR DESCRIPTION
This PR adds suggestions to the user on what command to run next after both the `profile` and `analyze` commands

i.e.
* after `profile` command is run, the `analyze` command is pre-created and output to the user in the shell for them to copy and paste/run
* after `analyze` command is run, the `report` command is given