### PR TITLE
Always run default config

### DIFF
--- a/model_analyzer/config/run/run_config_generator.py
+++ b/model_analyzer/config/run/run_config_generator.py
@@ -147,6 +147,7 @@ class RunConfigGenerator:
         specified list of configs
         """
 
+        return False  # FIXME
         found = False
         for config in configs:
             if config is None:

--- a/model_analyzer/config/run/run_config_generator.py
+++ b/model_analyzer/config/run/run_config_generator.py
@@ -137,36 +137,8 @@ class RunConfigGenerator:
 
     def generate_model_config_combinations(self, value):
         configs = self._generate_model_config_combinations_helper(value)
-        if not self._default_config_in_configs(configs):
-            self._add_default_config(configs)
+        self._add_default_config(configs)
         return configs
-
-    def _default_config_in_configs(self, configs):
-        """ 
-        Returns true if a default configuration exists within the
-        specified list of configs
-        """
-
-        return False  # FIXME
-        found = False
-        for config in configs:
-            if config is None:
-                found = True
-                break
-
-            default_dynamic_batching_found = config.get(
-                "dynamic_batching") is None
-
-            instances = None
-            instance_group = config.get("instance_group")
-            if instance_group is not None:
-                instances = instance_group[0]["count"]
-            default_instances_found = instances is None or instances == 1
-
-            if default_instances_found and default_dynamic_batching_found:
-                found = True
-                break
-        return found
 
     def _add_default_config(self, configs):
         # Add in an empty configuration, which will apply the default values

--- a/model_analyzer/config/run/run_config_generator.py
+++ b/model_analyzer/config/run/run_config_generator.py
@@ -113,8 +113,6 @@ class RunConfigGenerator:
 
             model_name_index = self._model_name_index
             model_config_dict = model_config.get_config()
-            self._apply_model_config_defaults(model_config_dict,
-                                              model_config.cpu_only())
 
             try:
                 model_name_index = self._model_configs.index(model_config_dict)
@@ -136,21 +134,6 @@ class RunConfigGenerator:
                 self._run_configs.append(
                     RunConfig(model.model_name(), model_config, perf_config,
                               model.triton_server_environment()))
-
-    def _apply_model_config_defaults(self, config_dict, cpu_only):
-        if "instance_group" not in config_dict:
-            config_dict["instance_group"] = [{}]
-        for instance_group in config_dict["instance_group"]:
-            self._apply_instance_group_defaults(instance_group, cpu_only)
-
-    def _apply_instance_group_defaults(self, instance_group, cpu_only):
-        if "count" not in instance_group:
-            instance_group["count"] = 1
-        if "kind" not in instance_group:
-            if cpu_only:
-                instance_group["kind"] = "KIND_CPU"
-            else:
-                instance_group["kind"] = "KIND_GPU"
 
     def generate_model_config_combinations(self, value):
         configs = self._generate_model_config_combinations_helper(value)

--- a/model_analyzer/config/run/run_config_generator.py
+++ b/model_analyzer/config/run/run_config_generator.py
@@ -147,18 +147,18 @@ class RunConfigGenerator:
         if "count" not in instance_group:
             instance_group["count"] = 1
         if "kind" not in instance_group:
-            if (cpu_only):
+            if cpu_only:
                 instance_group["kind"] = "KIND_CPU"
             else:
                 instance_group["kind"] = "KIND_GPU"
 
     def generate_model_config_combinations(self, value):
         configs = self._generate_model_config_combinations_helper(value)
-        if not self._default_config_in_configs(configs):
+        if not self._is_default_config_in_configs(configs):
             self._add_default_config(configs)
         return configs
 
-    def _default_config_in_configs(self, configs):
+    def _is_default_config_in_configs(self, configs):
         return None in configs
 
     def _add_default_config(self, configs):

--- a/qa/L0_config/config_generator.py
+++ b/qa/L0_config/config_generator.py
@@ -68,7 +68,8 @@ def _get_sweep_configs(profile_models):
             } for model in profile_models
         },
     }
-    model_config['total_param'] = 4
+    # total_param=5 because the default config will also be generated
+    model_config['total_param'] = 5
     sweep_configs.append(model_config)
     return sweep_configs
 

--- a/qa/L0_config/config_generator.py
+++ b/qa/L0_config/config_generator.py
@@ -33,7 +33,8 @@ def _get_sweep_configs(profile_models):
             } for model in profile_models
         },
     }
-    model_config['total_param'] = 4
+    # total_param=5 because the default config will also be generated
+    model_config['total_param'] = 5
     sweep_configs.append(model_config)
 
     model_config = {
@@ -51,7 +52,8 @@ def _get_sweep_configs(profile_models):
             } for model in profile_models
         },
     }
-    model_config['total_param'] = 4
+    # total_param=5 because the default config will also be generated
+    model_config['total_param'] = 5
     sweep_configs.append(model_config)
 
     model_config = {

--- a/qa/L0_config_search/test_config_generator.py
+++ b/qa/L0_config_search/test_config_generator.py
@@ -64,7 +64,7 @@ class TestConfigGenerator:
                 } for model in self.profile_models
             }
         }
-        self._write_file(2, 1, 2, 1, model_config)
+        self._write_file(3, 1, 2, 1, model_config)
 
     def generate_max_limit_with_model_config(self):
         model_config = {
@@ -82,7 +82,7 @@ class TestConfigGenerator:
                 } for model in self.profile_models
             },
         }
-        self._write_file(4, 2, 2, 1, model_config)
+        self._write_file(6, 2, 2, 1, model_config)
 
     def generate_max_limit(self):
         model_config = {
@@ -91,7 +91,7 @@ class TestConfigGenerator:
             "run_config_search_max_preferred_batch_size": 2,
             "profile_models": self.profile_models,
         }
-        self._write_file(16, 2, 8, 1, model_config)
+        self._write_file(18, 2, 8, 1, model_config)
 
     def generate_max_limit_with_param(self):
         model_config = {
@@ -106,7 +106,7 @@ class TestConfigGenerator:
                 } for model in self.profile_models
             },
         }
-        self._write_file(6, 1, 6, 1, model_config)
+        self._write_file(7, 1, 6, 1, model_config)
 
     def generate_max_limit_with_param_and_model_config(self):
         model_config = {
@@ -127,7 +127,7 @@ class TestConfigGenerator:
                 } for model in self.profile_models
             },
         }
-        self._write_file(2, 1, 2, 1, model_config)
+        self._write_file(3, 1, 2, 1, model_config)
 
     def generate_max_limit_with_dynamic_batch_disable(self):
         model_config = {
@@ -136,7 +136,7 @@ class TestConfigGenerator:
             "run_config_search_preferred_batch_size_disable": True,
             "profile_models": self.profile_models,
         }
-        self._write_file(4, 2, 4, 1, model_config)
+        self._write_file(5, 2, 4, 1, model_config)
 
     def _write_file(self, total_param, total_param_remote, total_models,
                     total_models_remote, model_config):

--- a/qa/L0_config_search/test_config_generator.py
+++ b/qa/L0_config_search/test_config_generator.py
@@ -136,7 +136,7 @@ class TestConfigGenerator:
             "run_config_search_preferred_batch_size_disable": True,
             "profile_models": self.profile_models,
         }
-        self._write_file(5, 2, 4, 1, model_config)
+        self._write_file(6, 2, 4, 1, model_config)
 
     def _write_file(self, total_param, total_param_remote, total_models,
                     total_models_remote, model_config):

--- a/qa/L0_metrics/test.sh
+++ b/qa/L0_metrics/test.sh
@@ -88,13 +88,16 @@ for config in ${LIST_OF_CONFIG_FILES[@]}; do
             METRICS_NUM_COLUMNS=`cat $METRICS_NUM_COLUMNS_FILE`
             INFERENCE_NUM_COLUMNS=`cat $INFERENCE_NUM_COLUMNS_FILE`
             SERVER_METRICS_NUM_COLUMNS=`cat $SERVER_NUM_COLUMNS_FILE`
+            INFERENCE_NUM_ROWS=2 # normal run + default config
+            METRICS_NUM_ROWS=$((${INFERENCE_NUM_ROWS} * ${#GPUS[@]}))
+            SERVER_NUM_ROWS=$((1 * ${#GPUS[@]}))
 
             check_table_row_column \
                 $ANALYZER_LOG $ANALYZER_LOG $ANALYZER_LOG \
                 $MODEL_METRICS_INFERENCE_FILE $MODEL_METRICS_GPU_FILE $SERVER_METRICS_FILE \
-                $INFERENCE_NUM_COLUMNS 1 \
-                $METRICS_NUM_COLUMNS $((1 * ${#GPUS[@]})) \
-                $SERVER_METRICS_NUM_COLUMNS $((1 * ${#GPUS[@]}))
+                $INFERENCE_NUM_COLUMNS $INFERENCE_NUM_ROWS \
+                $METRICS_NUM_COLUMNS $METRICS_NUM_ROWS \
+                $SERVER_METRICS_NUM_COLUMNS $SERVER_NUM_ROWS
             if [ $? -ne 0 ]; then
                 echo -e "\n***\n*** Test Output Verification Failed.\n***"
                 cat $ANALYZER_LOG

--- a/tests/mocks/mock_config.py
+++ b/tests/mocks/mock_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .mock_base import MockBase
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 
 
 class MockConfig(MockBase):
@@ -29,3 +29,4 @@ class MockConfig(MockBase):
         patchers.append(
             patch("builtins.open", mock_open(read_data=self.yaml_file_content)))
         patchers.append(patch("sys.argv", self.args))
+        patchers.append(patch('numba.cuda.is_available', MagicMock(True)))

--- a/tests/mocks/mock_run_configs.py
+++ b/tests/mocks/mock_run_configs.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+
+class MockRunConfig():
+    """ 
+    Mock class that only contains the important values from the model_config and
+    perf_config from a RunConfig object
+    """
+
+    def load_from_run_config(self, run_config):
+        """ Populate from a RunConfig object """
+        model_config = run_config.model_config().get_config()
+        perf_config = run_config.perf_config()
+        self._load_from_model_and_perf_config(model_config, perf_config)
+
+    def load_from_dict(self, dict):
+        """ Populate from a dictionary """
+        self._config = dict
+
+    def get_config_tuple(self):
+        """ 
+        Convert and return the data from a dict into a tuple 
+        of (key,value,key,value,...) where the keys are in a
+        sorted order
+        """
+        list_of_key_value_pairs = [(y, self._config[y])
+                                   for y in sorted(self._config.keys())
+                                   if self._config[y] != None]
+        out_tuple = tuple(item for x in list_of_key_value_pairs for item in x)
+        return out_tuple
+
+    def _load_from_model_and_perf_config(self, model_config, perf_config):
+        """
+        Given a model configuration and perf configuration, extract and store
+        the key bits of information
+        """
+        max_batch_size = None
+        if model_config.get("max_batch_size") is not None:
+            max_batch_size = model_config["max_batch_size"]
+
+        instances = None
+        kind = None
+        if model_config.get("instance_group") is not None:
+            instances = model_config["instance_group"][0]["count"]
+            kind = model_config["instance_group"][0]["kind"]
+
+        dynamic_batching = None
+        max_queue_delay = None
+        if model_config.get("dynamic_batching") is not None:
+            dynamic_batching = model_config["dynamic_batching"].get(
+                "preferred_batch_size", [0])[0]
+            max_queue_delay = model_config["dynamic_batching"].get(
+                "max_queue_delay_microseconds")
+
+        batch_size = perf_config.__getitem__("batch-size")
+        concurrency = perf_config.__getitem__("concurrency-range")
+
+        self._config = {
+            'kind': kind,
+            'batch_sizes': batch_size,
+            'batching': dynamic_batching,
+            'concurrency': concurrency,
+            'instances': instances,
+            'max_batch_size': max_batch_size,
+            'max_queue_delay': max_queue_delay
+        }
+
+
+class MockRunConfigs():
+    """
+    This class holds a list of MockRunConfig
+    """
+
+    def __init__(self):
+        self._configs = []
+
+    def get_configs_set(self):
+        configs_set = {config.get_config_tuple() for config in self._configs}
+        return configs_set
+
+    def add_from_run_config(self, config):
+        """ Add a single config from a RunConfig """
+
+        mock_run_config = MockRunConfig()
+        mock_run_config.load_from_run_config(config)
+        self._configs.append(mock_run_config)
+
+    def add_from_dict(self, config):
+        """ Add a single config from a dict """
+
+        mock_run_config = MockRunConfig()
+        mock_run_config.load_from_dict(config)
+        self._configs.append(mock_run_config)
+
+    def populate_from_ranges(self, ranges):
+        """
+        Given a dict of key-to-list, create the set of run_configs based on 
+        the full cartesian product of each dict in the list
+
+        For example, passing in
+        [{ A: [1,2], B: [3,4], C:[0] },  { A: [5], B: [8,9], C: [10] }]
+        would create configs with the following values:
+          - A=1, B=3, C=0
+          - A=1, B=4, C=0
+          - A=2, B=3, C=0
+          - A=2, B=4, C=0
+          - A=5, B=8, C=10
+          - A=5, B=9, C=10
+        """
+        for ranges_dict in ranges:
+            ranges_keys = list(sorted(ranges_dict.keys()))
+            value_lists = []
+            for key in ranges_keys:
+                value_lists.append(ranges_dict[key])
+            configs = list(itertools.product(*value_lists))
+
+            for value in configs:
+                config_dict = {
+                    ranges_keys[i]: value[i] for i in range(len(ranges_keys))
+                }
+                self.add_from_dict(config_dict)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from .common import test_result_collector as trc
 
 from .mocks.mock_config import MockConfig
@@ -36,17 +35,18 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 
-
 class ModelManagerSubclass(ModelManager):
     """ 
     Overrides execute_run_configs() to gather a list of tuples that contain 
     the main values of each 'executed' run_config
     """
 
-    def __init__(self, config, client, server, metrics_manager, result_manager, state_manager):
-        super().__init__(config, client, server, metrics_manager, result_manager, state_manager)
+    def __init__(self, config, client, server, metrics_manager, result_manager,
+                 state_manager):
+        super().__init__(config, client, server, metrics_manager,
+                         result_manager, state_manager)
         self._configs = []
-    
+
     def _execute_run_configs(self):
         while self._run_config_generator.run_configs():
             config = self._run_config_generator.next_config()
@@ -59,18 +59,21 @@ class ModelManagerSubclass(ModelManager):
 
             dynamic_batching = None
             if model_config.get("dynamicBatching") is not None:
-                dynamic_batching = model_config["dynamicBatching"].get("preferredBatchSize", [0])[0]
+                dynamic_batching = model_config["dynamicBatching"].get(
+                    "preferredBatchSize", [0])[0]
 
             batch_size = perf_config.__getitem__("batch-size")
             concurrency = perf_config.__getitem__("concurrency-range")
 
-            self._configs.append((instances, dynamic_batching, batch_size, concurrency))
+            self._configs.append(
+                (instances, dynamic_batching, batch_size, concurrency))
 
     def get_run_configs(self):
         return self._configs
 
 
-@patch('model_analyzer.config.run.run_search.RunSearch.add_measurements', MagicMock())
+@patch('model_analyzer.config.run.run_search.RunSearch.add_measurements',
+       MagicMock())
 class TestModelManager(trc.TestResultCollector):
 
     def test_full_sweep(self):
@@ -78,10 +81,10 @@ class TestModelManager(trc.TestResultCollector):
         Test a normal full sweep of options
         """
 
-        expected_instances = [1,2,3,4,5]
-        expected_batching = [None,0,1,2,4,8,16]
+        expected_instances = [1, 2, 3, 4, 5]
+        expected_batching = [None, 0, 1, 2, 4, 8, 16]
         expected_batch_sizes = [1]
-        expected_concurrency = [1,2,4,8,16,32,64,128]
+        expected_concurrency = [1, 2, 4, 8, 16, 32, 64, 128]
 
         yaml_content = """
             run_config_search_max_concurrency: 128
@@ -89,21 +92,23 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_max_instance_count: 5
             run_config_search_preferred_batch_size_disable : False
             run_config_search_disable: False
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def test_another_full_sweep(self):
         """
         Test another full sweep of options
         """
 
-        expected_instances = [1,2,3,4,5,6,7]
-        expected_batching = [None,0,1,2,4,8]
+        expected_instances = [1, 2, 3, 4, 5, 6, 7]
+        expected_batching = [None, 0, 1, 2, 4, 8]
         expected_batch_sizes = [1]
-        expected_concurrency = [1,2,4,8,16,32]
+        expected_concurrency = [1, 2, 4, 8, 16, 32]
 
         yaml_content = """
             run_config_search_max_concurrency: 32
@@ -111,21 +116,23 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_max_instance_count: 7
             run_config_search_preferred_batch_size_disable : False
             run_config_search_disable: False
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def test_preferred_batch_size_disable(self):
         """
         Test with search_preferred_batch_size_disable=True
         """
 
-        expected_instances = [1,2,3,4,5,6,7]
+        expected_instances = [1, 2, 3, 4, 5, 6, 7]
         expected_batching = [None]
         expected_batch_sizes = [1]
-        expected_concurrency = [1,2,4,8,16,32]
+        expected_concurrency = [1, 2, 4, 8, 16, 32]
 
         yaml_content = """
             run_config_search_max_concurrency: 32
@@ -133,11 +140,13 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_max_instance_count: 7
             run_config_search_preferred_batch_size_disable : True
             run_config_search_disable: False
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def test_run_search_disable(self):
         """
@@ -157,22 +166,23 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_max_instance_count: 7
             run_config_search_preferred_batch_size_disable : False
             run_config_search_disable: True
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def test_manual_concurrency(self):
         """
         Test with manually specified concurrencies
         """
 
-        expected_instances = [1,2,3,4,5,6,7]
-        expected_batching = [None,0,1,2,4,8]
+        expected_instances = [1, 2, 3, 4, 5, 6, 7]
+        expected_batching = [None, 0, 1, 2, 4, 8]
         expected_batch_sizes = [1]
-        expected_concurrency = [5,7]
-
+        expected_concurrency = [5, 7]
 
         yaml_content = """
             run_config_search_max_concurrency: 32
@@ -181,11 +191,13 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_preferred_batch_size_disable : False
             run_config_search_disable: False
             concurrency: [5, 7]
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def test_remote_mode(self):
         """
@@ -197,7 +209,7 @@ class TestModelManager(trc.TestResultCollector):
         expected_instances = [None]
         expected_batching = [None]
         expected_batch_sizes = [1]
-        expected_concurrency = [1,2,4,8,16,32,64,128,256,512]
+        expected_concurrency = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 
         yaml_content = """
             run_config_search_max_concurrency: 512
@@ -206,22 +218,23 @@ class TestModelManager(trc.TestResultCollector):
             run_config_search_preferred_batch_size_disable : False
             run_config_search_disable: False
             triton_launch_mode: remote            
-            """   
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
-
 
     def test_manual_parameters(self):
         """
         Test with manually specified concurrencies and batch sizes
         """
 
-        expected_instances = [1,2,3,4,5,6,7]
+        expected_instances = [1, 2, 3, 4, 5, 6, 7]
         expected_batching = [None, 0, 1, 2, 4, 8]
-        expected_batch_sizes = [1,2,3]
-        expected_concurrency = [2,10,18,26,34,42,50,58]
+        expected_batch_sizes = [1, 2, 3]
+        expected_concurrency = [2, 10, 18, 26, 34, 42, 50, 58]
 
         yaml_content = """
             run_config_search_max_concurrency: 512
@@ -233,12 +246,14 @@ class TestModelManager(trc.TestResultCollector):
                 start: 2
                 stop: 64
                 step: 8
-            batch_sizes: 1,2,3          
-            """   
+            batch_sizes: 1,2,3     
+            """
 
-        expected_values = [expected_instances, expected_batching, expected_batch_sizes, expected_concurrency]
+        expected_values = [
+            expected_instances, expected_batching, expected_batch_sizes,
+            expected_concurrency
+        ]
         self._test_model_manager(yaml_content, expected_values)
-
 
     def _test_model_manager(self, yaml_content, expected_values):
         """ 
@@ -254,19 +269,20 @@ class TestModelManager(trc.TestResultCollector):
 
         config = self._evaluate_config(args, yaml_content)
         state_manager = AnalyzerStateManager(config, MagicMock())
-        model_manager = ModelManagerSubclass(config, MagicMock(), MagicMock(), MagicMock(), MagicMock(), state_manager)
+        model_manager = ModelManagerSubclass(config, MagicMock(), MagicMock(),
+                                             MagicMock(), MagicMock(),
+                                             state_manager)
 
         model_manager.run_model(config.profile_models[0])
 
         run_configs = model_manager.get_run_configs()
         run_configs_set = set(run_configs)
-        
+
         expected_set = set(itertools.product(*expected_values))
 
         # Confirm that the full set of configs is exactly the same as expected
         #
         self.assertEqual(expected_set, run_configs_set)
-
 
     def _evaluate_config(self, args, yaml_content):
         """ Parse the given yaml_content into a config and return it """
@@ -282,13 +298,12 @@ class TestModelManager(trc.TestResultCollector):
             config=config)
         cli.parse()
         mock_config.stop()
-        return config    
+        return config
 
     def setUp(self):
-        # Use mock model config or else TritonModelAnalyzerException will be thrown as it tries to read from disc
+        # Use mock model config or else TritonModelAnalyzerException will be thrown as it tries to read from disk
         self.mock_model_config = MockModelConfig()
         self.mock_model_config.start()
 
     def tearDown(self):
         self.mock_model_config.stop()
-

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -395,14 +395,18 @@ class TestModelManager(trc.TestResultCollector):
                          expected_configs.get_configs())
 
     def _default_config_in_run_configs(self, run_configs):
-            for config in run_configs.get_configs():
-                config_dict = {config[i]:config[i+1] for i in range (0, len(config), 2)}
+        """ Returns true if a default configuration is within the passed in run_configs. Else returns false """
 
-                # Config is "default" if instances is unspecified or 1, and dynamic_batching is off
-                if config_dict.get("instances") is None or 1 and config_dict.get("dynamic_batching") is None:
-                    return True
-            return False
+        for config in run_configs.get_configs():
+            config_dict = {
+                config[i]: config[i + 1] for i in range(0, len(config), 2)
+            }
 
+            # Config is "default" if instances is unspecified or 1, and dynamic_batching is off
+            if config_dict.get("instances") is None or 1 and config_dict.get(
+                    "dynamic_batching") is None:
+                return True
+        return False
 
     def _evaluate_config(self, args, yaml_content):
         """ Parse the given yaml_content into a config and return it """

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -24,15 +24,12 @@ from model_analyzer.config.input.config_command_profile import ConfigCommandProf
 from model_analyzer.config.run.run_search import RunSearch
 from model_analyzer.config.run.run_config_generator import RunConfigGenerator
 from model_analyzer.constants import LOGGER_NAME
-from model_analyzer.model_analyzer_exceptions \
-    import TritonModelAnalyzerException
 from model_analyzer.model_manager import ModelManager
 from model_analyzer.state.analyzer_state_manager import AnalyzerStateManager
 
 import itertools
 import logging
 import sys
-from copy import deepcopy
 
 from unittest.mock import MagicMock
 from unittest.mock import patch

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -390,8 +390,19 @@ class TestModelManager(trc.TestResultCollector):
         run_configs = model_manager.get_run_configs()
         expected_configs = self._convert_ranges_to_run_configs(expected_ranges)
 
+        self.assertTrue(self._default_config_in_run_configs(run_configs))
         self.assertEqual(run_configs.get_configs(),
                          expected_configs.get_configs())
+
+    def _default_config_in_run_configs(self, run_configs):
+            for config in run_configs.get_configs():
+                config_dict = {config[i]:config[i+1] for i in range (0, len(config), 2)}
+
+                # Config is "default" if instances is unspecified or 1, and dynamic_batching is off
+                if config_dict.get("instances") is None or 1 and config_dict.get("dynamic_batching") is None:
+                    return True
+            return False
+
 
     def _evaluate_config(self, args, yaml_content):
         """ Parse the given yaml_content into a config and return it """

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -41,10 +41,10 @@ class TestRecordAggregatorMethods(trc.TestResultCollector):
         self.less_is_better_types = {
             record_types[k] for k in [
                 'perf_latency_avg', 'perf_latency_p90', 'perf_latency_p95',
-                'perf_latency_p99', 'gpu_used_memory', 'cpu_used_ram', 
-                'perf_server_compute_infer', 'perf_latency', 
-                'perf_server_queue', 'perf_client_response_wait', 
-                'perf_server_compute_output', 'perf_client_send_recv', 
+                'perf_latency_p99', 'gpu_used_memory', 'cpu_used_ram',
+                'perf_server_compute_infer', 'perf_latency',
+                'perf_server_queue', 'perf_client_response_wait',
+                'perf_server_compute_output', 'perf_client_send_recv',
                 'perf_server_compute_input'
             ]
         }
@@ -62,7 +62,8 @@ class TestRecordAggregatorMethods(trc.TestResultCollector):
         total_count = len(self.all_record_types)
         less_is_better_count = len(self.less_is_better_types)
         more_is_better_count = len(self.more_is_better_types)
-        self.assertEqual(total_count, less_is_better_count + more_is_better_count)
+        self.assertEqual(total_count,
+                         less_is_better_count + more_is_better_count)
 
     def test_add(self):
         """

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -96,7 +96,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 1
             }]
-        }]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
         yaml_content = """
@@ -130,7 +130,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 1
             }]
-        }]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
         yaml_content = """
@@ -161,7 +161,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 1
             }]
-        }]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
         yaml_content = """
@@ -210,7 +210,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 3
             }]
-        }]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
         yaml_content = """
@@ -271,7 +271,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 1
             }]
-        }, {}]
+        }, None]
 
         self.assertEqual(expected_model_configs, model_configs)
 
@@ -329,7 +329,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_GPU',
                 'count': 1
             }]
-        }, {}]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
         # list under dynamic batching
@@ -428,7 +428,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 2
             }]
-        }, {}]
+        }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
     def test_generate_run_config_for_model_sweep(self):
@@ -479,7 +479,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                                   client=self.client)
         model_configs = run_config_generator.generate_model_config_combinations(
             config.profile_models[0].model_config_parameters())
-        self.assertEqual(len(model_configs), 2)
+        self.assertEqual(len(model_configs), 3)
         self.mock_client.set_model_config(
             {'config': {
                 'name': 'vgg_16_graphdef'
@@ -487,7 +487,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         for model_config in model_configs:
             run_config_generator.generate_run_config_for_model_sweep(
                 config.profile_models[0], model_config)
-        self.assertEqual(len(run_config_generator.run_configs()), 18)
+        self.assertEqual(len(run_config_generator.run_configs()), 27)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
                 'name'), 'vgg_16_graphdef')
@@ -540,11 +540,11 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                                   client=self.client)
         model_configs = run_config_generator.generate_model_config_combinations(
             config.profile_models[0].model_config_parameters())
-        self.assertEqual(len(model_configs), 2)
+        self.assertEqual(len(model_configs), 3)
         for model_config in model_configs:
             run_config_generator.generate_run_config_for_model_sweep(
                 config.profile_models[0], model_config)
-        self.assertEqual(len(run_config_generator.run_configs()), 18)
+        self.assertEqual(len(run_config_generator.run_configs()), 27)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
                 'name'), 'vgg_16_graphdef_i0')
@@ -574,7 +574,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                                   client=self.client)
         model_configs = run_config_generator.generate_model_config_combinations(
             config.profile_models[0].model_config_parameters())
-        self.assertEqual(len(model_configs), 10)
+        self.assertEqual(len(model_configs), 11)
         self.mock_client.set_model_config(
             {'config': {
                 'name': 'vgg_16_graphdef'
@@ -582,7 +582,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         for model_config in model_configs:
             run_config_generator.generate_run_config_for_model_sweep(
                 config.profile_models[0], model_config)
-        self.assertEqual(len(run_config_generator.run_configs()), 90)
+        self.assertEqual(len(run_config_generator.run_configs()), 99)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
                 'name'), 'vgg_16_graphdef_i0')

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -271,7 +271,8 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 1
             }]
-        }]
+        }, {}]
+
         self.assertEqual(expected_model_configs, model_configs)
 
         yaml_content = """
@@ -328,7 +329,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_GPU',
                 'count': 1
             }]
-        }]
+        }, {}]
         self.assertEqual(expected_model_configs, model_configs)
 
         # list under dynamic batching
@@ -354,7 +355,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                                   client=self.client)
         model_configs = run_config_generator.generate_model_config_combinations(
             config.profile_models[0].model_config_parameters())
-        self.assertEqual(len(model_configs), 8)
+        self.assertEqual(len(model_configs), 9)
         expected_model_configs = [{
             'dynamic_batching': {
                 'preferred_batch_size': [4, 8],
@@ -427,7 +428,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'kind': 'KIND_CPU',
                 'count': 2
             }]
-        }]
+        }, {}]
         self.assertEqual(expected_model_configs, model_configs)
 
     def test_generate_run_config_for_model_sweep(self):


### PR DESCRIPTION
Run the default config (the unmodified model_config passed to MA) on all MA profile runs.

Also updated test_model_manager tests to use a dict of expected values ranges instead of lists, and added many new tests to lock up the behavior.