### PR TITLE
Fix perf analyzer single shape non list arg usage

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -656,13 +656,16 @@ perf_analyzer_flags:
 The `input-data`, `shape`, and `streaming` perf_analyzer options are additive and can take either a single string (non-list) or a list of strings:
 
 ```yaml
-...
+model_repository: /path/to/model/repository/
+profile_models:
+  model_1:
+    parameters:
+        batch_sizes: 4
 perf_analyzer_flags:
   input-data: my-input-data-1
   shape:
-    - my-shape-1
-    - my-shape-2
-...
+    - INPUT0:1024,1024
+    - INPUT1:1024,1024
 ```
 
 **Important Notes**:

--- a/docs/config.md
+++ b/docs/config.md
@@ -653,6 +653,18 @@ perf_analyzer_flags:
     latency-report-file: /path/to/latency/report/file
 ```
 
+The `input-data`, `shape`, and `streaming` perf_analyzer options are additive and can take either a single string (non-list) or a list of strings:
+
+```yaml
+...
+perf_analyzer_flags:
+  input-data: my-input-data-1
+  shape:
+    - my-shape-1
+    - my-shape-2
+...
+```
+
 **Important Notes**:
 * When providing arguments under `perf_analyzer_flags`, you must use `-` instead
   of `_`. This casing is important and Model Analyzer will not recognize

--- a/model_analyzer/perf_analyzer/perf_config.py
+++ b/model_analyzer/perf_analyzer/perf_config.py
@@ -189,8 +189,11 @@ class PerfAnalyzerConfig:
         for key, value in self._args.items():
             if value:
                 if key in self._additive_args:
-                    for additive_value in value:
-                        args.append(f'--{key}={additive_value}')
+                    if type(value) is list:
+                        for additive_value in value:
+                            args.append(f'--{key}={additive_value}')
+                    elif type(value) is str:
+                        args.append(f'--{key}={value}')
                 else:
                     args.append(f'--{key}={value}')
 

--- a/model_analyzer/perf_analyzer/perf_config.py
+++ b/model_analyzer/perf_analyzer/perf_config.py
@@ -194,6 +194,10 @@ class PerfAnalyzerConfig:
                             args.append(f'--{key}={additive_value}')
                     elif type(value) is str:
                         args.append(f'--{key}={value}')
+                    else:
+                        raise TritonModelAnalyzerException(
+                            f"Unexpected type {type(value)} for perf_analyzer_flag {key}."
+                        )
                 else:
                     args.append(f'--{key}={value}')
 

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -125,6 +125,12 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         self.assertEqual(self.config['shape'], shape)
         self.assertEqual(self.config.to_cli_string(), expected_cli_str)
 
+        shape = 'name1:1,2,3'
+        expected_cli_str = '-m test_model --measurement-interval=1000 --shape=name1:1,2,3 --measurement-request-count=50'
+        self.config['shape'] = shape
+
+        self.assertEqual(self.config.to_cli_string(), expected_cli_str)
+
     def test_run(self):
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -131,6 +131,12 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
 
         self.assertEqual(self.config.to_cli_string(), expected_cli_str)
 
+        shape = 5
+        self.config['shape'] = shape
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self.config.to_cli_string()
+
     def test_run(self):
         server_config = TritonServerConfig()
         server_config['model-repository'] = MODEL_REPOSITORY_PATH


### PR DESCRIPTION
`perf_analyzer_flags` `shape` option of model analyzer config currently supports list of strings, but not a non-list single string. It should support a non-list single string. This PR adds that support

Example of list of strings (supported before and after PR--unaffected):
```
# config.yml
...
perf_analyzer_flags:
  shape:
    - INPUT0:2
    - INPUT1:2
...
```

Example of non-list single string (not supported before PR, supported after PR):
```
# config.yml
...
perf_analyzer_flags:
  shape: INPUT0:2
...
```