### PR TITLE
Link subsequent model variants to first model variant

### DIFF
--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ class ModelManager:
         self._result_manager = result_manager
         self._state_manager = state_manager
         self._run_search = RunSearch(config=config)
-        self._last_config_variant = None
+        self._first_config_variant = None
         self._run_config_generator = RunConfigGenerator(config=config,
                                                         client=self._client)
 
@@ -249,9 +249,10 @@ class ModelManager:
                 os.makedirs(new_model_dir, exist_ok=False)
                 variant_config.write_config_to_file(new_model_dir,
                                                     original_model_dir,
-                                                    self._last_config_variant)
-                self._last_config_variant = os.path.join(
-                    self._output_model_repo_path, variant_name)
+                                                    self._first_config_variant)
+                if self._first_config_variant is None:
+                    self._first_config_variant = os.path.join(
+                        self._output_model_repo_path, variant_name)
             except FileExistsError:
                 pass
 

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -78,6 +78,9 @@ class ModelManager:
         # Clear any configs from previous model run
         self._run_config_generator.clear_configs()
 
+        # Reset first config variant for new model
+        self._first_config_variant = None
+
         # Save the global server config and update the server's config for this model run
         server_config_copy = self._server.config().copy()
         self._server.update_config(params=model.triton_server_flags())


### PR DESCRIPTION
Before, we would link model variant i{N} to i{N-1}. The first model variant is a deep copy of the source model. With large runs, this would break as unix apparently only allows a symlink chain length maximum of 40.

After this PR, all model variants after the first link directly to the first model variant. The first model variant is still a deep copy of the source model. Now there is no symlink chain. Each (non-first) variant just points directly to first variant.