### PR TITLE
Fixing errors in unit tests when running from vscode

### DIFF
--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -18,7 +18,7 @@ from model_analyzer.record.metrics_manager import MetricsManager
 from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
 
 
-def create_yaml(string):
+def convert_to_bytes(string):
     """
     Converts string into bytes and ensures minimum length requirement 
     for compatibility with unpack function called in usr/lib/python3.8/gettext.py

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -18,6 +18,17 @@ from model_analyzer.record.metrics_manager import MetricsManager
 from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
 
 
+def create_yaml(string):
+    """
+    Converts string into bytes and ensures minimum length requirement 
+    for compatibility with unpack function called in usr/lib/python3.8/gettext.py
+    """
+    if (len(string) > 4):
+        return bytes(string, 'utf-8')
+    else:
+        return bytes(string + "    ", 'utf-8')
+
+
 def construct_measurement(model_name, gpu_metric_values, non_gpu_metric_values,
                           comparator):
     """

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -33,7 +33,7 @@ from tritonclient.grpc import model_config_pb2
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from .common.test_utils import create_yaml
+from .common.test_utils import convert_to_bytes
 
 
 class ModelManagerSubclass(ModelManager):
@@ -114,7 +114,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32, 64, 128]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
@@ -144,7 +144,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
@@ -170,7 +170,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
@@ -199,7 +199,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [5, 7]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
@@ -224,7 +224,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 512
             run_config_search_max_instance_count: 7
@@ -255,7 +255,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [2, 10, 18, 26, 34, 42, 50, 58]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models: test_model
             run_config_search_max_concurrency: 512
             run_config_search_max_instance_count: 7
@@ -285,7 +285,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 8
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -321,7 +321,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 8
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -384,7 +384,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -447,7 +447,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -511,7 +511,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 1
             run_config_search_disable: False

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -33,6 +33,8 @@ from tritonclient.grpc import model_config_pb2
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from .common.test_utils import create_yaml
+
 
 class ModelManagerSubclass(ModelManager):
     """ 
@@ -112,12 +114,12 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32, 64, 128]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
             run_config_search_disable: False
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -142,12 +144,12 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
             run_config_search_disable: False
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -168,12 +170,12 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
             run_config_search_disable: True
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -197,13 +199,13 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [5, 7]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 32
             run_config_search_max_instance_count: 7
             run_config_search_disable: False
             concurrency: [5, 7]
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -222,13 +224,13 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 512
             run_config_search_max_instance_count: 7
             run_config_search_disable: False
             triton_launch_mode: remote            
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -253,7 +255,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [2, 10, 18, 26, 34, 42, 50, 58]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models: test_model
             run_config_search_max_concurrency: 512
             run_config_search_max_instance_count: 7
@@ -263,7 +265,7 @@ class TestModelManager(trc.TestResultCollector):
                 stop: 64
                 step: 8
             batch_sizes: 1,2,3     
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -283,7 +285,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 8
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -291,7 +293,7 @@ class TestModelManager(trc.TestResultCollector):
                 test_model:
                     model_config_parameters:
                         max_batch_size: [1,2,4,8,16]
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -319,7 +321,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4, 8]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 8
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -329,7 +331,7 @@ class TestModelManager(trc.TestResultCollector):
                         max_batch_size: [1,2,4,8,16]
                         dynamic_batching:
                             max_queue_delay_microseconds: [200, 300]                        
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -382,7 +384,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -393,7 +395,7 @@ class TestModelManager(trc.TestResultCollector):
                         -
                             kind: KIND_GPU
                             count: 1
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -445,7 +447,7 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 16
             run_config_search_disable: False
@@ -456,7 +458,7 @@ class TestModelManager(trc.TestResultCollector):
                         -
                             kind: KIND_GPU
                             count: 1
-            """
+            """)
 
         self._test_model_manager(yaml_content, expected_ranges)
 
@@ -509,12 +511,12 @@ class TestModelManager(trc.TestResultCollector):
             'concurrency': [1, 2, 4]
         }]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 4
             run_config_search_max_instance_count: 1
             run_config_search_disable: False
             profile_models: test_model
-            """
+            """)
         self._test_model_manager(yaml_content, expected_ranges)
 
     def _test_model_manager(self, yaml_content, expected_ranges):

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -35,7 +35,7 @@ from .common import test_result_collector as trc
 
 import unittest
 
-from .common.test_utils import create_yaml
+from .common.test_utils import convert_to_bytes
 
 
 class TestReportManagerMethods(trc.TestResultCollector):
@@ -62,7 +62,7 @@ class TestReportManagerMethods(trc.TestResultCollector):
             "model-analyzer", "analyze", "-f", "path-to-config-file",
             "--analysis-models", analysis_models
         ]
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             num_configs_per_model: """ + str(num_configs_per_model) + """
             client_protocol: grpc
             export_path: /test/export/path

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -35,6 +35,8 @@ from .common import test_result_collector as trc
 
 import unittest
 
+from .common.test_utils import create_yaml
+
 
 class TestReportManagerMethods(trc.TestResultCollector):
 
@@ -60,14 +62,14 @@ class TestReportManagerMethods(trc.TestResultCollector):
             "model-analyzer", "analyze", "-f", "path-to-config-file",
             "--analysis-models", analysis_models
         ]
-        yaml_content = """
+        yaml_content = create_yaml("""
             num_configs_per_model: """ + str(num_configs_per_model) + """
             client_protocol: grpc
             export_path: /test/export/path
             constraints:
               perf_latency_p99:
                 max: 100
-        """
+        """)
         config = self._evaluate_config(args, yaml_content)
         state_manager = AnalyzerStateManager(config=config, server=None)
         gpu_info = {'gpu_uuid': {'name': 'gpu_name', 'total_memory': 10}}

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -23,7 +23,7 @@ from model_analyzer.triton.client.grpc_client import TritonGRPCClient
 from model_analyzer.config.run.run_config_generator \
     import RunConfigGenerator
 
-from .common.test_utils import create_yaml
+from .common.test_utils import convert_to_bytes
 
 
 class TestRunConfigGenerator(trc.TestResultCollector):
@@ -56,7 +56,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         ]
 
         # Empty yaml
-        yaml_content = create_yaml('')
+        yaml_content = convert_to_bytes('')
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -71,7 +71,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         ]
 
         # List of instance groups
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -101,7 +101,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -135,7 +135,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -166,7 +166,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -215,7 +215,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -232,7 +232,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             config.profile_models[0].model_config_parameters())
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -274,7 +274,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
 
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -311,7 +311,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(expected_model_configs, model_configs)
 
         # list under dynamic batching
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -405,7 +405,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file', '--triton-launch-mode', 'remote'
         ]
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -429,7 +429,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'name'), 'vgg_16_graphdef')
 
         # remote mode, with model sweeps
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -465,7 +465,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file'
         ]
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -490,7 +490,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file'
         ]
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -521,7 +521,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'name'), 'vgg_16_graphdef_i1')
 
         # Test map fields
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -23,6 +23,8 @@ from model_analyzer.triton.client.grpc_client import TritonGRPCClient
 from model_analyzer.config.run.run_config_generator \
     import RunConfigGenerator
 
+from .common.test_utils import create_yaml
+
 
 class TestRunConfigGenerator(trc.TestResultCollector):
 
@@ -54,7 +56,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         ]
 
         # Empty yaml
-        yaml_content = ''
+        yaml_content = create_yaml('')
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -69,7 +71,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         ]
 
         # List of instance groups
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -82,7 +84,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                 kind: KIND_CPU
                                 count: 1
 
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -99,7 +101,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -114,7 +116,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                 kind: KIND_CPU
                                 count: 1
 
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -133,7 +135,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -147,7 +149,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                                 kind: KIND_CPU
                                 count: 1
 
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -164,7 +166,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -174,7 +176,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                             -
                                 kind: [KIND_GPU, KIND_CPU]
                                 count: [1, 2, 3]
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -213,7 +215,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         }, None]
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -222,7 +224,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         -
                             kind: [KIND_GPU, KIND_CPU]
                             count: [1, 2, 3]
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -230,7 +232,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             config.profile_models[0].model_config_parameters())
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -246,7 +248,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                             -
                                 kind: KIND_CPU
                                 count: 1
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -272,7 +274,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
 
         self.assertEqual(expected_model_configs, model_configs)
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -283,7 +285,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         -
                             kind: KIND_GPU
                             count: 1
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -309,7 +311,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(expected_model_configs, model_configs)
 
         # list under dynamic batching
-        yaml_content = """
+        yaml_content = create_yaml("""
             profile_models:
             -
                 vgg_16_graphdef:
@@ -323,7 +325,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         -
                             kind: [KIND_GPU, KIND_CPU]
                             count: [1, 2]
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -403,12 +405,12 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file', '--triton-launch-mode', 'remote'
         ]
-        yaml_content = """
+        yaml_content = create_yaml("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
             - vgg_16_graphdef
-            """
+            """)
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
                                                   client=self.client)
@@ -427,7 +429,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'name'), 'vgg_16_graphdef')
 
         # remote mode, with model sweeps
-        yaml_content = """
+        yaml_content = create_yaml("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -438,7 +440,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         -
                             kind: KIND_GPU
                             count: [1, 2]
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
@@ -463,12 +465,12 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file'
         ]
-        yaml_content = """
+        yaml_content = create_yaml("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
             - vgg_16_graphdef
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
@@ -488,7 +490,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file'
         ]
-        yaml_content = """
+        yaml_content = create_yaml("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -499,7 +501,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         -
                             kind: KIND_GPU
                             count: [1, 2]
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,
@@ -519,7 +521,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                 'name'), 'vgg_16_graphdef_i1')
 
         # Test map fields
-        yaml_content = """
+        yaml_content = create_yaml("""
             concurrency: [1, 2, 3]
             batch_sizes: [2, 3, 4]
             profile_models:
@@ -533,7 +535,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
                         parameters:
                             MAX_SESSION_SHARE_COUNT: 
                               string_value: [1, 2, 3, 4, 5]
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_config_generator = RunConfigGenerator(config=config,

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -23,7 +23,7 @@ from model_analyzer.cli.cli import CLI
 from .mocks.mock_config import MockConfig
 from .mocks.mock_os import MockOSMethods
 
-from .common.test_utils import create_yaml
+from .common.test_utils import convert_to_bytes
 
 
 class TestRunSearch(trc.TestResultCollector):
@@ -65,7 +65,7 @@ class TestRunSearch(trc.TestResultCollector):
             '-f', 'path-to-config-file', '--profile-models', 'vgg11'
         ]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
             concurrency: []
@@ -110,7 +110,7 @@ class TestRunSearch(trc.TestResultCollector):
             '-f', 'path-to-config-file', '--profile-models', 'vgg11'
         ]
 
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
             concurrency: []

--- a/tests/test_run_search.py
+++ b/tests/test_run_search.py
@@ -23,6 +23,8 @@ from model_analyzer.cli.cli import CLI
 from .mocks.mock_config import MockConfig
 from .mocks.mock_os import MockOSMethods
 
+from .common.test_utils import create_yaml
+
 
 class TestRunSearch(trc.TestResultCollector):
 
@@ -63,13 +65,13 @@ class TestRunSearch(trc.TestResultCollector):
             '-f', 'path-to-config-file', '--profile-models', 'vgg11'
         ]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
             concurrency: []
             profile_models:
                 - my-model
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_search = RunSearch(config=config)
@@ -108,13 +110,13 @@ class TestRunSearch(trc.TestResultCollector):
             '-f', 'path-to-config-file', '--profile-models', 'vgg11'
         ]
 
-        yaml_content = """
+        yaml_content = create_yaml("""
             run_config_search_max_concurrency: 128
             run_config_search_max_instance_count: 5
             concurrency: []
             profile_models:
                 - my-model
-            """
+            """)
 
         config = self._evaluate_config(args, yaml_content)
         run_search = RunSearch(config=config)

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -29,6 +29,8 @@ from .common import test_result_collector as trc
 
 import unittest
 
+from .common.test_utils import create_yaml
+
 
 class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
 
@@ -51,9 +53,9 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file', '--profile-models', 'test_model'
         ]
-        yaml_content = """
+        yaml_content = create_yaml("""
             export_path: /test_export_path/
-        """
+        """)
 
         # start mocks
         self.mock_io = MockIOMethods(

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -29,7 +29,7 @@ from .common import test_result_collector as trc
 
 import unittest
 
-from .common.test_utils import create_yaml
+from .common.test_utils import convert_to_bytes
 
 
 class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
@@ -53,7 +53,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',
             '-f', 'path-to-config-file', '--profile-models', 'test_model'
         ]
-        yaml_content = create_yaml("""
+        yaml_content = convert_to_bytes("""
             export_path: /test_export_path/
         """)
 


### PR DESCRIPTION
This is the issue:
File "/usr/lib/python3.8/gettext.py", line 411, in _parse
    magic = unpack('<I', buf[:4])[0]

It expects the buffer to be of type byte and a minimum length of 4. Still not sure why this only complains from vscode, but it's simple enough to fix:

- create_yaml() to convert strings and append blanks (if too short)

I have observed all unit tests passing and interactive debug is now working in vscode.
