### PR TITLE
Rename output directories to use config instead of i

### DIFF
--- a/model_analyzer/config/run/run_config_generator.py
+++ b/model_analyzer/config/run/run_config_generator.py
@@ -130,7 +130,7 @@ class RunConfigGenerator:
             # The new model name is the original model suffixed with
             # _i<config_index>. Where the config index is the index
             # of the model config alternative.
-            model_tmp_name = f'{model.model_name()}_i{model_name_index}'
+            model_tmp_name = f'{model.model_name()}_config{model_name_index}'
             model_config.set_field('name', model_tmp_name)
             model_config.set_cpu_only(model.cpu_only())
             perf_configs = self._generate_perf_config_for_model(

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -181,14 +181,14 @@ class ModelConfig:
                 'Model output path must be a directory.')
 
         model_config_bytes = text_format.MessageToBytes(self._model_config)
-
         # Create current variant model as symlinks to first variant model
         if first_variant_model_path is not None:
             src_model_name = Path(src_model_path).name
             first_variant_model_name = Path(first_variant_model_path).name
 
             # If the model files have been copied once, do not copy it again
-            if re.search(f'^{src_model_name}_i\d+$', first_variant_model_name):
+            if re.search(f'^{src_model_name}_config\d+$',
+                         first_variant_model_name):
                 for file in os.listdir(first_variant_model_path):
                     # Do not copy the config.pbtxt file
                     if file == 'config.pbtxt':

--- a/qa/L0_profile/check_results.py
+++ b/qa/L0_profile/check_results.py
@@ -51,7 +51,7 @@ class TestOutputValidator:
         expected_num_measurements = len(self._config['batch_sizes']) * len(
             self._config['concurrency'])
         for model in self._models:
-            token = f"Profiling model {model}_i0..."
+            token = f"Profiling model {model}_config0..."
             token_idx = 0
             found_count = 0
             while True:

--- a/qa/L0_quick_start/test.sh
+++ b/qa/L0_quick_start/test.sh
@@ -35,7 +35,7 @@ model-analyzer analyze \
   exit_early_if_nonzero $?
 
 model-analyzer report \
-  --report-model-configs add_sub_i0,add_sub_i1 \
+  --report-model-configs add_sub_config0,add_sub_config1 \
   -e analysis_results ; \
   exit_early_if_nonzero $?
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -142,9 +142,9 @@ instance_group [
 
         model_config = ModelConfig.create_from_dictionary(self._model_config)
 
-        model_path = './output_model_repository/model_i1'
+        model_path = './output_model_repository/model_config1'
         src_model_path = '/tmp/src_model_repository/model'
-        last_model_path = './output_model_repository/model_i0'
+        last_model_path = './output_model_repository/model_config0'
 
         mock_model_config = MockModelConfig()
         mock_model_config.start()
@@ -152,8 +152,8 @@ instance_group [
                                           last_model_path)
         mock_model_config.stop()
 
-        mock_os_symlink.assert_any_call('../model_i0/1',
-                                        './output_model_repository/model_i1/1')
         mock_os_symlink.assert_any_call(
-            '../model_i0/output0_labels.txt',
-            './output_model_repository/model_i1/output0_labels.txt')
+            '../model_config0/1', './output_model_repository/model_config1/1')
+        mock_os_symlink.assert_any_call(
+            '../model_config0/output0_labels.txt',
+            './output_model_repository/model_config1/output0_labels.txt')

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -483,7 +483,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(len(run_config_generator.run_configs()), 9)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
-                'name'), 'vgg_16_graphdef_i0')
+                'name'), 'vgg_16_graphdef_config0')
 
         # Not remote, with model sweep
         args = [
@@ -515,10 +515,10 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(len(run_config_generator.run_configs()), 27)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
-                'name'), 'vgg_16_graphdef_i0')
+                'name'), 'vgg_16_graphdef_config0')
         self.assertEqual(
             run_config_generator.run_configs()[9].model_config().get_field(
-                'name'), 'vgg_16_graphdef_i1')
+                'name'), 'vgg_16_graphdef_config1')
 
         # Test map fields
         yaml_content = convert_to_bytes("""
@@ -553,7 +553,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(len(run_config_generator.run_configs()), 99)
         self.assertEqual(
             run_config_generator.run_configs()[0].model_config().get_field(
-                'name'), 'vgg_16_graphdef_i0')
+                'name'), 'vgg_16_graphdef_config0')
 
     def tearDown(self):
         self.mock_model_config.stop()


### PR DESCRIPTION
Changing the output directory naming convention to remove the ambiguous i.