### PR TITLE
Fix argument parsing

### DIFF
--- a/model_analyzer/triton/server/server_config.py
+++ b/model_analyzer/triton/server/server_config.py
@@ -142,11 +142,11 @@ class TritonServerConfig:
             output: ['--model-control-mode', 'explicit', 
                 '--backend-config', 'tensorflow,version=2']
         """
-        list = []
+        args_list = []
         args = self.to_cli_string().split()
         for arg in args:
-            list += arg.split('=', 1)
-        return list
+            args_list += arg.split('=', 1)
+        return args_list
 
     def copy(self):
         """

--- a/model_analyzer/triton/server/server_config.py
+++ b/model_analyzer/triton/server/server_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,6 +122,31 @@ class TritonServerConfig:
 
         return ' '.join(
             [f'--{key}={val}' for key, val in self._server_args.items() if val])
+
+    def to_args_list(self):
+        """
+        Utility function to convert a cli string into a list of arguments while
+        taking into account "smart" delimiters.  Notice in the example below
+        that only the first equals sign is used as split delimiter.
+
+        Returns
+        -------
+        list
+            the list of arguments consisting of all set arguments to
+            the tritonserver.
+
+            Example:
+            input cli_string: "--model-control-mode=explicit 
+                --backend-config=tensorflow,version=2"
+
+            output: ['--model-control-mode', 'explicit', 
+                '--backend-config', 'tensorflow,version=2']
+        """
+        list = []
+        args = self.to_cli_string().split()
+        for arg in args:
+            list += arg.split('=', 1)
+        return list
 
     def copy(self):
         """

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020,21 NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,11 +62,7 @@ class TritonServerLocal(TritonServer):
         if self._server_path:
             # Create command list and run subprocess
             cmd = [self._server_path]
-
-            args = self._server_config.to_cli_string().split()
-            for arg in args:
-                list = arg.split('=', 1)
-                cmd += list
+            cmd += self._server_config.to_args_list()
 
             # Set environment, update with user config env
             triton_env = os.environ.copy()

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -62,7 +62,12 @@ class TritonServerLocal(TritonServer):
         if self._server_path:
             # Create command list and run subprocess
             cmd = [self._server_path]
-            cmd += self._server_config.to_cli_string().replace('=', ' ').split()
+
+            args = self._server_config.to_cli_string().split()
+            for arg in args:
+                list = arg.split('=', 1)
+                cmd += list
+
             # Set environment, update with user config env
             triton_env = os.environ.copy()
 

--- a/qa/L0_custom_flags/test_config_generator.py
+++ b/qa/L0_custom_flags/test_config_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qa/L0_custom_flags/test_config_generator.py
+++ b/qa/L0_custom_flags/test_config_generator.py
@@ -95,14 +95,9 @@ class TestConfigGenerator:
         with open('config-triton-global.yml', 'w+') as f:
             yaml.dump(self.config, f)
 
-    def generate_triton_flags_backend_with_default_version(self):
-        self.config['triton_server_flags'] = {'backend_config': 'tensorflow'}
-
-        with open('config-triton-backend-with-default-version.yml', 'w+') as f:
-            yaml.dump(self.config, f)
-
     def generate_triton_flags_backend_with_specific_version(self):
         self.config['triton_server_flags'] = {
+            'strict_model_config': False,
             'backend_config': 'tensorflow,version=2'
         }
 

--- a/qa/L0_custom_flags/test_config_generator.py
+++ b/qa/L0_custom_flags/test_config_generator.py
@@ -95,6 +95,20 @@ class TestConfigGenerator:
         with open('config-triton-global.yml', 'w+') as f:
             yaml.dump(self.config, f)
 
+    def generate_triton_flags_backend_with_default_version(self):
+        self.config['triton_server_flags'] = {'backend_config': 'tensorflow'}
+
+        with open('config-triton-backend-with-default-version.yml', 'w+') as f:
+            yaml.dump(self.config, f)
+
+    def generate_triton_flags_backend_with_specific_version(self):
+        self.config['triton_server_flags'] = {
+            'backend_config': 'tensorflow,version=2'
+        }
+
+        with open('config-triton-backend-with-specific-version.yml', 'w+') as f:
+            yaml.dump(self.config, f)
+
 
 if __name__ == '__main__':
     TestConfigGenerator()


### PR DESCRIPTION
Fixes issue: https://github.com/triton-inference-server/model_analyzer/issues/279
Feature: https://github.com/triton-inference-server/tensorflow_backend#--backend-configtensorflowversionint
Exercises this server code: https://github.com/triton-inference-server/server/blob/main/src/servers/main.cc#L1132-L1159

Problem: The MA code was not handling properly the case where TWO equals signs exist
(eg, `--backend-config=tensorflow,version=2`)
Before, the code accidentally split on both equals signs:
```
['tritonserver',  '--backend-config', 'tensorflow,version', '2']
```
The fix is to 
1) split on the argument list by spaces
2) Then for each of those arguments, split on the `first` equals sign
After the fix, the code splits on only the first equals sign:
```
['tritonserver', '--backend-config', 'tensorflow,version=2']
```
Notice how `version=2` is now correctly part of the `--backend_config` value
