### PR TITLE
Improve launch mode docs

### DIFF
--- a/docs/launch_modes.md
+++ b/docs/launch_modes.md
@@ -19,79 +19,83 @@ Triton Model Analyzer's `profile` subcommand supports four different launch
 modes along with Triton Inference Server. In the `local` and `docker` modes,
 Triton Inference Server will be launched by the Model Analyzer. In the `c_api`
 mode, the Triton Inference Server is launched locally via a C API. In the
-`remote` mode, it is assumed there is an already running instance of
-Triton Inference Server.
+`remote` mode, it is assumed there is an already running instance of Triton
+Inference Server.
 
 ### Local
 
-CLI Option: **`--triton-launch-mode=local`**
+| CLI Option | **`--triton-launch-mode=local`** |
+| - | - |
 
-In this mode, Model Analyzer will launch
-   Triton Server using the local binary supplied using `--triton-server-path`,
-   or if none is supplied, the `tritonserver` binary in `$PATH`.
+In this mode, Model Analyzer will launch Triton Server using the local binary
+supplied using `--triton-server-path`, or if none is supplied, the
+`tritonserver` binary in `$PATH`.
+
+This mode is useful if you don't want to install/use Docker. You will need
+Triton Server and all of its dependencies installed locally, though.
 
 ### Docker
 
-CLI Option: **`--triton-launch-mode=docker`**
+| CLI Option | **`--triton-launch-mode=docker`** |
+| - | - |
 
-In this mode, Model Analyzer uses the
-   Python Docker API to launch the Triton Inference Server container. If you are
-   running Model Analyzer inside a Docker container, make sure that the
-   container is launched with appropriate flags. The following flags are
-   mandatory for correct behavior:
-   ```
-   --gpus <gpus> -v /var/run/docker.sock:/var/run/docker.sock --net host
-   ```
+In this mode, Model Analyzer uses the Python Docker API to launch the Triton
+Inference Server container. If you are running Model Analyzer inside a Docker
+container, make sure that the container is launched with appropriate flags. The
+following flags are mandatory for correct behavior:
 
-   Additionally, Model Analyzer uses the `output_model_repository_path` to
-   manipulate and store model config variants. When Model Analyzer launches the
-   Triton container, it does so as a *sibling container*. The launched Triton
-   container will only have access to the host filesystem. **As a result, in the
-   docker launch mode, the output model directory will need to be mounted to the
-   Model Analyzer docker container at the same absolute path it has outside the
-   container.** So you must add the following when you launch the model analyzer
-   container as well.
+```
+--gpus <gpus> -v /var/run/docker.sock:/var/run/docker.sock --net host
+```
 
-   ```
-   -v <path-to-output-model-repository>:<path-to-output-model-repository>
-   ```
+Additionally, Model Analyzer uses the `output_model_repository_path` to
+manipulate and store model config variants. When Model Analyzer launches the
+Triton container, it does so as a *sibling container*. The launched Triton
+container will only have access to the host filesystem. **As a result, in the
+docker launch mode, the output model directory will need to be mounted to the
+Model Analyzer docker container at the same absolute path it has outside the
+container.** So you must add the following when you launch the model analyzer
+container as well.
 
-   Finally, when launching model analyzer, the argument
-   `--output-model-repository` must be provided as a directory inside
-   `<path-to-output-model-repository>`. This directory need not exist. 
+```
+-v <path-to-output-model-repository>:<path-to-output-model-repository>
+```
 
-   ```
-   --output-model-repository=<path-to-output-model-repository>/output
-   ```
+Finally, when launching model analyzer, the argument `--output-model-repository`
+must be provided as a directory inside `<path-to-output-model-repository>`. This
+directory need not exist. 
+
+```
+--output-model-repository=<path-to-output-model-repository>/output
+```
+
+This mode is useful if you don't want to install Triton Server and all of its
+dependencies locally. You will need Docker installed, though.
 
 ### C API
 
-CLI Option: **`--triton-launch-mode=c_api`**
+| CLI Option | **`--triton-launch-mode=c_api`** |
+| - | - |
 
-In this mode, Triton server is launched
-   locally via the
-   [C_API](https://github.com/triton-inference-server/server/blob/main/docs/inference_protocols.md#c-api)
-   by the perf_analyzer instances launched by Model Analyzer.
+In this mode, Triton server is launched locally via the
+[C_API](https://github.com/triton-inference-server/server/blob/main/docs/inference_protocols.md#c-api)
+by the perf_analyzer instances launched by Model Analyzer.
+
+This mode is useful if you want to run with the Triton Server installed locally
+and want the increased performance from the C API. You will need Triton Server
+and all of its dependencies installed locally, though.
 
 ### Remote
 
-CLI Option: **`--triton-launch-mode=remote`**
+| CLI Option | **`--triton-launch-mode=remote`** |
+| - | - |
 
-This mode is beneficial when you want to
-   use an already running Triton Inference Server. You may provide the URLs for
-   the Triton instance's HTTP or GRPC endpoint depending on your chosen client
-   protocol using the `--triton-grpc-endpoint`, and `--triton-http-endpoint`
-   flags.  You should also make sure that same GPUs are available to the
-   Inference Server and Model Analyzer and they are on the same machine. Model
-   Analyzer does not currently support profiling remote GPUs. Triton Server in this
-   mode needs to be launched with `--model-control-mode explicit` flag to support
-   loading/unloading of the models.
-
-### Tradeoffs
-
-| Mode | Pro | Con |
-| - | - | - |
-| *docker* | Don't need Triton Server or its dependencies installed locally | Need Docker installed |
-| *local* | Don't need Docker installed | Need Triton Server and all of its dependencies installed locally |
-| *c_api* | Same as local, but uses faster C API | Need Triton Server and all of its dependencies installed locally |
-| *remote* | Can use Model Analzer on already-running Triton Server | Need Triton Server running on same machine as Model Analyzer |
+This mode is beneficial when you want to use an already running Triton Inference
+Server. You may provide the URLs for the Triton instance's HTTP or GRPC endpoint
+depending on your chosen client protocol using the `--triton-grpc-endpoint`, and
+`--triton-http-endpoint` flags. You should also make sure that same GPUs are
+available to the Inference Server and Model Analyzer and they are on the same
+machine. Model Analyzer does not currently support profiling remote GPUs. Triton
+Server in this mode needs to be launched with `--model-control-mode explicit`
+flag to support loading/unloading of the models. The model parameters cannot be
+changed in remote mode, though.

--- a/docs/launch_modes.md
+++ b/docs/launch_modes.md
@@ -31,8 +31,9 @@ In this mode, Model Analyzer will launch Triton Server using the local binary
 supplied using `--triton-server-path`, or if none is supplied, the
 `tritonserver` binary in `$PATH`.
 
-This mode is useful if you don't want to install/use Docker. You will need
-Triton Server and all of its dependencies installed locally, though.
+Local mode is the recommended method of getting started with Model Analyzer.
+There are detailed instructions about using this mode in the
+[Quick Start Guide](quick_start.md).
 
 ### Docker
 
@@ -69,8 +70,8 @@ directory need not exist.
 --output-model-repository=<path-to-output-model-repository>/output
 ```
 
-This mode is useful if you don't want to install Triton Server and all of its
-dependencies locally. You will need Docker installed, though.
+This mode is useful if you want to use the Model Analyzer installed in the
+Triton SDK Container. You will need Docker installed, though.
 
 ### C API
 
@@ -82,8 +83,9 @@ In this mode, Triton server is launched locally via the
 by the perf_analyzer instances launched by Model Analyzer.
 
 This mode is useful if you want to run with the Triton Server installed locally
-and want the increased performance from the C API. You will need Triton Server
-and all of its dependencies installed locally, though.
+and want the increased performance from the C API. Similar to the
+[local mode](#local), Triton Server must be installed in the environment that
+the Model Analyzer is being used.
 
 ### Remote
 

--- a/docs/launch_modes.md
+++ b/docs/launch_modes.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,11 +22,19 @@ mode, the Triton Inference Server is launched locally via a C API. In the
 `remote` mode, it is assumed there is an already running instance of
 Triton Inference Server.
 
-1. **`--triton-launch-mode=local`** In this mode, Model Analyzer will launch
+### Local
+
+CLI Option: **`--triton-launch-mode=local`**
+
+In this mode, Model Analyzer will launch
    Triton Server using the local binary supplied using `--triton-server-path`,
    or if none is supplied, the `tritonserver` binary in `$PATH`.
 
-2. **`--triton-launch-mode=docker`** In this mode, Model Analyzer uses the
+### Docker
+
+CLI Option: **`--triton-launch-mode=docker`**
+
+In this mode, Model Analyzer uses the
    Python Docker API to launch the Triton Inference Server container. If you are
    running Model Analyzer inside a Docker container, make sure that the
    container is launched with appropriate flags. The following flags are
@@ -56,12 +64,20 @@ Triton Inference Server.
    --output-model-repository=<path-to-output-model-repository>/output
    ```
 
-3. **`--triton-launch-mode=c_api`** In this mode, Triton server is launched
+### C API
+
+CLI Option: **`--triton-launch-mode=c_api`**
+
+In this mode, Triton server is launched
    locally via the
    [C_API](https://github.com/triton-inference-server/server/blob/main/docs/inference_protocols.md#c-api)
    by the perf_analyzer instances launched by Model Analyzer.
 
-4. **`--triton-launch-mode=remote`**. This mode is beneficial when you want to
+### Remote
+
+CLI Option: **`--triton-launch-mode=remote`**
+
+This mode is beneficial when you want to
    use an already running Triton Inference Server. You may provide the URLs for
    the Triton instance's HTTP or GRPC endpoint depending on your chosen client
    protocol using the `--triton-grpc-endpoint`, and `--triton-http-endpoint`
@@ -70,3 +86,12 @@ Triton Inference Server.
    Analyzer does not currently support profiling remote GPUs. Triton Server in this
    mode needs to be launched with `--model-control-mode explicit` flag to support
    loading/unloading of the models.
+
+### Tradeoffs
+
+| Mode | Pro | Con |
+| - | - | - |
+| *docker* | Don't need Triton Server or its dependencies installed locally | Need Docker installed |
+| *local* | Don't need Docker installed | Need Triton Server and all of its dependencies installed locally |
+| *c_api* | Same as local, but uses faster C API | Need Triton Server and all of its dependencies installed locally |
+| *remote* | Can use Model Analzer on already-running Triton Server | Need Triton Server running on same machine as Model Analyzer |

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ $ docker build --pull -t model-analyzer .
 2. Run the docker:
 ```
 $ docker run -it --rm --gpus all \
-    -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd)/examples/quick-start:/quick_start_repository \
     --net=host --name model-analyzer \
     model-analyzer /bin/bash
@@ -58,7 +57,7 @@ configuration:
 
 ```
 --run-config-search-max-concurrency 2 \
---run-config-search-max-instance-count 2 \
+--run-config-search-max-instance-count 2
 ```
 
 `--run-config-search-max-concurrency` sets the max concurrency value that run


### PR DESCRIPTION
The ask was to add a table to the launch mode docs showing tradeoffs between various model analyzer launch modes to help users understand which launch mode they may want to use.