### PR TITLE
Validate `triton_install_path` in c_api launch mode only

### DIFF
--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -425,10 +425,8 @@ class ConfigCommandProfile(ConfigCommand):
                 parser_args={'action': 'store_true'},
                 default_value=False,
                 flags=['--reload-model-disable'],
-                description=
-                'Flag to indicate whether or not to disable model '
-                'loading and unloading in remote mode.'
-            ))
+                description='Flag to indicate whether or not to disable model '
+                'loading and unloading in remote mode.'))
 
     def _add_client_configs(self):
         """
@@ -574,7 +572,7 @@ class ConfigCommandProfile(ConfigCommand):
         self._add_config(
             ConfigField(
                 'triton_install_path',
-                field_type=ConfigPrimitive(str, validator=file_path_validator),
+                field_type=ConfigPrimitive(str),
                 default_value=DEFAULT_TRITON_INSTALL_PATH,
                 flags=['--triton-install-path'],
                 description=

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -93,7 +93,7 @@ def get_server_handle(config, gpus):
             ' Model Analyzer does not have access to the model repository of'
             ' the remote Triton Server.')
     elif config.triton_launch_mode == 'local':
-        validate_triton_server_path(config)
+        validate_triton_path(config, 'triton_server_path')
 
         triton_config = TritonServerConfig()
         triton_config.update_config(config.triton_server_flags)
@@ -132,6 +132,8 @@ def get_server_handle(config, gpus):
             mounts=config.triton_docker_mounts,
             labels=config.triton_docker_labels)
     elif config.triton_launch_mode == 'c_api':
+        validate_triton_path(config, 'triton_install_path')
+
         triton_config = TritonServerConfig()
         triton_config['model-repository'] = os.path.abspath(
             config.output_model_repository_path)
@@ -152,16 +154,16 @@ def get_server_handle(config, gpus):
     return server
 
 
-def validate_triton_server_path(config):
+def validate_triton_path(config, key):
     """
-    Validates that the value of 'triton_server_path' exists on disk
+    Validates that the value of {key} exists on disk
 
     Parameters
     ----------
     config : namespace
         Arguments parsed from the CLI
     """
-    path = config.get_config()['triton_server_path'].value()
+    path = config.get_config()[key].value()
     config_status = binary_path_validator(path)
     if config_status.status() == CONFIG_PARSER_FAILURE:
         raise TritonModelAnalyzerException(config_status.message())

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -172,7 +172,12 @@ def validate_triton_server_path(config):
 
 def validate_triton_install_path(config):
     """
-    Validates that the value of 'triton_install_path' exists on disk
+    Validates that the value of 'triton_install_path':
+        is specified
+        exists
+        is a directory
+        contains more than one file
+    
 
     Parameters
     ----------
@@ -180,9 +185,18 @@ def validate_triton_install_path(config):
         Arguments parsed from the CLI
     """
     path = config.get_config()['triton_install_path'].value()
-    config_status = file_path_validator(path)
-    if config_status.status() == CONFIG_PARSER_FAILURE:
-        raise TritonModelAnalyzerException(config_status.message())
+
+    # Check the file system
+    if not path or not os.path.exists(path) or not os.path.isdir(path):
+        raise TritonModelAnalyzerException(
+            f"triton_install_path {path} is not specified, does not exist, " \
+            "or is not a directory."
+        )
+
+    # Make sure that files exist in the install directory
+    if len(os.listdir(path)) == 0:
+        raise TritonModelAnalyzerException(
+            f"triton_install_path {path} should not be empty.")
 
 
 def get_triton_handles(config, gpus):

--- a/qa/L0_server_launch_modes/test_config_generator.py
+++ b/qa/L0_server_launch_modes/test_config_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qa/L0_server_launch_modes/test_config_generator.py
+++ b/qa/L0_server_launch_modes/test_config_generator.py
@@ -68,6 +68,7 @@ class TestConfigGenerator:
         for launch_mode in self.launch_modes:
             self.config['triton_launch_mode'] = launch_mode
             self.set_triton_server_path(launch_mode, self.config)
+            self.set_triton_install_path(launch_mode, self.config)
 
             if launch_mode == 'c_api':
                 self.config['perf_output'] = True
@@ -90,7 +91,6 @@ class TestConfigGenerator:
                               'w') as f:
                         yaml.dump(self.config, f)
 
-
     def set_triton_server_path(self, launch_mode, config):
         """
         Helper function to set the 'triton_server_path' to something bogus
@@ -101,6 +101,17 @@ class TestConfigGenerator:
 
         if launch_mode != 'local':
             config['triton_server_path'] = '/path/to/nowhere'
+
+    def set_triton_install_path(self, launch_mode, config):
+        """
+        Helper function to set the 'triton_install_path' to something bogus
+            for all configuration except 'c_api'
+        This ensures only the 'c_api' launch mode uses 'triton_install_path'.
+        """
+        config.pop('triton_install_path', None)
+
+        if launch_mode != 'c_api':
+            config['triton_install_path'] = '/path/to/nowhere'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Much like validating the `triton_server_path in local launch mode`, the PR is validating `triton_install_path in c_api launch mode`.