### PR TITLE
Pass SSL options to python triton client instantiations

### DIFF
--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -47,17 +47,43 @@ def get_client_handle(config):
         Arguments parsed from the CLI
     """
 
+    ssl_options = get_ssl_options(config)
     if config.client_protocol == 'http':
         client = TritonClientFactory.create_http_client(
-            server_url=config.triton_http_endpoint)
+            server_url=config.triton_http_endpoint, ssl_options=ssl_options)
     elif config.client_protocol == 'grpc':
         client = TritonClientFactory.create_grpc_client(
-            server_url=config.triton_grpc_endpoint)
+            server_url=config.triton_grpc_endpoint, ssl_options=ssl_options)
     else:
         raise TritonModelAnalyzerException(
             f"Unrecognized client-protocol : {config.client_protocol}")
 
     return client
+
+
+def get_ssl_options(config):
+    """
+    Returns SSL options dictionary
+
+    Parameters
+    ----------
+    config : namespace
+        Arguments parsed from the CLI
+    """
+
+    ssl_option_keys = [
+        'ssl-grpc-use-ssl', 'ssl-grpc-root-certifications-file',
+        'ssl-grpc-private-key-file', 'ssl-grpc-certificate-chain-file',
+        'ssl-https-verify-peer', 'ssl-https-verify-host',
+        'ssl-https-ca-certificates-file', 'ssl-https-client-certificate-file',
+        'ssl-https-client-certificate-type', 'ssl-https-private-key-file',
+        'ssl-https-private-key-type'
+    ]
+    return {
+        key: config.perf_analyzer_flags[key]
+        for key in ssl_option_keys
+        if key in config.perf_analyzer_flags
+    }
 
 
 def get_server_handle(config, gpus):

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -47,13 +47,16 @@ def get_client_handle(config):
         Arguments parsed from the CLI
     """
 
-    ssl_options = get_ssl_options(config)
     if config.client_protocol == 'http':
+        http_ssl_options = get_http_ssl_options(config)
         client = TritonClientFactory.create_http_client(
-            server_url=config.triton_http_endpoint, ssl_options=ssl_options)
+            server_url=config.triton_http_endpoint,
+            ssl_options=http_ssl_options)
     elif config.client_protocol == 'grpc':
+        grpc_ssl_options = get_grpc_ssl_options(config)
         client = TritonClientFactory.create_grpc_client(
-            server_url=config.triton_grpc_endpoint, ssl_options=ssl_options)
+            server_url=config.triton_grpc_endpoint,
+            ssl_options=grpc_ssl_options)
     else:
         raise TritonModelAnalyzerException(
             f"Unrecognized client-protocol : {config.client_protocol}")
@@ -61,9 +64,9 @@ def get_client_handle(config):
     return client
 
 
-def get_ssl_options(config):
+def get_http_ssl_options(config):
     """
-    Returns SSL options dictionary
+    Returns HTTP SSL options dictionary
 
     Parameters
     ----------
@@ -72,13 +75,36 @@ def get_ssl_options(config):
     """
 
     ssl_option_keys = [
-        'ssl-grpc-use-ssl', 'ssl-grpc-root-certifications-file',
-        'ssl-grpc-private-key-file', 'ssl-grpc-certificate-chain-file',
         'ssl-https-verify-peer', 'ssl-https-verify-host',
         'ssl-https-ca-certificates-file', 'ssl-https-client-certificate-file',
         'ssl-https-client-certificate-type', 'ssl-https-private-key-file',
         'ssl-https-private-key-type'
     ]
+
+    return {
+        key: config.perf_analyzer_flags[key]
+        for key in ssl_option_keys
+        if key in config.perf_analyzer_flags
+    }
+
+
+def get_grpc_ssl_options(config):
+    """
+    Returns gRPC SSL options dictionary
+
+    Parameters
+    ----------
+    config : namespace
+        Arguments parsed from the CLI
+    """
+
+    ssl_option_keys = [
+        'ssl-grpc-use-ssl',
+        'ssl-grpc-root-certifications-file',
+        'ssl-grpc-private-key-file',
+        'ssl-grpc-certificate-chain-file',
+    ]
+
     return {
         key: config.perf_analyzer_flags[key]
         for key in ssl_option_keys

--- a/model_analyzer/triton/client/client_factory.py
+++ b/model_analyzer/triton/client/client_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,29 +23,33 @@ class TritonClientFactory:
     """
 
     @staticmethod
-    def create_grpc_client(server_url):
+    def create_grpc_client(server_url, ssl_options={}):
         """
         Parameters
         ----------
         server_url : str
             The url for Triton server's GRPC endpoint
+        ssl_options : dict
+            Dictionary of SSL options for gRPC python client
 
         Returns
         -------
         TritonGRPCClient
         """
-        return TritonGRPCClient(server_url=server_url)
+        return TritonGRPCClient(server_url=server_url, ssl_options=ssl_options)
 
     @staticmethod
-    def create_http_client(server_url):
+    def create_http_client(server_url, ssl_options={}):
         """
         Parameters
         ----------
         server_url : str
             The url for Triton server's HTTP endpoint
+        ssl_options : dict
+            Dictionary of SSL options for HTTP python client
 
         Returns
         -------
         TritonHTTPClient
         """
-        return TritonHTTPClient(server_url=server_url)
+        return TritonHTTPClient(server_url=server_url, ssl_options=ssl_options)

--- a/model_analyzer/triton/client/client_factory.py
+++ b/model_analyzer/triton/client/client_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/triton/client/grpc_client.py
+++ b/model_analyzer/triton/client/grpc_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/triton/client/grpc_client.py
+++ b/model_analyzer/triton/client/grpc_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,15 +22,36 @@ class TritonGRPCClient(TritonClient):
     for GRPC
     """
 
-    def __init__(self, server_url):
+    def __init__(self, server_url, ssl_options={}):
         """
         Parameters
         ----------
         server_url : str
             The url for Triton server's GRPC endpoint
+        ssl_options : dict
+            Dictionary of SSL options for gRPC python client
         """
 
-        self._client = grpcclient.InferenceServerClient(url=server_url)
+        ssl = False
+        root_certificates = None
+        private_key = None
+        certificate_chain = None
+
+        if 'ssl-grpc-use-ssl' in ssl_options:
+            ssl = ssl_options['ssl-grpc-use-ssl'].lower() == 'true'
+        if 'ssl-grpc-root-certifications-file' in ssl_options:
+            root_certificates = ssl_options['ssl-grpc-root-certifications-file']
+        if 'ssl-grpc-private-key-file' in ssl_options:
+            private_key = ssl_options['ssl-grpc-private-key-file']
+        if 'ssl-grpc-certificate-chain-file' in ssl_options:
+            certificate_chain = ssl_options['ssl-grpc-certificate-chain-file']
+
+        self._client = grpcclient.InferenceServerClient(
+            url=server_url,
+            ssl=ssl,
+            root_certificates=root_certificates,
+            private_key=private_key,
+            certificate_chain=certificate_chain)
 
     def get_model_config(self, model_name, num_retries):
         """

--- a/model_analyzer/triton/client/http_client.py
+++ b/model_analyzer/triton/client/http_client.py
@@ -73,7 +73,7 @@ class TritonHTTPClient(TritonClient):
             verify_peer = ssl_options['ssl-https-verify-peer']
         if 'ssl-https-verify-host' in ssl_options:
             verify_host = ssl_options['ssl-https-verify-host']
-        if verify_peer == 0 and verify_host == 0:
+        if verify_peer == 0 or verify_host == 0:
             insecure = True
         if insecure == True:
             ssl_context_factory = gevent.ssl._create_unverified_context

--- a/model_analyzer/triton/client/http_client.py
+++ b/model_analyzer/triton/client/http_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gevent.ssl
+import logging
+
 from .client import TritonClient
 import tritonclient.http as httpclient
 
@@ -22,12 +25,62 @@ class TritonHTTPClient(TritonClient):
     for HTTP
     """
 
-    def __init__(self, server_url):
+    def __init__(self, server_url, ssl_options={}):
         """
         Parameters
         ----------
         server_url : str
             The url for Triton server's HTTP endpoint
+        ssl_options : dict
+            Dictionary of SSL options for HTTP python client
         """
 
-        self._client = httpclient.InferenceServerClient(url=server_url)
+        ssl = False
+        client_ssl_options = {}
+        ssl_context_factory = None
+        insecure = False
+        verify_peer = 0
+        verify_host = 0
+
+        if server_url.startswith('http://'):
+            ssl = False
+            server_url = server_url.replace('http://', '', 1)
+        elif server_url.startswith('https://'):
+            ssl = True
+            server_url = server_url.replace('https://', '', 1)
+        if 'ssl-https-ca-certificates-file' in ssl_options:
+            client_ssl_options['ca_certs'] = ssl_options[
+                'ssl-https-ca-certificates-file']
+        if 'ssl-https-client-certificate-file' in ssl_options:
+            if 'ssl-https-client-certificate-type' in ssl_options and ssl_options[
+                    'ssl-https-client-certificate-type'] == 'PEM':
+                client_ssl_options['certfile'] = ssl_options[
+                    'ssl-https-client-certificate-file']
+            else:
+                logging.warning(
+                    'model-analyzer with SSL must be passed a client certificate file in PEM format.'
+                )
+        if 'ssl-https-private-key-file' in ssl_options:
+            if 'ssl-https-private-key-type' in ssl_options and ssl_options[
+                    'ssl-https-private-key-type'] == 'PEM':
+                client_ssl_options['keyfile'] = ssl_options[
+                    'ssl-https-private-key-file']
+            else:
+                logging.warning(
+                    'model-analyzer with SSL must be passed a private key file in PEM format.'
+                )
+        if 'ssl-https-verify-peer' in ssl_options:
+            verify_peer = ssl_options['ssl-https-verify-peer']
+        if 'ssl-https-verify-host' in ssl_options:
+            verify_host = ssl_options['ssl-https-verify-host']
+        if verify_peer == 0 and verify_host == 0:
+            insecure = True
+        if insecure == True:
+            ssl_context_factory = gevent.ssl._create_unverified_context
+
+        self._client = httpclient.InferenceServerClient(
+            url=server_url,
+            ssl=ssl,
+            ssl_options=client_ssl_options,
+            ssl_context_factory=ssl_context_factory,
+            insecure=insecure)

--- a/model_analyzer/triton/client/http_client.py
+++ b/model_analyzer/triton/client/http_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+server {
+   listen 443 ssl;
+   server_name localhost;
+
+   ssl_certificate /etc/nginx/cert.crt;
+   ssl_certificate_key /etc/nginx/cert.key;
+
+    location / {
+              proxy_pass http://localhost:8000;
+              proxy_http_version 1.1;
+              }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,3 +24,4 @@ pdfkit>=0.6.1
 cryptography>=3.3.2
 httplib2>=0.19.0
 tritonclient[all]>=2.4.0
+gevent>=21.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a duplicate of https://github.com/triton-inference-server/model_analyzer/pull/326 so that we can get it merged since Tanmay is offline right now