### PR TITLE
Explicitly fail if data missing in analyze/report steps

### DIFF
--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -308,9 +308,10 @@ class ResultManager:
         ]
         for model_name in analysis_model_names:
             if model_name not in results:
-                logger.warning(
+                raise TritonModelAnalyzerException(
                     f"Model {model_name} requested for analysis but no results were found. "
-                    "Ensure that this model was actually profiled.")
+                    "Double check the name and ensure that this model was actually profiled."
+                )
             else:
                 result_dict = results[model_name]
                 for (model_config, measurements) in result_dict.values():
@@ -351,9 +352,10 @@ class ResultManager:
 
         if model_name not in results or model_config_name not in results[
                 model_name]:
-            logger.error(
-                f'No results found for model config: {model_config_name}')
-            return (None, [])
+            raise TritonModelAnalyzerException(
+                f"Model Config {model_config_name} requested for report step but no results were found. "
+                "Double check the name and ensure that this model config was actually profiled."
+            )
         else:
             model_config_data = results[model_name][model_config_name]
             return model_config_data[0], list(model_config_data[1].values())


### PR DESCRIPTION
Current behavior:
- Report step will print errors, but not stop. Then it will raise a totally unrelated and confusing error
- Analyze step will print a ton of warnings, one of which (in the middle) actually says that the requested data is missing. Then it will print out empty data tables, and give an invalid "next step" command for the report step

New behavior:
- Both report and analyze will fail very early on if requested model or model variant data does not exist

Top 2 images are before changes. Bottom 2 are after changes.
 
![tgerdes-fix-no-checkpoint-error-report](https://user-images.githubusercontent.com/50968584/156459164-2e3ee3d5-21ba-4357-b0e8-fb7b1421c410.PNG)
![tgerdes-fix-no-checkpoint-error-analysis](https://user-images.githubusercontent.com/50968584/156459169-0a205219-97de-442b-995f-764f431d992b.PNG)


![tgerdes-fix-no-checkpoint-error-analysis-fixed](https://user-images.githubusercontent.com/50968584/156459175-f3a31dbe-c220-4ea3-94ae-edad9bf25b3f.PNG)
![tgerdes-fix-no-checkpoint-error-report-fixed](https://user-images.githubusercontent.com/50968584/156459177-e3157a76-1a76-48dc-8810-6655d207fa3f.PNG)

