### PR TITLE
Prep for MPI PA integration

### DIFF
--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -522,7 +522,7 @@ class ConfigCommandProfile(ConfigCommand):
                         parser_args={'action': 'store_true'},
                         default_value=DEFAULT_RUN_CONFIG_SEARCH_DISABLE,
                         description="Disable run config search."))
-        # FIXME: TODO-MM:  Disable until we support this feature
+        # TODO-TMA-518:  Disable until we support this feature
         # self._add_config(
         #     ConfigField(
         #         'run_config_profile_models_concurrently_enable',

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -533,7 +533,6 @@ class ConfigCommandProfile(ConfigCommand):
         #         DEFAULT_RUN_CONFIG_PROFILE_MODELS_CONCURRENTLY_ENABLE,
         #         description=
         #         "Enable the profiling of all supplied models concurrently."))
-
     def _add_triton_configs(self):
         """
         Adds the triton related flags

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -15,6 +15,9 @@
 from model_analyzer.constants import LOGGER_NAME
 import logging
 
+from model_analyzer.triton.model.model_config import ModelConfig
+from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
+
 logger = logging.getLogger(LOGGER_NAME)
 
 
@@ -54,6 +57,18 @@ class ModelRunConfig:
         """
 
         return self._model_name
+
+    def model_variant_name(self):
+        """
+        Get the model config variant name for this config.
+
+        Returns
+        -------
+        str
+            Model variant name
+        """
+
+        return self.model_config().get_field('name')
 
     def model_config(self):
         """
@@ -100,3 +115,13 @@ class ModelRunConfig:
                 f"Illegal model run config because client batch size {perf_batch_size} is greater than model max batch size {max_batch_size}"
             )
         return legal
+
+    @classmethod
+    def from_dict(cls, model_run_config_dict):
+        model_run_config = ModelRunConfig(None, None, None)
+        model_run_config._model_name = model_run_config_dict['_model_name']
+        model_run_config._model_config = ModelConfig.from_dict(
+            model_run_config_dict['_model_config'])
+        model_run_config._perf_config = PerfAnalyzerConfig.from_dict(
+            model_run_config_dict['_perf_config'])
+        return model_run_config

--- a/model_analyzer/config/run/run_config.py
+++ b/model_analyzer/config/run/run_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from model_analyzer.config.run.model_run_config import ModelRunConfig
+
 
 class RunConfig:
     """
@@ -60,6 +62,15 @@ class RunConfig:
             for model_run_config in self._model_run_configs
         ])
 
+    def cpu_only(self):
+        """
+        Returns true if all model_run_configs only operate on the CPU
+        """
+        return all([
+            model_run_config.model_config().cpu_only()
+            for model_run_config in self._model_run_configs
+        ])
+
     def triton_environment(self):
         """
         Returns
@@ -70,3 +81,23 @@ class RunConfig:
         """
 
         return self._triton_env
+
+    def models_name(self):
+        """ Returns a single comma-joined name of the original model names """
+        return ','.join([mrc.model_name() for mrc in self.model_run_configs()])
+
+    def model_variants_name(self):
+        """ Returns a single comma-joined name of the model variant names """
+        return ','.join(
+            [mrc.model_variant_name() for mrc in self.model_run_configs()])
+
+    @classmethod
+    def from_dict(cls, run_config_dict):
+        run_config = RunConfig({})
+
+        run_config._triton_env = run_config_dict['_triton_env']
+        for mrc_dict in run_config_dict['_model_run_configs']:
+            run_config._model_run_configs.append(
+                ModelRunConfig.from_dict(mrc_dict))
+
+        return run_config

--- a/model_analyzer/plots/plot_manager.py
+++ b/model_analyzer/plots/plot_manager.py
@@ -92,7 +92,7 @@ class PlotManager:
                 constraints = self._constraints[plots_key]
             for run_config_result in self._result_manager.top_n_results(
                     model_name=model_name, n=num_results, include_default=True):
-                if run_config_result.model_configs()[0].cpu_only():
+                if run_config_result.run_config().cpu_only():
                     if plot_config.y_axis() == 'gpu_used_memory':
                         plot_name, plot_config_dict = list(
                             DEFAULT_CPU_MEM_PLOT.items())[0]
@@ -124,7 +124,7 @@ class PlotManager:
         for run_config_measurement in run_config_measurements:
             self._simple_plots[plots_key][
                 plot_config.name()].add_run_config_measurement(
-                    model_config_label=run_config_measurement.model_name(),
+                    label=run_config_measurement.model_variants_name(),
                     run_config_measurement=run_config_measurement)
 
         # In case this plot already had lines, we want to clear and replot

--- a/model_analyzer/plots/simple_plot.py
+++ b/model_analyzer/plots/simple_plot.py
@@ -59,42 +59,41 @@ class SimplePlot:
 
         self._data = {}
 
-    def add_run_config_measurement(self, model_config_label,
-                                   run_config_measurement):
+    def add_run_config_measurement(self, label, run_config_measurement):
         """
         Adds a measurment to this plot
 
         Parameters
         ----------
-        model_config_label : str
-            The name of the model config this measurement
+        label : str
+            The name of the config(s) this measurement
             is taken from. 
         run_config_measurement : RunConfigMeasurement
             The measurement containing the data to
             be plotted.
         """
 
-        if model_config_label not in self._data:
-            self._data[model_config_label] = defaultdict(list)
+        if label not in self._data:
+            self._data[label] = defaultdict(list)
 
         # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         if self._x_axis.replace('_', '-') in PerfAnalyzerConfig.allowed_keys():
-            self._data[model_config_label]['x_data'].append(
+            self._data[label]['x_data'].append(
                 run_config_measurement.model_specific_pa_params()[0][
                     self._x_axis.replace('_', '-')])
         else:
             # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
-            self._data[model_config_label]['x_data'].append(
+            self._data[label]['x_data'].append(
                 run_config_measurement.get_metric_value(tag=self._x_axis))
 
         # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         if self._y_axis.replace('_', '-') in PerfAnalyzerConfig.allowed_keys():
-            self._data[model_config_label]['y_data'].append(
+            self._data[label]['y_data'].append(
                 run_config_measurement.model_specific_pa_params()[0][
                     self._y_axis.replace('_', '-')])
         else:
             # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
-            self._data[model_config_label]['y_data'].append(
+            self._data[label]['y_data'].append(
                 run_config_measurement.get_metric_value(tag=self._y_axis))
 
     def clear(self):
@@ -136,8 +135,9 @@ class SimplePlot:
 
         for model_config_name, data in self._data.items():
             # Sort the data by x-axis
-            x_data, y_data = (list(t) for t in zip(
-                *sorted(zip(data['x_data'], data['y_data']))))
+            x_data, y_data = (
+                list(t)
+                for t in zip(*sorted(zip(data['x_data'], data['y_data']))))
 
             if self._monotonic:
                 filtered_x, filtered_y = [x_data[0]], [y_data[0]]

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -172,28 +172,21 @@ class MetricsManager:
         measurement to the result manager
         """
 
-        # TODO TMA-518
-        model_run_config = run_config.model_run_configs()[0]
-
-        # Create model variants
-        self._create_model_variants(model_run_config)
+        self._create_model_variants(run_config)
 
         # If this run config was already run, do not run again, just get the measurement
-        measurement = self._get_measurement_if_config_duplicate(
-            model_run_config)
+        measurement = self._get_measurement_if_config_duplicate(run_config)
         if measurement:
             logger.info(
                 "Existing measurement found for run config. Skipping profile")
             return measurement
 
-        # Start server, and load model variants
         self._server.start(env=run_config.triton_environment())
-        if not self._load_model_variants(model_run_config):
+        if not self._load_model_variants(run_config):
             self._server.stop()
             return
 
-        # Profile various batch size and concurrency values.
-        measurement = self.profile_model(run_config)
+        measurement = self.profile_models(run_config)
 
         self._server.stop()
 
@@ -203,9 +196,9 @@ class MetricsManager:
         """
         Creates and fills all model variant directories
         """
-
-        self._create_model_variant(original_name=run_config.model_name(),
-                                   variant_config=run_config.model_config())
+        for mrc in run_config.model_run_configs():
+            self._create_model_variant(original_name=mrc.model_name(),
+                                       variant_config=mrc.model_config())
 
     def _create_model_variant(self, original_name, variant_config):
         """
@@ -237,10 +230,9 @@ class MetricsManager:
         """
         Loads all model variants in the client
         """
-
-        if not self._load_model_variant(
-                variant_config=run_config.model_config()):
-            return False
+        for mrc in run_config.model_run_configs():
+            if not self._load_model_variant(variant_config=mrc.model_config()):
+                return False
         return True
 
     def _load_model_variant(self, variant_config):
@@ -279,22 +271,22 @@ class MetricsManager:
         in the state manager's results object
         """
 
-        model_name = run_config.model_name()
-        model_config_name = run_config.model_config().get_field('name')
+        models_name = run_config.models_name()
+        model_variants_name = run_config.model_variants_name()
         key = run_config.representation()
 
         results = self._state_manager.get_state_variable(
             'ResultManager.results')
 
-        if not results.contains_model_config(model_name, model_config_name):
+        if not results.contains_model_variant(models_name, model_variants_name):
             return False
 
-        measurements = results.get_model_config_measurements_dict(
-            model_name, model_config_name)
+        measurements = results.get_model_variants_measurements_dict(
+            models_name, model_variants_name)
 
         return measurements.get(key, None)
 
-    def profile_model(self, run_config):
+    def profile_models(self, run_config):
         """
         Runs monitors while running perf_analyzer with a specific set of
         arguments. This will profile model inferencing.
@@ -310,49 +302,21 @@ class MetricsManager:
             The gpu specific and non gpu metrics
         """
 
-        # TODO TMA-518
-        model_run_config = run_config.model_run_configs()[0]
-
-        # TODO: Need to sort the values for batch size and concurrency
-        # for correct measurment of the GPU memory metrics.
         perf_output_writer = None if \
             not self._config.perf_output else FileWriter(self._config.perf_output_path)
-        perf_config = model_run_config.perf_config()
-        logger.info(
-            f"Profiling {perf_config['model-name']}: client batch size={perf_config['batch-size']}, concurrency={perf_config['concurrency-range']}"
-        )
+        cpu_only = run_config.cpu_only()
 
-        cpu_only = model_run_config.model_config().cpu_only()
-        perf_config = model_run_config.perf_config()
+        self._print_run_config_info(run_config)
 
-        # Inform user CPU metric(s) are not being collected under CPU mode
-        collect_cpu_metrics_expect = cpu_only or len(self._gpus) == 0
-        collect_cpu_metrics_actual = len(self._cpu_metrics) > 0
-        if collect_cpu_metrics_expect and not collect_cpu_metrics_actual:
-            logger.info(
-                "CPU metric(s) are not being collected, while this profiling will run on CPU(s)."
-            )
-        # Warn user about CPU monitor performance issue
-        if collect_cpu_metrics_actual:
-            logger.warning("CPU metric(s) are being collected.")
-            logger.warning(
-                "Collecting CPU metric(s) can affect the latency or throughput numbers reported by perf analyzer."
-            )
-
-        # Start monitors and run perf_analyzer
         self._start_monitors(cpu_only=cpu_only)
-        perf_analyzer_metrics_or_status = self._get_perf_analyzer_metrics(
-            perf_config,
-            perf_output_writer,
-            perf_analyzer_env=run_config.triton_environment())
 
-        # Failed Status
-        if perf_analyzer_metrics_or_status == 1:
+        perf_analyzer_metrics = self._run_perf_analyzer(run_config,
+                                                        perf_output_writer)
+
+        if not perf_analyzer_metrics:
             self._stop_monitors(cpu_only=cpu_only)
             self._destroy_monitors(cpu_only=cpu_only)
             return None
-        else:
-            perf_analyzer_metrics = perf_analyzer_metrics_or_status
 
         # Get metrics for model inference and combine metrics that do not have GPU UUID
         model_gpu_metrics = {}
@@ -362,27 +326,31 @@ class MetricsManager:
 
         self._destroy_monitors(cpu_only=cpu_only)
 
-        model_non_gpu_metrics = list(perf_analyzer_metrics.values()) + list(
-            model_cpu_metrics.values())
-
         run_config_measurement = None
-        if model_gpu_metrics is not None and model_non_gpu_metrics is not None:
+        if model_gpu_metrics is not None and perf_analyzer_metrics is not None:
 
             run_config_measurement = RunConfigMeasurement(
-                run_config.representation(), perf_config['model-name'],
-                model_gpu_metrics)
+                run_config.model_variants_name(), model_gpu_metrics)
 
-            # FIXME: TMA-518 - this needs to be added per model
-            model_specific_pa_params = perf_config.extract_model_specific_parameters(
-            )
+            # Combine all per-model measurements into the RunConfigMeasurement
+            #
+            for model_run_config in run_config.model_run_configs():
+                perf_config = model_run_config.perf_config()
+                model_name = perf_config['model-name']
 
-            run_config_measurement.add_model_config_measurement(
-                perf_config['model-name'], model_specific_pa_params,
-                model_non_gpu_metrics)
+                model_non_gpu_metrics = \
+                      list(perf_analyzer_metrics[model_name].values()) \
+                    + list(model_cpu_metrics.values())
 
-            # FIXME: TMA-518 this should be taking the run_config (multiple model_run_configs will be extracted)
+                model_specific_pa_params = perf_config.extract_model_specific_parameters(
+                )
+
+                run_config_measurement.add_model_config_measurement(
+                    perf_config['model-name'], model_specific_pa_params,
+                    model_non_gpu_metrics)
+
             self._result_manager.add_run_config_measurement(
-                model_run_config, run_config_measurement)
+                run_config, run_config_measurement)
 
         return run_config_measurement
 
@@ -436,47 +404,45 @@ class MetricsManager:
         self._gpu_monitor = None
         self._cpu_monitor = None
 
-    def _get_perf_analyzer_metrics(self,
-                                   perf_config,
-                                   perf_output_writer=None,
-                                   perf_analyzer_env=None):
+    def _run_perf_analyzer(self, run_config, perf_output_writer):
         """
-        Gets the aggregated metrics from the perf_analyzer
+        Runs perf_analyzer and returns the aggregated metrics
+
         Parameters
         ----------
-        perf_config : dict
-            The keys are arguments to perf_analyzer The values are their
-            values
+        run_config : RunConfig
+            The RunConfig to execute on perf analyzer
+
         perf_output_writer : OutputWriter
             Writer that writes the output from perf_analyzer to the output
             stream/file. If None, the output is not written
-        perf_analyzer_env : dict
-            a dict of name:value pairs for the environment variables with which
-            perf_analyzer should be run.
 
         Raises
         ------
         TritonModelAnalyzerException
         """
 
-        perf_analyzer = PerfAnalyzer(
-            path=self._config.perf_analyzer_path,
-            config=perf_config,
-            max_retries=self._config.perf_analyzer_max_auto_adjusts,
-            timeout=self._config.perf_analyzer_timeout,
-            max_cpu_util=self._config.perf_analyzer_cpu_util)
+        perf_analyzer_env = run_config.triton_environment()
 
         # IF running with C_API, need to set CUDA_VISIBLE_DEVICES here
         if self._config.triton_launch_mode == 'c_api':
             perf_analyzer_env['CUDA_VISIBLE_DEVICES'] = ','.join(
                 [gpu.device_uuid() for gpu in self._gpus])
 
+        perf_analyzer = PerfAnalyzer(
+            path=self._config.perf_analyzer_path,
+            config=run_config,
+            max_retries=self._config.perf_analyzer_max_auto_adjusts,
+            timeout=self._config.perf_analyzer_timeout,
+            max_cpu_util=self._config.perf_analyzer_cpu_util)
+
         status = perf_analyzer.run(self._perf_metrics, env=perf_analyzer_env)
 
         if perf_output_writer:
+            # TODO-TMA-518: MPI command
             perf_output_writer.write(
                 '============== Perf Analyzer Launched ==============\n '
-                f'Command: perf_analyzer {perf_config.to_cli_string()} \n\n',
+                f'Command: perf_analyzer {run_config.model_run_configs()[0].perf_config().to_cli_string()} \n\n',
                 append=True)
             if perf_analyzer.output():
                 perf_output_writer.write(perf_analyzer.output() + '\n',
@@ -484,13 +450,17 @@ class MetricsManager:
 
         # PerfAnalyzer run was not succesful
         if status == 1:
-            return 1
+            return None
 
-        perf_records = perf_analyzer.get_records()
-        perf_record_aggregator = RecordAggregator()
-        perf_record_aggregator.insert_all(perf_records)
+        per_model_perf_records = perf_analyzer.get_records()
 
-        return perf_record_aggregator.aggregate()
+        for (model, perf_records) in per_model_perf_records.items():
+            perf_record_aggregator = RecordAggregator()
+            perf_record_aggregator.insert_all(perf_records)
+
+            per_model_perf_records[model] = perf_record_aggregator.aggregate()
+
+        return per_model_perf_records
 
     def _get_gpu_inference_metrics(self):
         """
@@ -574,6 +544,30 @@ class MetricsManager:
                     triton_gpus.append(sample.labels['gpu_uuid'])
 
         return triton_gpus
+
+    def _print_run_config_info(self, run_config):
+        for perf_config in [
+                mrc.perf_config() for mrc in run_config.model_run_configs()
+        ]:
+            logger.info(
+                f"Profiling {perf_config['model-name']}: client batch size={perf_config['batch-size']}, concurrency={perf_config['concurrency-range']}"
+            )
+
+        cpu_only = run_config.cpu_only()
+
+        # Inform user CPU metric(s) are not being collected under CPU mode
+        collect_cpu_metrics_expect = cpu_only or len(self._gpus) == 0
+        collect_cpu_metrics_actual = len(self._cpu_metrics) > 0
+        if collect_cpu_metrics_expect and not collect_cpu_metrics_actual:
+            logger.info(
+                "CPU metric(s) are not being collected, while this profiling will run on CPU(s)."
+            )
+        # Warn user about CPU monitor performance issue
+        if collect_cpu_metrics_actual:
+            logger.warning("CPU metric(s) are being collected.")
+            logger.warning(
+                "Collecting CPU metric(s) can affect the latency or throughput numbers reported by perf analyzer."
+            )
 
     @staticmethod
     def get_metric_types(tags):

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -191,7 +191,8 @@ class ReportManager:
 
             # TODO-TMA-568: This needs to be updated because there will be multiple model configs
             for result in top_results:
-                model_config = result.model_configs()[0]
+                model_config = result.run_config().model_run_configs(
+                )[0].model_config()
                 for measurement in result.top_n_measurements(n=1):
                     self._summary_data[model_name].append(
                         (model_config, measurement))
@@ -200,7 +201,8 @@ class ReportManager:
         if self._config.num_top_model_configs:
             for result in self._result_manager.top_n_results(
                     n=self._config.num_top_model_configs):
-                model_config = result.model_configs()[0]
+                model_config = result.run_config().model_run_configs(
+                )[0].model_config()
                 for measurement in result.top_n_measurements(n=1):
                     self._summary_data[TOP_MODELS_REPORT_KEY].append(
                         (model_config, measurement))
@@ -216,6 +218,7 @@ class ReportManager:
             for model in self._config.report_model_configs
         ]
 
+        # TODO-TMA-568 - this likely needs to be updated for multi-model
         for model_config_name in model_config_names:
             self._detailed_report_data[
                 model_config_name] = self._result_manager.get_model_configs_run_config_measurements(
@@ -538,8 +541,10 @@ class ReportManager:
         specified
         """
 
-        model_config, measurements = self._detailed_report_data[
-            model_config_name]
+        run_config, measurements = self._detailed_report_data[model_config_name]
+
+        # TODO-TMA-568 - add support for multi-model
+        model_config = run_config.model_run_configs()[0].model_config()
         instance_group_string = model_config.instance_group_string()
         dynamic_batching = model_config.dynamic_batching_string()
         max_batch_size = model_config.max_batch_size()
@@ -554,7 +559,7 @@ class ReportManager:
 
         gpu_cpu_string = "CPU"
 
-        if not model_config.cpu_only():
+        if not run_config.cpu_only():
             gpu_dict = self._get_gpu_stats(measurements=measurements)
             gpu_names = ','.join(list(gpu_dict.keys()))
             max_memories = ','.join([str(x) + ' GB' for x in gpu_dict.values()])

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -202,7 +202,7 @@ class ResultManager:
                     for gpu_metric in gpu_metrics:
                         if gpu_metric.tag not in gpu_specific_metrics_from_measurements:
                             gpu_specific_metrics_from_measurements[
-                                gpu_metric[0]] = gpu_metric
+                                gpu_metric.tag] = gpu_metric
 
                 for non_gpu_metric_list in run_config_measurement.non_gpu_data(
                 ):
@@ -253,8 +253,6 @@ class ResultManager:
         self._state_manager.set_state_variable('ResultManager.server_only_data',
                                                data)
 
-    # FIXME: TMA-518 this should be taking the run_config
-    # and extracting the multiple model_run_config will be extracted
     def add_run_config_measurement(self, run_config, run_config_measurement):
         """
         This function adds model inference
@@ -264,7 +262,6 @@ class ResultManager:
         ----------
         run_config : RunConfig
             Contains the parameters used to generate the measurment
-            like the model name, model_config_name
         run_config_measurement: RunConfigMeasurement
             the measurement to be added
         """

--- a/model_analyzer/result/results.py
+++ b/model_analyzer/result/results.py
@@ -68,13 +68,12 @@ class Results:
 
     def add_run_config_measurement(self, run_config, run_config_measurement):
         """
-        Given a ModelRunConfig and a RunConfigMeasurement, add the measurement to the
-        ModelRunConfig's measurements
+        Given a RunConfig and a RunConfigMeasurement, add the measurement to the
+        RunConfig's measurements
         
         Parameters
         ----------
         run_config: RunConfig
-        key: str
         run_config_measurement: RunConfigMeasurement
         """
 
@@ -166,35 +165,49 @@ class Results:
 
         return measurements
 
-    def get_model_measurements_dict(self, model_name):
+    def get_model_measurements_dict(self, models_name):
         """
-        # FIXME is this description correct?
-        Given a model name, return a dict of tuples of model configs and 
-        a dict of all associated measurement values
+        Given a model name, return a dict with all measurements for that model.
         
         Parameters
         ----------
-        model_name : str
+        models_name : str
             The model name for the requested results
             
         Returns
         -------
-        Dict of tuples - {(ModelConfig, list of RunConfigMeasurements)}
-            Dict of tuples consisting of the model's ModelConfig 
-            and a list of all associated measurement values
+        Dict (keyed by model_variants_name) of tuples containing a RunConfig and 
+        a dict of Keys:RunConfigMeasurements
+            {
+                model_variants_name_1: 
+                (
+                    RunConfig1, 
+                    {
+                        Key1: RunConfigMeasurement1
+                        Key2: RunConfigMeasurement2
+                    }
+                ),
+                model_variants_name_2: 
+                (
+                    RunConfig2, 
+                    {
+                        Key3: RunConfigMeasurement3
+                        Key4: RunConfigMeasurement4
+                    }
+                )
+            }
         """
-        if not self.contains_model(model_name):
-            logger.error(f'No results found for model: {model_name}')
+        if not self.contains_model(models_name):
+            logger.error(f'No results found for model: {models_name}')
             return {}
 
-        return self._results[model_name]
+        return self._results[models_name]
 
     def get_model_variants_measurements_dict(self, models_name,
                                              model_variants_name):
         """
-        FIXME: is this description correct?
-        Given a models name and model variants name, return a dict where the
-        key is run_config and the values are list of all associated measurements
+        Given a models name and model variants name, return a dict of all 
+        associated RunConfigMeasurements
         
         Parameters
         ----------
@@ -203,7 +216,7 @@ class Results:
 
         Returns
         -------
-        Dict of RunConfigMeasurements
+        Dict of {Key:RunConfigMeasurement}
         """
         if not self.contains_model(
                 models_name) or not self.contains_model_variant(
@@ -214,32 +227,29 @@ class Results:
         return self._results[models_name][model_variants_name][
             Results.MEASUREMENTS_INDEX]
 
-    def get_all_model_variant_measurements(self, model_name,
-                                           model_variant_name):
+    def get_all_model_variant_measurements(self, models_name,
+                                           model_variants_name):
         """
         Given a model name and model variant name, return the RunConfig and 
         a list of all associated measurement values
         
         Parameters
         ----------
-        model_name : str
-        model_variant_name: str
+        models_name : str
+        model_variants_name: str
 
         Returns
         -------
         Tuple - (RunConfig, list of RunConfigMeasurements)
-            Tuple consisting of the model_config and a list of
-            all associated measurement values
         """
-        # FIXME -- run config or model config here?
         if not self.contains_model(
-                model_name) or not self.contains_model_variant(
-                    model_name, model_variant_name):
+                models_name) or not self.contains_model_variant(
+                    models_name, model_variants_name):
             logger.error(
-                f'No results found for model config: {model_variant_name}')
+                f'No results found for model variant: {model_variants_name}')
             return (None, [])
 
-        model_config_data = self._results[model_name][model_variant_name]
+        model_config_data = self._results[models_name][model_variants_name]
 
         return model_config_data[Results.RUN_CONFIG_INDEX], list(
             model_config_data[Results.MEASUREMENTS_INDEX].values())

--- a/model_analyzer/result/results.py
+++ b/model_analyzer/result/results.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from model_analyzer.triton.model.model_config import ModelConfig
+from model_analyzer.config.run.run_config import RunConfig
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 from model_analyzer.constants import LOGGER_NAME
 
@@ -25,7 +25,7 @@ class Results:
     """
     Provides storage and accessor functions for measurements
     """
-    MODEL_CONFIG_INDEX = 0
+    RUN_CONFIG_INDEX = 0
     MEASUREMENTS_INDEX = 1
 
     def __init__(self):
@@ -40,7 +40,7 @@ class Results:
         (stored in the checkpoint)
         
         The checkpoint format is:
-        {model_name: { [model_config: (key, {run_config_measurements} ) ] } }
+        {models_name: { [run_config: (key, {run_config_measurements} ) ] } }
         ---results_dict-------------------------------------------
                      ---model_dict------------------------------
                        ---model_config_tuple_list-------------
@@ -48,80 +48,78 @@ class Results:
         """
         results = Results()
 
-        for model_name, model_dict in results_dict['_results'].items():
-            for model_config_name, model_config_tuple_list in model_dict.items(
+        for models_name, model_dict in results_dict['_results'].items():
+            for model_variants_name, run_config_tuple_list in model_dict.items(
             ):
-                model_config = ModelConfig.from_dict(
-                    model_config_tuple_list[Results.MODEL_CONFIG_INDEX])
+                run_config = RunConfig.from_dict(
+                    run_config_tuple_list[Results.RUN_CONFIG_INDEX])
 
-                for key, measurement_dict in model_config_tuple_list[
+                for key, measurement_dict in run_config_tuple_list[
                         Results.MEASUREMENTS_INDEX].items():
                     run_config_measurement = RunConfigMeasurement.from_dict(
                         measurement_dict)
 
-                    results._add_run_config_measurement(model_name,
-                                                        model_config,
-                                                        model_config_name, key,
+                    results._add_run_config_measurement(models_name, run_config,
+                                                        model_variants_name,
+                                                        key,
                                                         run_config_measurement)
 
         return results
 
-    def add_run_config_measurement(self, model_run_config,
-                                   run_config_measurement):
+    def add_run_config_measurement(self, run_config, run_config_measurement):
         """
         Given a ModelRunConfig and a RunConfigMeasurement, add the measurement to the
         ModelRunConfig's measurements
         
         Parameters
         ----------
-        model_run_config: ModelRunConfig
+        run_config: RunConfig
         key: str
         run_config_measurement: RunConfigMeasurement
         """
-        model_name, model_config, model_config_name, key = self._extract_model_run_config_fields(
-            model_run_config)
 
-        self._add_run_config_measurement(model_name, model_config,
-                                         model_config_name, key,
+        models_name = run_config.models_name()
+        model_variants_name = run_config.model_variants_name()
+        key = run_config.representation()
+
+        self._add_run_config_measurement(models_name, run_config,
+                                         model_variants_name, key,
                                          run_config_measurement)
 
-    def contains_model(self, model_name):
+    def contains_model(self, models_name):
         """
-        Checks if the model name exists
+        Checks if the models name exists
         in the results
 
         Parameters
         ----------
-        model_name : str
-            The model name
+        models_name : str
+            The models name
 
         Returns
         -------
         bool
         """
-        return model_name in self._results
+        return models_name in self._results
 
-    def contains_model_config(self, model_name, model_config_name):
+    def contains_model_variant(self, models_name, model_variants_name):
         """
-        Checks if the model name and model config name
-        exists in the results
+        Checks if the models name and model variants name
+        exist in the results
         
         Parameters
         ----------
-        model_name : str
-            The model name
-            
-        model_config_name: str
-            The model config name 
+        models_name : str
+        model_variants_name: str
             
         Returns
         -------
         bool
         """
-        if not self.contains_model(model_name):
+        if not self.contains_model(models_name):
             return False
 
-        return model_config_name in self._results[model_name]
+        return model_variants_name in self._results[models_name]
 
     def get_list_of_models(self):
         """
@@ -170,6 +168,7 @@ class Results:
 
     def get_model_measurements_dict(self, model_name):
         """
+        # FIXME is this description correct?
         Given a model name, return a dict of tuples of model configs and 
         a dict of all associated measurement values
         
@@ -190,77 +189,69 @@ class Results:
 
         return self._results[model_name]
 
-    def get_model_config_measurements_dict(self, model_name, model_config_name):
+    def get_model_variants_measurements_dict(self, models_name,
+                                             model_variants_name):
         """
-        Given a model name and model config name, return a dict where the
-        key is model configs and the values are list of all associated measurements
+        FIXME: is this description correct?
+        Given a models name and model variants name, return a dict where the
+        key is run_config and the values are list of all associated measurements
         
         Parameters
         ----------
         model_name : str
-            The model name for the requested results
-            
-        model_config_name: str
-            The model config name for the requested results
+        model_variants_name: str
 
         Returns
         -------
         Dict of RunConfigMeasurements
         """
         if not self.contains_model(
-                model_name) or not self.contains_model_config(
-                    model_name, model_config_name):
-            logger.error(
-                f'No results found for model config: {model_config_name}')
+                models_name) or not self.contains_model_variant(
+                    models_name, model_variants_name):
+            logger.error(f'No results found for variant: {model_variants_name}')
             return {}
 
-        return self._results[model_name][model_config_name][
+        return self._results[models_name][model_variants_name][
             Results.MEASUREMENTS_INDEX]
 
-    def get_all_model_config_measurements(self, model_name, model_config_name):
+    def get_all_model_variant_measurements(self, model_name,
+                                           model_variant_name):
         """
-        Given a model name and model config name, return the model config and 
+        Given a model name and model variant name, return the RunConfig and 
         a list of all associated measurement values
         
         Parameters
         ----------
         model_name : str
-            The model name for the requested results
-            
-        model_config_name: str
-            The model config name for the requested results
+        model_variant_name: str
 
         Returns
         -------
-        Tuple - (ModelConfig, list of RunConfigMeasurements)
+        Tuple - (RunConfig, list of RunConfigMeasurements)
             Tuple consisting of the model_config and a list of
             all associated measurement values
         """
+        # FIXME -- run config or model config here?
         if not self.contains_model(
-                model_name) or not self.contains_model_config(
-                    model_name, model_config_name):
+                model_name) or not self.contains_model_variant(
+                    model_name, model_variant_name):
             logger.error(
-                f'No results found for model config: {model_config_name}')
+                f'No results found for model config: {model_variant_name}')
             return (None, [])
 
-        model_config_data = self._results[model_name][model_config_name]
+        model_config_data = self._results[model_name][model_variant_name]
 
-        return model_config_data[Results.MODEL_CONFIG_INDEX], list(
+        return model_config_data[Results.RUN_CONFIG_INDEX], list(
             model_config_data[Results.MEASUREMENTS_INDEX].values())
 
-    def _add_run_config_measurement(self, model_name, model_config,
-                                    model_config_name, key,
+    def _add_run_config_measurement(self, models_name, run_config,
+                                    model_variants_name, key,
                                     run_config_measurement):
-        if model_name not in self._results:
-            self._results[model_name] = {}
+        if models_name not in self._results:
+            self._results[models_name] = {}
 
-        if model_config_name not in self._results[model_name]:
-            self._results[model_name][model_config_name] = (model_config, {})
+        if model_variants_name not in self._results[models_name]:
+            self._results[models_name][model_variants_name] = (run_config, {})
 
-        self._results[model_name][model_config_name][
+        self._results[models_name][model_variants_name][
             Results.MEASUREMENTS_INDEX][key] = run_config_measurement
-
-    def _extract_model_run_config_fields(self, model_run_config):
-        return (model_run_config.model_name(), model_run_config.model_config(),
-                model_run_config.model_config().get_field('name'),
-                model_run_config.representation())

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -33,18 +33,16 @@ class RunConfigMeasurement:
     in a single RunConfig
     """
 
-    def __init__(self, key, model_name, gpu_data):
+    def __init__(self, model_variants_name, gpu_data):
         """
-        key: str
-        Unique string which can be used to differentiate this measurement 
-        from all others in the model
+        model_variants_name: str
+            Name of the model variants this measurement was collected for
         
         gpu_data : dict of list of Records
             Metrics from the monitors that have a GPU UUID
             associated with them            
         """
-        self._key = key
-        self._model_name = model_name
+        self._model_variants_name = model_variants_name
 
         self._gpu_data = gpu_data
         self._avg_gpu_data = self._average_list(list(self._gpu_data.values()))
@@ -55,11 +53,10 @@ class RunConfigMeasurement:
 
     @classmethod
     def from_dict(cls, run_config_measurement_dict):
-        run_config_measurement = RunConfigMeasurement(None, None, {})
+        run_config_measurement = RunConfigMeasurement(None, {})
 
-        run_config_measurement._key = run_config_measurement_dict['_key']
-        run_config_measurement._model_name = run_config_measurement_dict[
-            '_model_name']
+        run_config_measurement._model_variants_name = run_config_measurement_dict[
+            '_model_variants_name']
 
         run_config_measurement._gpu_data = cls._deserialize_gpu_data(
             run_config_measurement, run_config_measurement_dict['_gpu_data'])
@@ -123,14 +120,13 @@ class RunConfigMeasurement:
         for index, measurement in enumerate(self._model_config_measurements):
             measurement.set_metric_weighting(metric_objectives[index])
 
-    def key(self):
+    def model_variants_name(self):
         """
-        Returns
-        -------
-        str: Key used to uniquely identify the RunConfigMeasurement
+        Returns: str
+            The name of the model variants this measurement was collected for
         """
 
-        return self._key
+        return self._model_variants_name
 
     def model_name(self):
         """

--- a/model_analyzer/result/run_config_result.py
+++ b/model_analyzer/result/run_config_result.py
@@ -30,14 +30,13 @@ class RunConfigResult:
     to a particular ResultTable
     """
 
-    def __init__(self, model_name, model_configs, comparator, constraints=None):
+    def __init__(self, model_name, run_config, comparator, constraints=None):
         """
         Parameters
         ----------
         model_name: str
             The name of the model
-        model_configs : list of ModelConfigs
-            The list of model configs corresponding to this RunConfig
+        run_config : RunConfig
         comparator : RunConfigResultComparator
             An object whose compare function receives two
             RunConfigResults and returns 1 if the first is better than
@@ -49,7 +48,7 @@ class RunConfigResult:
         """
 
         self._model_name = model_name
-        self._model_configs = model_configs
+        self._run_config = run_config
         self._comparator = comparator
         self._constraints = constraints
 
@@ -68,15 +67,9 @@ class RunConfigResult:
 
         return self._model_name
 
-    def model_configs(self):
-        """
-        Returns
-        -------
-        List of ModelConfigs
-            Returns the list model_configs associated with this RunConfigResult
-        """
-
-        return self._model_configs
+    def run_config(self):
+        """ Returns the RunConfig associated with this result """
+        return self._run_config
 
     def failing(self):
         """

--- a/model_analyzer/state/analyzer_state_manager.py
+++ b/model_analyzer/state/analyzer_state_manager.py
@@ -155,7 +155,7 @@ class AnalyzerStateManager:
         if self._state_changed:
             with open(ckpt_filename, 'w') as f:
                 json.dump(self._current_state, f, default=self.default_encode)
-            logger.info(f"Saved checkpoint to {ckpt_filename}.")
+            logger.info(f"Saved checkpoint to {ckpt_filename}")
 
             self._checkpoint_index += 1
             self._state_changed = False

--- a/qa/L0_analyze/test.sh
+++ b/qa/L0_analyze/test.sh
@@ -20,7 +20,7 @@ rm -f *.log
 # Set test parameters
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/qa/L0_output_fields/test.sh
+++ b/qa/L0_output_fields/test.sh
@@ -24,7 +24,7 @@ python3 config_generator.py
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
 EXPORT_PATH="`pwd`/results"
 FILENAME_SERVER_ONLY="server-metrics.csv"
 FILENAME_INFERENCE_MODEL="model-metrics-inference.csv"

--- a/qa/L0_results/test.sh
+++ b/qa/L0_results/test.sh
@@ -22,7 +22,7 @@ rm -rf results && mkdir -p results
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -189,10 +189,9 @@ def construct_run_config_measurement(model_name, model_config_names,
     """
 
     gpu_data = convert_gpu_metrics_to_data(gpu_metric_values)
-    pa_config = construct_perf_analyzer_config(model_name=model_name)
 
-    rc_measurement = RunConfigMeasurement(pa_config.representation(),
-                                          model_name, gpu_data)
+    model_variants_name = ''.join(model_config_names)
+    rc_measurement = RunConfigMeasurement(model_variants_name, gpu_data)
 
     non_gpu_data = [
         convert_non_gpu_metrics_to_data(non_gpu_metric_value)
@@ -215,8 +214,8 @@ def construct_run_config_result(avg_gpu_metric_values,
                                 avg_non_gpu_metric_values,
                                 comparator,
                                 value_step=1,
-                                model_name=None,
-                                model_config=None):
+                                model_name="fake_model_name",
+                                run_config=None):
     """
     Takes a dictionary whose values are average
     metric values, constructs artificial data 
@@ -248,7 +247,7 @@ def construct_run_config_result(avg_gpu_metric_values,
 
     # Construct a result
     run_config_result = RunConfigResult(model_name=model_name,
-                                        model_configs=[model_config],
+                                        run_config=run_config,
                                         comparator=comparator)
 
     # Get dict of list of metric values

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from model_analyzer.analyzer import Analyzer
 from model_analyzer.cli.cli import CLI
 from model_analyzer.config.input.config_command_analyze import ConfigCommandAnalyze
@@ -23,7 +23,9 @@ from model_analyzer.constants import CONFIG_PARSER_SUCCESS
 from model_analyzer.result.results import Results
 from model_analyzer.result.run_config_result import RunConfigResult
 from model_analyzer.state.analyzer_state_manager import AnalyzerStateManager
+from model_analyzer.config.run.run_config import RunConfig
 from model_analyzer.triton.model.model_config import ModelConfig
+from model_analyzer.config.run.model_run_config import ModelRunConfig
 
 from google.protobuf import json_format
 from tritonclient.grpc import model_config_pb2
@@ -81,22 +83,30 @@ class TestAnalyzer(trc.TestResultCollector):
             '/tmp/my_checkpoints`')
 
     def mock_top_n_results(self, model_name=None, n=-1):
+
+        rc1 = RunConfig({})
+        rc1.add_model_run_config(
+            ModelRunConfig(
+                "fake_model_name",
+                ModelConfig.create_from_dictionary({"name": "config1"}),
+                MagicMock()))
+        rc2 = RunConfig({})
+        rc2.add_model_run_config(
+            ModelRunConfig(
+                "fake_model_name",
+                ModelConfig.create_from_dictionary({"name": "config3"}),
+                MagicMock()))
+        rc3 = RunConfig({})
+        rc3.add_model_run_config(
+            ModelRunConfig(
+                "fake_model_name",
+                ModelConfig.create_from_dictionary({"name": "config4"}),
+                MagicMock()))
+
         return [
-            RunConfigResult(None, [
-                ModelConfig(
-                    json_format.ParseDict({'name': 'config1'},
-                                          model_config_pb2.ModelConfig()))
-            ], None),
-            RunConfigResult(None, [
-                ModelConfig(
-                    json_format.ParseDict({'name': 'config3'},
-                                          model_config_pb2.ModelConfig()))
-            ], None),
-            RunConfigResult(None, [
-                ModelConfig(
-                    json_format.ParseDict({'name': 'config4'},
-                                          model_config_pb2.ModelConfig()))
-            ], None)
+            RunConfigResult("fake_model_name", rc1, MagicMock()),
+            RunConfigResult("fake_model_name", rc2, MagicMock()),
+            RunConfigResult("fake_model_name", rc3, MagicMock())
         ]
 
     @patch(

--- a/tests/test_model_config_generator.py
+++ b/tests/test_model_config_generator.py
@@ -638,7 +638,7 @@ class TestModelConfigGenerator(trc.TestResultCollector):
 
         measurement = construct_run_config_measurement(
             model_name=MagicMock(),
-            model_config_names=[MagicMock()],
+            model_config_names=["test_model_config_name"],
             model_specific_pa_params=MagicMock(),
             gpu_metric_values=MagicMock(),
             non_gpu_metric_values=[{

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -67,7 +67,7 @@ class MetricsManagerSubclass(MetricsManager):
         else:
             return construct_run_config_measurement(
                 model_name=MagicMock(),
-                model_config_names=[MagicMock()],
+                model_config_names=["test_model_config_name"],
                 model_specific_pa_params=MagicMock(),
                 gpu_metric_values=MagicMock(),
                 non_gpu_metric_values=[{
@@ -914,7 +914,7 @@ class TestModelManager(trc.TestResultCollector):
                                      MagicMock(), MagicMock(), metrics_manager,
                                      MagicMock(), state_manager)
 
-        model_manager.run_model(config.profile_models[0])
+        model_manager.run_models([config.profile_models[0]])
         self.mock_model_config.stop()
 
         self._check_results(model_manager, expected_ranges)

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -18,6 +18,8 @@ from model_analyzer.config.input.config_command_analyze \
 from model_analyzer.config.input.config_command_report \
     import ConfigCommandReport
 from model_analyzer.config.run.model_run_config import ModelRunConfig
+from model_analyzer.config.run.run_config import RunConfig
+from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
 
 from model_analyzer.reports.report_manager import ReportManager
 from model_analyzer.result.run_config_result_comparator import RunConfigResultComparator
@@ -121,7 +123,11 @@ class TestReportManagerMethods(trc.TestResultCollector):
             metric_objectives=result_comparator._metric_weights,
             model_config_weights=[1])
 
-        run_config = ModelRunConfig(model_name, model_config, MagicMock())
+        perf_config = PerfAnalyzerConfig()
+        perf_config.update_config({'model-name': model_config_name})
+        mrc = ModelRunConfig(model_name, model_config, perf_config)
+        run_config = RunConfig({})
+        run_config.add_model_run_config(mrc)
 
         self.result_manager.add_run_config_measurement(run_config, measurement)
 

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
+from model_analyzer.triton.model.model_config import ModelConfig
+
+from .common import test_result_collector as trc
+
+from model_analyzer.config.run.model_run_config import ModelRunConfig
+from model_analyzer.config.run.run_config import RunConfig
+
+
+class TestRunConfig(trc.TestResultCollector):
+
+    def test_triton_env(self):
+        """ 
+        Test triton env initialized correctly and returns correctly from function
+        """
+        fake_env = {'a': 5, 'b': {'c': 7}}
+        rc = RunConfig(fake_env)
+        self.assertEqual(rc.triton_environment(), fake_env)
+
+    def test_model_run_configs(self):
+        """
+        Test adding and getting ModelRunConfigs
+        """
+        mrc1 = ModelRunConfig("model1", MagicMock(), MagicMock())
+        mrc2 = ModelRunConfig("model2", MagicMock(), MagicMock())
+        rc = RunConfig({})
+        rc.add_model_run_config(mrc1)
+        rc.add_model_run_config(mrc2)
+
+        mrc_out = rc.model_run_configs()
+
+        self.assertEqual(mrc_out[0], mrc1)
+        self.assertEqual(mrc_out[1], mrc2)
+
+    def test_representation(self):
+        """
+        Test that representation() is just a string join of member ModelRunConfig's representations
+        """
+        pc1 = PerfAnalyzerConfig()
+        pc1.update_config({'model-name': "TestModel1"})
+        pc2 = PerfAnalyzerConfig()
+        pc2.update_config({'model-name': "TestModel2"})
+        mrc1 = ModelRunConfig("model1", MagicMock(), pc1)
+        mrc2 = ModelRunConfig("model2", MagicMock(), pc2)
+        rc = RunConfig({})
+        rc.add_model_run_config(mrc1)
+        rc.add_model_run_config(mrc2)
+
+        expected_representation = pc1.representation() + pc2.representation()
+        self.assertEqual(rc.representation(), expected_representation)
+
+    def test_cpu_only(self):
+        """
+        Test that cpu_only() is only true if all ModelConfigs are cpu_only() 
+        """
+        cpu_only_true_mc = ModelConfig({})
+        cpu_only_true_mc.set_cpu_only(True)
+        cpu_only_false_mc = ModelConfig({})
+        cpu_only_false_mc.set_cpu_only(False)
+
+        mrc1 = ModelRunConfig("model1", cpu_only_true_mc, MagicMock())
+        mrc2 = ModelRunConfig("model2", cpu_only_false_mc, MagicMock())
+
+        rc = RunConfig({})
+        rc.add_model_run_config(mrc1)
+        self.assertTrue(rc.cpu_only())
+
+        rc.add_model_run_config(mrc2)
+        self.assertFalse(rc.cpu_only())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -481,7 +481,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
 
         measurement = construct_run_config_measurement(
             model_name=MagicMock(),
-            model_config_names=[MagicMock()],
+            model_config_names=["test_config_name"],
             model_specific_pa_params=MagicMock(),
             gpu_metric_values=MagicMock(),
             non_gpu_metric_values=[{

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -38,19 +38,12 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
     def tearDown(self):
         NotImplemented
 
-    def test_key(self):
+    def test_model_variants_name(self):
         """
-        Test that the key was initialized correctly
+        Test that the model_variants_name was initialized correctly
         """
-        self.assertEqual(
-            self.rcm0.key(),
-            construct_perf_analyzer_config(self.model_name).representation())
-
-    def test_model_name(self):
-        """
-        Test that the model name was initialized correctly
-        """
-        self.assertEqual(self.rcm0.model_name(), self.model_name)
+        self.assertEqual(self.rcm0.model_variants_name(),
+                         self.model_variants_name)
 
     def test_gpu_data(self):
         """
@@ -246,8 +239,8 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
 
         rcm0_from_dict = RunConfigMeasurement.from_dict(json.loads(rcm0_json))
 
-        self.assertEqual(rcm0_from_dict.key(), self.rcm0.key())
-        self.assertEqual(rcm0_from_dict.model_name(), self.rcm0.model_name())
+        self.assertEqual(rcm0_from_dict.model_variants_name(),
+                         self.rcm0.model_variants_name())
         self.assertEqual(rcm0_from_dict.gpu_data(), self.rcm0.gpu_data())
         self.assertEqual(rcm0_from_dict.non_gpu_data(),
                          self.rcm0.non_gpu_data())
@@ -261,6 +254,7 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
     def _construct_rcm0(self):
         self.model_name = "modelA,modelB"
         self.model_config_name = ["modelA_config_0", "modelB_config_1"]
+        self.model_variants_name = "".join(self.model_config_name)
         self.model_specific_pa_params = [{
             "batch_size": 1,
             "concurrency": 1
@@ -324,6 +318,7 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
     def _construct_rcm1(self):
         model_name = "modelA,modelB"
         model_config_name = ["modelA_config_2", "modelB_config_3"]
+        model_variants_name = "".join(model_config_name)
         model_specific_pa_params = [{
             "batch_size": 3,
             "concurrency": 3

--- a/tests/test_run_config_result_comparator.py
+++ b/tests/test_run_config_result_comparator.py
@@ -95,16 +95,14 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
             avg_non_gpu_metric_values=avg_non_gpu_metrics1,
             comparator=result_comparator,
             value_step=value_step1,
-            model_name=MagicMock(),
-            model_config=MagicMock())
+            run_config=MagicMock())
 
         result2 = construct_run_config_result(
             avg_gpu_metric_values=avg_gpu_metrics2,
             avg_non_gpu_metric_values=avg_non_gpu_metrics2,
             comparator=result_comparator,
             value_step=value_step2,
-            model_name=MagicMock(),
-            model_config=MagicMock())
+            run_config=MagicMock())
 
         self.assertEqual(result_comparator.is_better_than(result1, result2),
                          expected_result)


### PR DESCRIPTION
Update ResultManager to store tuple using RunConfig instead of ModelConfig

RunConfig new functions:
- cpu_only()
- models_name()     : for base model names
- model_variants_name()  : for model variants
- from_dict()

ModelRunConfig new functions:
- model_variant_name()
- from_dict()

Updated ModelManager.run_model() to ModelManager.run_models(), which can handle single or multiple concurrent models
Refactor PerfAnalyzer to prep for MPI changes
Update MetricsManager.execute_run_config() and MetricsManager.profile_models() to handle multi-model



