### PR TITLE
Adding accessor function for PA params to RCM

### DIFF
--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -115,10 +115,10 @@ class DetailedPlot:
             be plotted.
         """
 
-        # TODO-TMA-559: Need accessor function for PA params
+        # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         self._data['concurrency'].append(
-            run_config_measurement._model_config_measurements[0].
-            _model_specific_pa_params['concurrency-range'])
+            run_config_measurement.model_specific_pa_params()[0]
+            ['concurrency-range'])
 
         self._data['perf_throughput'].append(
             run_config_measurement.get_metric_value(tag='perf_throughput'))

--- a/model_analyzer/plots/simple_plot.py
+++ b/model_analyzer/plots/simple_plot.py
@@ -77,21 +77,21 @@ class SimplePlot:
         if model_config_label not in self._data:
             self._data[model_config_label] = defaultdict(list)
 
+        # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         if self._x_axis.replace('_', '-') in PerfAnalyzerConfig.allowed_keys():
-            # TODO-TMA-559: get_parameter no longer exists
             self._data[model_config_label]['x_data'].append(
-                run_config_measurement.get_parameter(
-                    tag=self._x_axis.replace('_', '-')))
+                run_config_measurement.model_specific_pa_params()[0][
+                    self._x_axis.replace('_', '-')])
         else:
             # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
             self._data[model_config_label]['x_data'].append(
                 run_config_measurement.get_metric_value(tag=self._x_axis))
 
+        # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         if self._y_axis.replace('_', '-') in PerfAnalyzerConfig.allowed_keys():
-            # TODO-TMA-559: get_parameter no longer exists
             self._data[model_config_label]['y_data'].append(
-                run_config_measurement.get_parameter(
-                    tag=self._y_axis.replace('_', '-')))
+                run_config_measurement.model_specific_pa_params()[0][
+                    self._y_axis.replace('_', '-')])
         else:
             # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
             self._data[model_config_label]['y_data'].append(

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -503,9 +503,8 @@ class ReportManager:
         if not cpu_only:
             for measurement in measurements:
                 row = [
-                    # TODO-TMA-559: Need accessor function for PA Params
-                    measurement._model_config_measurements[0].
-                    _model_specific_pa_params[first_column_tag],
+                    # TODO-TMA-568: This needs to be updated because there will be multiple model configs
+                    measurement.model_specific_pa_params()[0][first_column_tag],
                     measurement.get_metric_value('perf_latency_p99'),
                     measurement.get_metric_value('perf_client_response_wait'),
                     measurement.get_metric_value('perf_server_queue'),
@@ -520,9 +519,8 @@ class ReportManager:
         else:
             for measurement in measurements:
                 row = [
-                    # TODO-TMA-559: Need accessor function for PA Params
-                    measurement._model_config_measurements[0].
-                    _model_specific_pa_params[first_column_tag],
+                    # TODO-TMA-568: This needs to be updated because there will be multiple model configs
+                    measurement.model_specific_pa_params()[0][first_column_tag],
                     measurement.get_metric_value('perf_latency_p99'),
                     measurement.get_metric_value('perf_client_response_wait'),
                     measurement.get_metric_value('perf_server_queue'),

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -356,6 +356,21 @@ class RunConfigMeasurement:
 
         return list(self._gpu_data.keys())
 
+    def model_specific_pa_params(self):
+        """
+        Returns
+        -------
+        list:
+            of dicts:
+                of model specific PA parameters
+                used in this measurement
+        """
+
+        return [
+            model_config_measurement.model_specific_pa_params()
+            for model_config_measurement in self._model_config_measurements
+        ]
+
     def is_better_than(self, other):
         """
         Checks whether a measurement is better than another

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -208,6 +208,15 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
             self.rcm0.get_weighted_metric_value("perf_latency_p99"),
             weighted_metric_value)
 
+    def test_model_specific_pa_params(self):
+        """
+        Test that the model specific PA params are correct
+        """
+        foo = self.rcm0.model_specific_pa_params()
+
+        self.assertEqual(self.rcm0.model_specific_pa_params(),
+                         self.model_specific_pa_params)
+
     def test_is_better_than(self):
         """
         Test to ensure measurement comparison is working as intended


### PR DESCRIPTION
Added accessor function for getting MCM's PA parameters (from RCM) with unit testing.
Replaced private variable in plot and report files with this method.