### PR TITLE
Replace key with model-name in plot manager

### DIFF
--- a/model_analyzer/plots/plot_manager.py
+++ b/model_analyzer/plots/plot_manager.py
@@ -124,7 +124,7 @@ class PlotManager:
         for run_config_measurement in run_config_measurements:
             self._simple_plots[plots_key][
                 plot_config.name()].add_run_config_measurement(
-                    model_config_label=run_config_measurement.key(),
+                    model_config_label=run_config_measurement.model_name(),
                     run_config_measurement=run_config_measurement)
 
         # In case this plot already had lines, we want to clear and replot

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -369,7 +369,8 @@ class MetricsManager:
         if model_gpu_metrics is not None and model_non_gpu_metrics is not None:
 
             run_config_measurement = RunConfigMeasurement(
-                run_config.representation(), model_gpu_metrics)
+                run_config.representation(), perf_config['model-name'],
+                model_gpu_metrics)
 
             # FIXME: TMA-518 - this needs to be added per model
             model_specific_pa_params = perf_config.extract_model_specific_parameters(

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -33,7 +33,7 @@ class RunConfigMeasurement:
     in a single RunConfig
     """
 
-    def __init__(self, key, gpu_data):
+    def __init__(self, key, model_name, gpu_data):
         """
         key: str
         Unique string which can be used to differentiate this measurement 
@@ -44,6 +44,7 @@ class RunConfigMeasurement:
             associated with them            
         """
         self._key = key
+        self._model_name = model_name
 
         self._gpu_data = gpu_data
         self._avg_gpu_data = self._average_list(list(self._gpu_data.values()))
@@ -54,9 +55,11 @@ class RunConfigMeasurement:
 
     @classmethod
     def from_dict(cls, run_config_measurement_dict):
-        run_config_measurement = RunConfigMeasurement(None, {})
+        run_config_measurement = RunConfigMeasurement(None, None, {})
 
         run_config_measurement._key = run_config_measurement_dict['_key']
+        run_config_measurement._model_name = run_config_measurement_dict[
+            '_model_name']
 
         run_config_measurement._gpu_data = cls._deserialize_gpu_data(
             run_config_measurement, run_config_measurement_dict['_gpu_data'])
@@ -124,10 +127,19 @@ class RunConfigMeasurement:
         """
         Returns
         -------
-        Key used to uniquely identify the RunConfigMeasurement
+        str: Key used to uniquely identify the RunConfigMeasurement
         """
 
         return self._key
+
+    def model_name(self):
+        """
+        Returns
+        -------
+        str: Model name for this RunConfigMeasurement
+        """
+
+        return self._model_name
 
     def data(self):
         """

--- a/qa/L0_analyze/test.sh
+++ b/qa/L0_analyze/test.sh
@@ -20,7 +20,7 @@ rm -f *.log
 # Set test parameters
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_01"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/qa/L0_output_fields/test.sh
+++ b/qa/L0_output_fields/test.sh
@@ -24,7 +24,7 @@ python3 config_generator.py
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_01"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
 EXPORT_PATH="`pwd`/results"
 FILENAME_SERVER_ONLY="server-metrics.csv"
 FILENAME_INFERENCE_MODEL="model-metrics-inference.csv"

--- a/qa/L0_results/test.sh
+++ b/qa/L0_results/test.sh
@@ -22,7 +22,7 @@ rm -rf results && mkdir -p results
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_01"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_07"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -191,7 +191,8 @@ def construct_run_config_measurement(model_name, model_config_names,
     gpu_data = convert_gpu_metrics_to_data(gpu_metric_values)
     pa_config = construct_perf_analyzer_config(model_name=model_name)
 
-    rc_measurement = RunConfigMeasurement(pa_config.representation(), gpu_data)
+    rc_measurement = RunConfigMeasurement(pa_config.representation(),
+                                          model_name, gpu_data)
 
     non_gpu_data = [
         convert_non_gpu_metrics_to_data(non_gpu_metric_value)

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -46,6 +46,12 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
             self.rcm0.key(),
             construct_perf_analyzer_config(self.model_name).representation())
 
+    def test_model_name(self):
+        """
+        Test that the model name was initialized correctly
+        """
+        self.assertEqual(self.rcm0.model_name(), self.model_name)
+
     def test_gpu_data(self):
         """
         Test that the gpu data is correct
@@ -232,6 +238,7 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         rcm0_from_dict = RunConfigMeasurement.from_dict(json.loads(rcm0_json))
 
         self.assertEqual(rcm0_from_dict.key(), self.rcm0.key())
+        self.assertEqual(rcm0_from_dict.model_name(), self.rcm0.model_name())
         self.assertEqual(rcm0_from_dict.gpu_data(), self.rcm0.gpu_data())
         self.assertEqual(rcm0_from_dict.non_gpu_data(),
                          self.rcm0.non_gpu_data())


### PR DESCRIPTION
Added model-name to RCM class with unit testing
Using model-name instead of key in plot manager

Visually verified that the detailed report pdf is working as intended:

![image](https://user-images.githubusercontent.com/92820864/162327324-06c977a1-31a6-4546-9bbb-d4b17abd6e37.png)
