### PR TITLE
Fix link to subcommand-analyze in docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ in which it is being run. Currently model analyzer supports 2 modes.
 This is the default mode. When in this mode, Model Analyzer will operate to find
 the optimal model configuration for an online inference scenario. By default in 
 online mode, the best model configuration will be the one that maximizes 
-throughput. If a latency budget is specified to the [analyze subcommand](subcommand-analyze) via 
+throughput. If a latency budget is specified to the [analyze subcommand](#subcommand-analyze) via 
 `--latency-budget`, then the best model configuration will be the one with the highest throughput in the given budget. 
 
 In online mode the analyze and report subcommands will generate summaries specific to online inference. 
@@ -47,7 +47,7 @@ See the example [online summary](../examples/online_summary.pdf) and [online det
 The offline mode `--mode=offline` tells Model Analyzer to operate to find the
 optimal model configuration for an offline inference scenario.  By default
 in offline mode, the best model configuration will be the one that maximizes throughput.
-A minimum throughput can be specified to the [analyze subcommand](subcommand-analyze)
+A minimum throughput can be specified to the [analyze subcommand](#subcommand-analyze)
 via `--min-throughput` to ignore any configuration that does not exceed a minimum number of inferences per second. 
 
 In offline mode the analyze and report subcommands will generate reports specific to offline inference.


### PR DESCRIPTION
Links are wrong in main: https://github.com/triton-inference-server/model_analyzer/blob/main/docs/cli.md

Links work with the fix: https://github.com/triton-inference-server/model_analyzer/blob/tgerdes-fix-docs/docs/cli.md
