### PR TITLE
Enable multi-model

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -218,10 +218,8 @@ class Analyzer:
                     self._state_manager.save_checkpoint()
 
     def _should_profile_multiple_models_concurrently(self):
-        # TODO-TMA-518: Disable until we support this feature
-        # return (self._config.run_config_profile_models_concurrently_enable and
-        #         len(self._config.profile_models) > 1)
-        return False
+        return (self._config.run_config_profile_models_concurrently_enable and
+                len(self._config.profile_models) > 1)
 
     def _get_profile_complete_string(self):
         profiled_model_list = self._state_manager.get_state_variable(

--- a/model_analyzer/config/generate/perf_analyzer_config_generator.py
+++ b/model_analyzer/config/generate/perf_analyzer_config_generator.py
@@ -108,8 +108,13 @@ class PerfAnalyzerConfigGenerator(ConfigGeneratorInterface):
         ----------
         measurements: List of Measurements from the last run(s)
         """
-        self._last_results = measurements
-        self._all_results.extend(measurements)
+
+        # Remove 'NONE' cases, and find single max measurement from the list
+        measurements = [m for m in measurements if m]
+        measurement = [max(measurements)] if measurements else [None]
+
+        self._last_results = measurement
+        self._all_results.extend(measurement)
 
     def _create_concurrency_list(self, cli_config, model_parameters):
         if model_parameters['concurrency']:

--- a/model_analyzer/config/generate/perf_analyzer_config_generator.py
+++ b/model_analyzer/config/generate/perf_analyzer_config_generator.py
@@ -143,7 +143,7 @@ class PerfAnalyzerConfigGenerator(ConfigGeneratorInterface):
     def _create_non_concurrency_perf_config_params(self):
         perf_config_params = {
             'model-name': [self._model_name],
-            'latency-report-file': [self._model_name],
+            'latency-report-file': [self._model_name + "-results.csv"],
             'batch-size': self._batch_sizes,
             'measurement-mode': [DEFAULT_MEASUREMENT_MODE],
             'verbose-csv': ['--verbose-csv'],

--- a/model_analyzer/config/generate/perf_analyzer_config_generator.py
+++ b/model_analyzer/config/generate/perf_analyzer_config_generator.py
@@ -71,7 +71,7 @@ class PerfAnalyzerConfigGenerator(ConfigGeneratorInterface):
         self._model_name = model_name
         self._perf_analyzer_flags = model_perf_analyzer_flags
 
-        self._batch_sizes = model_parameters['batch_sizes']
+        self._batch_sizes = sorted(model_parameters['batch_sizes'])
         self._concurrencies = self._create_concurrency_list(
             cli_config, model_parameters)
         self._client_protocol_is_http = (cli_config.client_protocol == 'http')

--- a/model_analyzer/config/generate/run_config_generator.py
+++ b/model_analyzer/config/generate/run_config_generator.py
@@ -42,9 +42,9 @@ class RunConfigGenerator(ConfigGeneratorInterface):
 
         self._num_models = len(models)
 
-        self._curr_model_run_configs = [None] * self._num_models
-        self._curr_results = [[]] * self._num_models
-        self._curr_generators = [None] * self._num_models
+        self._curr_model_run_configs = [None for n in range(self._num_models)]
+        self._curr_results = [[] for n in range(self._num_models)]
+        self._curr_generators = [None for n in range(self._num_models)]
 
     def is_done(self):
         return    self._curr_generators[0] is not None \

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -522,17 +522,17 @@ class ConfigCommandProfile(ConfigCommand):
                         parser_args={'action': 'store_true'},
                         default_value=DEFAULT_RUN_CONFIG_SEARCH_DISABLE,
                         description="Disable run config search."))
-        # TODO-TMA-518:  Disable until we support this feature
-        # self._add_config(
-        #     ConfigField(
-        #         'run_config_profile_models_concurrently_enable',
-        #         flags=['--run-config-profile-models-concurrently-enable'],
-        #         field_type=ConfigPrimitive(bool),
-        #         parser_args={'action': 'store_true'},
-        #         default_value=
-        #         DEFAULT_RUN_CONFIG_PROFILE_MODELS_CONCURRENTLY_ENABLE,
-        #         description=
-        #         "Enable the profiling of all supplied models concurrently."))
+        self._add_config(
+            ConfigField(
+                'run_config_profile_models_concurrently_enable',
+                flags=['--run-config-profile-models-concurrently-enable'],
+                field_type=ConfigPrimitive(bool),
+                parser_args={'action': 'store_true'},
+                default_value=
+                DEFAULT_RUN_CONFIG_PROFILE_MODELS_CONCURRENTLY_ENABLE,
+                description=
+                "Enable the profiling of all supplied models concurrently."))
+
     def _add_triton_configs(self):
         """
         Adds the triton related flags

--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -167,6 +167,31 @@ class PerfAnalyzer:
 
         return self.PA_SUCCESS
 
+    def get_records(self):
+        """
+        Returns
+        -------
+        The records from the last perf_analyzer run
+        """
+
+        if self._perf_records:
+            return self._perf_records
+        raise TritonModelAnalyzerException(
+            "Attempted to get perf_analyzer results"
+            "without calling run first.")
+
+    def output(self):
+        """
+        Returns
+        -------
+        The stdout output of the
+        last perf_analyzer run
+        """
+
+        if self._output:
+            return self._output
+        logger.info('perf_analyzer did not produce any output.')
+
     def _execute_pa(self, env):
 
         cmd = self._get_cmd()
@@ -265,7 +290,7 @@ class PerfAnalyzer:
         """
         Use of the perf analyzer process
         """
-
+        # TODO-TMA-518 - how to handle?
         if self._output.find("Failed to obtain stable measurement"
                             ) != -1 or self._output.find(
                                 "Please use a larger time window") != -1:
@@ -305,30 +330,11 @@ class PerfAnalyzer:
         # TODO-TMA-518 - update for multi-model
         return self._base_perf_config.to_cli_string()
 
-    def output(self):
+    def _is_multi_model(self):
         """
-        Returns
-        -------
-        The stdout output of the
-        last perf_analyzer run
+        Returns true if the RunConfig provided to this class contains multiple perf_configs. Else False
         """
-
-        if self._output:
-            return self._output
-        logger.info('perf_analyzer did not produce any output.')
-
-    def get_records(self):
-        """
-        Returns
-        -------
-        The records from the last perf_analyzer run
-        """
-
-        if self._perf_records:
-            return self._perf_records
-        raise TritonModelAnalyzerException(
-            "Attempted to get perf_analyzer results"
-            "without calling run first.")
+        return len(self._config.model_run_configs()) > 1
 
     def _parse_outputs(self, metrics):
         """
@@ -338,6 +344,8 @@ class PerfAnalyzer:
         for perf_config in [
                 mrc.perf_config() for mrc in self._config.model_run_configs()
         ]:
+            logger.debug(
+                f"Reading PA results from {perf_config['latency-report-file']}")
             with open(perf_config['latency-report-file'], mode='r') as f:
                 csv_reader = csv.DictReader(f, delimiter=',')
 

--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -177,6 +177,12 @@ class PerfAnalyzer:
             return self._output
         logger.info('perf_analyzer did not produce any output.')
 
+    def get_cmd(self):
+        """ 
+        Returns a string of the command to run
+        """
+        return " ".join(self._get_cmd())
+
     def _execute_pa(self, env):
 
         cmd = self._get_cmd()

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -238,6 +238,11 @@ class MetricsManager:
             run_config_measurement = RunConfigMeasurement(
                 run_config.model_variants_name(), model_gpu_metrics)
 
+            # Add default metric weighting to all measurements for easy sorting
+            run_config_measurement.set_metric_weightings([{
+                "perf_throughput": 1
+            } for x in run_config.model_run_configs()])
+
             # Combine all per-model measurements into the RunConfigMeasurement
             #
             for model_run_config in run_config.model_run_configs():

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -439,10 +439,9 @@ class MetricsManager:
         status = perf_analyzer.run(self._perf_metrics, env=perf_analyzer_env)
 
         if perf_output_writer:
-            # TODO-TMA-518: MPI command - still need to fix
             perf_output_writer.write(
-                '============== Perf Analyzer Launched ==============\n '
-                f'Command: perf_analyzer {run_config.model_run_configs()[0].perf_config().to_cli_string()} \n\n',
+                '============== Perf Analyzer Launched ==============\n'
+                f'Command: {perf_analyzer.get_cmd()}\n\n',
                 append=True)
             if perf_analyzer.output():
                 perf_output_writer.write(perf_analyzer.output() + '\n',

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -439,7 +439,7 @@ class MetricsManager:
         status = perf_analyzer.run(self._perf_metrics, env=perf_analyzer_env)
 
         if perf_output_writer:
-            # TODO-TMA-518: MPI command
+            # TODO-TMA-518: MPI command - still need to fix
             perf_output_writer.write(
                 '============== Perf Analyzer Launched ==============\n '
                 f'Command: perf_analyzer {run_config.model_run_configs()[0].perf_config().to_cli_string()} \n\n',

--- a/qa/L0_multi_model_profile/check_results.py
+++ b/qa/L0_multi_model_profile/check_results.py
@@ -42,12 +42,12 @@ class TestOutputValidator:
         Check that each model was profiled the number of times
         corresponding with batch size and concurrency combinations
 
-        For multi-model with 2 models, the expected number of measurements
+        For multi-model with 2 models (A and B), the expected number of measurements
         is X*Y, where:
         - X is the number of measurements that we would expected 
-        for model 1 in a single-model case
+        for model A in a single-model case
         - Y is the number of measurements that we would expected 
-        for model 1 in a single-model case
+        for model B in a single-model case
 
         Since we know that X == Y for this test (since they both have the same
         parameters), then the expected total is just X*X

--- a/qa/L0_multi_model_profile/check_results.py
+++ b/qa/L0_multi_model_profile/check_results.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+import argparse
+import sys
+import yaml
+import os
+
+
+class TestOutputValidator:
+    """
+    Functions that validate the output
+    of the test
+    """
+
+    def __init__(self, config, test_name, analyzer_log):
+        self._config = config
+        self._models = config['profile_models']
+        self._analyzer_log = analyzer_log
+
+        check_function = self.__getattribute__(f'check_{test_name}')
+
+        if check_function():
+            sys.exit(0)
+        else:
+            sys.exit(1)
+
+    def check_profile_logs(self):
+        """
+        Check that each model was profiled the number of times
+        corresponding with batch size and concurrency combinations
+
+        For multi-model with 2 models, the expected number of measurements
+        is X*Y, where:
+        - X is the number of measurements that we would expected 
+        for model 1 in a single-model case
+        - Y is the number of measurements that we would expected 
+        for model 1 in a single-model case
+
+        Since we know that X == Y for this test (since they both have the same
+        parameters), then the expected total is just X*X
+        """
+
+        with open(self._analyzer_log, 'r') as f:
+            log_contents = f.read()
+
+        expected_single_model_num_measurements = len(
+            self._config['batch_sizes']) * len(self._config['concurrency'])
+        expected_num_measurements = expected_single_model_num_measurements * expected_single_model_num_measurements
+        for model in self._models:
+            token = f"Profiling {model}_config_default"
+            token_idx = 0
+            found_count = 0
+            while True:
+                token_idx = log_contents.find(token, token_idx + 1)
+                if token_idx == -1:
+                    break
+                found_count += 1
+            if found_count != expected_num_measurements:
+                print(
+                    f"\n***\n***  Expected number of measurements for {model} : {expected_num_measurements}."
+                    f"Found {found_count}. \n***")
+                return False
+        return True
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f',
+                        '--config-file',
+                        type=str,
+                        required=True,
+                        help='The path to the config yaml file.')
+    parser.add_argument('-l',
+                        '--analyzer-log-file',
+                        type=str,
+                        required=True,
+                        help='The full path to the analyzer log.')
+    parser.add_argument('-t',
+                        '--test-name',
+                        type=str,
+                        required=True,
+                        help='The name of the test to be run.')
+    args = parser.parse_args()
+
+    with open(args.config_file, 'r') as f:
+        config = yaml.safe_load(f)
+
+    TestOutputValidator(config, args.test_name, args.analyzer_log_file)

--- a/qa/L0_multi_model_profile/test.sh
+++ b/qa/L0_multi_model_profile/test.sh
@@ -1,0 +1,74 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ANALYZER_LOG="test.log"
+source ../common/util.sh
+
+rm -f *.log
+rm -rf results && mkdir -p results
+
+# Set test parameters
+MODEL_ANALYZER="`which model-analyzer`"
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
+QA_MODELS="vgg19_libtorch resnet50_libtorch"
+MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
+BATCH_SIZES="1,2"
+CONCURRENCY="1,2"
+TRITON_LAUNCH_MODE=${TRITON_LAUNCH_MODE:="local"}
+CLIENT_PROTOCOL="grpc"
+PORTS=(`find_available_ports 3`)
+GPUS=(`get_all_gpus_uuids`)
+OUTPUT_MODEL_REPOSITORY=${OUTPUT_MODEL_REPOSITORY:=`get_output_directory`}
+CONFIG_FILE="config.yml"
+
+rm -rf $OUTPUT_MODEL_REPOSITORY
+
+python3 test_config_generator.py --profile-models $MODEL_NAMES
+
+# Run the analyzer and check the results
+RET=0
+
+set +e
+
+MODEL_ANALYZER_ARGS="-m $MODEL_REPOSITORY -f $CONFIG_FILE"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --client-protocol=$CLIENT_PROTOCOL --triton-launch-mode=$TRITON_LAUNCH_MODE"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint localhost:${PORTS[0]} --triton-grpc-endpoint localhost:${PORTS[1]}"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url http://localhost:${PORTS[2]}/metrics"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
+MODEL_ANALYZER_SUBCOMMAND="profile"
+run_analyzer
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Test Failed. model-analyzer $MODEL_ANALYZER_SUBCOMMAND exited with non-zero exit code. \n***"
+    cat $ANALYZER_LOG
+    RET=1
+else
+    # Check the Analyzer log for correct output
+    TEST_NAME='profile_logs'
+    python3 check_results.py -f $CONFIG_FILE -t $TEST_NAME -l $ANALYZER_LOG
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test Output Verification Failed for $TEST_NAME test.\n***"
+        cat $ANALYZER_LOG
+        RET=1
+    fi
+fi
+set -e
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test PASSED\n***"
+else
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/L0_multi_model_profile/test_config_generator.py
+++ b/qa/L0_multi_model_profile/test_config_generator.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import yaml
+
+
+class TestConfigGenerator:
+    """
+    This class contains functions that
+    create configs for various test scenarios.
+    
+    The `setup` function does the work common to all tests
+
+    TO ADD A TEST: Simply add a member function whose name starts
+                    with 'generate'.
+    """
+
+    def __init__(self):
+        test_functions = [
+            self.__getattribute__(name)
+            for name in dir(self)
+            if name.startswith('generate')
+        ]
+
+        for test_function in test_functions:
+            self.setup()
+            test_function()
+
+    def setup(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('-m',
+                            '--profile-models',
+                            type=str,
+                            required=True,
+                            help='The config file for this test')
+
+        args = parser.parse_args()
+        self.config = {
+            'batch_sizes': [1, 2],
+            'concurrency': [1, 2],
+        }
+        self.config['profile_models'] = sorted(args.profile_models.split(','))
+        self.config['run_config_search_disable'] = True
+        self.config['run_config_profile_models_concurrently_enable'] = True
+
+    def generate_config(self):
+        with open('config.yml', 'w+') as f:
+            yaml.dump(self.config, f)
+
+
+if __name__ == '__main__':
+    TestConfigGenerator()

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -101,7 +101,7 @@ def convert_avg_gpu_metrics_to_data(avg_gpu_metric_values):
 
 
 def construct_perf_analyzer_config(model_name='my-model',
-                                   output_file_name='my-model',
+                                   output_file_name='my-model-results.csv',
                                    batch_size=DEFAULT_BATCH_SIZES,
                                    concurrency=1,
                                    launch_mode=DEFAULT_TRITON_LAUNCH_MODE,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,7 @@ def get_test_options():
         OptionStruct("bool", "profile","--collect-cpu-metrics"),
         OptionStruct("bool", "profile","--perf-output"),
         OptionStruct("bool", "profile","--run-config-search-disable"),
+        OptionStruct("bool", "profile","--run-config-profile-models-concurrently-enable"),
         OptionStruct("bool", "profile","--reload-model-disable"),
         #Int/Float options
         # Options format:

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -51,6 +51,7 @@ from model_analyzer.record.types.perf_server_compute_infer \
 from model_analyzer.record.types.perf_server_compute_output \
     import PerfServerComputeOutput
 from .common import test_result_collector as trc
+from model_analyzer.constants import PERF_ANALYZER_MEASUREMENT_WINDOW, MEASUREMENT_WINDOW_STEP, PERF_ANALYZER_MINIMUM_REQUEST_COUNT, MEASUREMENT_REQUEST_COUNT_STEP
 
 # Test Parameters
 MODEL_LOCAL_PATH = '/model_analyzer/models'
@@ -493,7 +494,7 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
 
     def test_get_cmd_multi_model(self):
         """
-        Test the functionality of _get_cmd() for single model
+        Test the functionality of _get_cmd() for multi model
         """
         pac1 = PerfAnalyzerConfig()
         pac1['model-name'] = "MultiModel1"
@@ -519,7 +520,7 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
 
         #yapf: disable
         expected_cmd = [
-            'mpiexec', '--allow-run-as-root',
+            'mpiexec', '--allow-run-as-root', '--tag-output',
             '-n', '1', 'perf_analyzer',
                 '-m', 'MultiModel1',
                 '--measurement-interval', '1000',
@@ -532,6 +533,145 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         #yapf: enable
 
         self.assertEqual(pa._get_cmd(), expected_cmd)
+
+    def test_split_output_per_rank_for_single_model(self):
+        """
+        Test functionality of _get_output_per_rank() for single-model
+        """
+
+        output = """
+[1,0]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:Request concurrency: 2
+[1,0]<stdout>:Request concurrency: 1
+"""
+
+        # Expect no change for single-model
+        expected_result = [output]
+
+        run_config = RunConfig({})
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), MagicMock()))
+
+        pa = PerfAnalyzer(path=PERF_BIN_PATH,
+                          config=run_config,
+                          max_retries=10,
+                          timeout=100,
+                          max_cpu_util=50)
+
+        pa._output = output
+        result = pa._split_output_per_rank()
+        self.assertEqual(result, expected_result)
+
+    def test_split_output_per_rank_for_multi_model(self):
+        """
+        Test functionality of _get_output_per_rank() for multi-model
+        """
+
+        output = """
+[1,0]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:Request concurrency: 2
+[1,0]<stdout>:Request concurrency: 1
+"""
+
+        expected_result = [
+            """[1,0]<stdout>:*** Measurement Settings ***
+[1,0]<stdout>:Request concurrency: 1
+""", """[1,1]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:Request concurrency: 2
+"""
+        ]
+
+        run_config = RunConfig({})
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), MagicMock()))
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), MagicMock()))
+
+        pa = PerfAnalyzer(path=PERF_BIN_PATH,
+                          config=run_config,
+                          max_retries=10,
+                          timeout=100,
+                          max_cpu_util=50)
+
+        pa._output = output
+        result = pa._split_output_per_rank()
+        self.assertEqual(result, expected_result)
+
+    def test_auto_adjust_parameters(self):
+        """ 
+        Test function _auto_adjust_parameters()
+        
+        In the case below:
+            - Model0 fails to be stable in time_windows and should have measurement-interval increased
+            - Model1 is fine and should have no changes
+            - Model2 fails to be stable in count_windows and should have measurement-request-count increased
+        """
+        pac0 = PerfAnalyzerConfig()
+        pac0['model-name'] = "MultiModel0"
+        pac0['measurement-mode'] = "time_windows"
+
+        pac1 = PerfAnalyzerConfig()
+        pac1['model-name'] = "MultiModel1"
+        pac1['measurement-mode'] = "time_windows"
+
+        pac2 = PerfAnalyzerConfig()
+        pac2['model-name'] = "MultiModel2"
+        pac2['measurement-mode'] = "count_windows"
+
+        run_config = RunConfig({})
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), pac0))
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), pac1))
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), pac2))
+
+        pa = PerfAnalyzer(path=PERF_BIN_PATH,
+                          config=run_config,
+                          max_retries=10,
+                          timeout=100,
+                          max_cpu_util=50)
+
+        pa._output = """
+[1,0]<stdout>:*** Measurement Settings ***
+[1,1]<stdout>:*** Measurement Settings ***
+[1,2]<stdout>:*** Measurement Settings ***
+[1,2]<stdout>:Failed to obtain stable measurement
+[1,0]<stdout>:Failed to obtain stable measurement
+[1,1]<stdout>:Success
+        """
+
+        pa._auto_adjust_parameters(MagicMock())
+
+        expected_measurement_interval = PERF_ANALYZER_MEASUREMENT_WINDOW + MEASUREMENT_WINDOW_STEP
+        expected_request_count = PERF_ANALYZER_MINIMUM_REQUEST_COUNT + MEASUREMENT_REQUEST_COUNT_STEP
+
+        self.assertEqual(
+            expected_measurement_interval,
+            pa._config.model_run_configs()[0].perf_config()
+            ['measurement-interval'])
+        self.assertEqual(
+            None,
+            pa._config.model_run_configs()[0].perf_config()
+            ['measurement-request-count'])
+        self.assertEqual(
+            None,
+            pa._config.model_run_configs()[1].perf_config()
+            ['measurement-interval'])
+        self.assertEqual(
+            None,
+            pa._config.model_run_configs()[1].perf_config()
+            ['measurement-request-count'])
+        self.assertEqual(
+            None,
+            pa._config.model_run_configs()[2].perf_config()
+            ['measurement-interval'])
+        self.assertEqual(
+            expected_request_count,
+            pa._config.model_run_configs()[2].perf_config()
+            ['measurement-request-count'])
 
     def tearDown(self):
         # In case test raises exception

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -448,6 +448,33 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         self.assertEqual(
             self.perf_mock.get_perf_analyzer_popen_read_call_count(), 10)
 
+    def test_is_multi_model(self):
+        """ 
+        Test the functionality of the _is_multi_model() function 
+        
+        If the provided run_config only has one ModelRunConfig, then is_multi_model is false. Any
+        more than one ModelRunConfig and it should return true
+        """
+        run_config = RunConfig({})
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), MagicMock()))
+
+        pa1 = PerfAnalyzer(path=PERF_BIN_PATH,
+                           config=run_config,
+                           max_retries=10,
+                           timeout=100,
+                           max_cpu_util=50)
+        self.assertFalse(pa1._is_multi_model())
+
+        run_config.add_model_run_config(
+            ModelRunConfig(MagicMock(), MagicMock(), MagicMock()))
+        pa2 = PerfAnalyzer(path=PERF_BIN_PATH,
+                           config=run_config,
+                           max_retries=10,
+                           timeout=100,
+                           max_cpu_util=50)
+        self.assertTrue(pa2._is_multi_model())
+
     def tearDown(self):
         # In case test raises exception
         if self.server is not None:


### PR DESCRIPTION
Enable multi-model (--run-config-profile-models-concurrently-enable)
Added L0_multi_model_profile test
Updated PA get_cmd() for multi-model to use MPI
Updated auto_adjust_parameters() support to handle multi-model