### PR TITLE
Don't print plateau warning more than once

### DIFF
--- a/model_analyzer/config/generate/automatic_model_config_generator.py
+++ b/model_analyzer/config/generate/automatic_model_config_generator.py
@@ -48,6 +48,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
 
         self._sweep_max_batch_size_disabled = self._determine_sweep_max_batch_size_disabled(
         )
+        self._max_batch_size_warning_printed = False
 
         # Contains the max throughput from each provided list of measurements
         # since the last time we stepped max_batch_size
@@ -95,9 +96,11 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
             return True
 
         if not self._last_results_increased_throughput():
-            logger.info(
-                "No longer increasing max_batch_size because throughput has plateaued"
-            )
+            if not self._max_batch_size_warning_printed:
+                logger.info(
+                    "No longer increasing max_batch_size because throughput has plateaued"
+                )
+                self._max_batch_size_warning_printed = True
             return True
         return False
 
@@ -127,6 +130,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
         else:
             self._curr_max_batch_size = self._min_model_batch_size
         self._curr_max_batch_size_throughputs = []
+        self._max_batch_size_warning_printed = False
 
     def _get_last_results_max_throughput(self):
         throughputs = [


### PR DESCRIPTION
```
[Model Analyzer] Profiling resnet50_libtorch_config_2: client batch size=1, concurrency=64
[Model Analyzer] Profiling resnet50_libtorch_config_2: client batch size=1, concurrency=128
[Model Analyzer] No longer increasing concurrency as throughput has plateaued
[Model Analyzer] No longer increasing max_batch_size because throughput has plateaued
[Model Analyzer] Saved checkpoint to /opt/triton-model-analyzer/checkpoints/0.ckpt
```