### PR TITLE
Set default model and metric weightings to RCM/MCM classes

### DIFF
--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -238,11 +238,6 @@ class MetricsManager:
             run_config_measurement = RunConfigMeasurement(
                 run_config.model_variants_name(), model_gpu_metrics)
 
-            # Add default metric weighting to all measurements for easy sorting
-            run_config_measurement.set_metric_weightings([{
-                "perf_throughput": 1
-            } for x in run_config.model_run_configs()])
-
             # Combine all per-model measurements into the RunConfigMeasurement
             #
             for model_run_config in run_config.model_run_configs():

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -49,7 +49,8 @@ class ModelConfigMeasurement:
 
         self._non_gpu_data_from_tag = self._get_non_gpu_data_from_tag()
 
-        self._metric_weights = {}
+        # Set a default metric weighting
+        self._metric_weights = {"perf_throughput": 1}
 
     @classmethod
     def from_dict(cls, model_config_measurement_dict):
@@ -66,6 +67,8 @@ class ModelConfigMeasurement:
 
         model_config_measurement._non_gpu_data_from_tag = cls._get_non_gpu_data_from_tag(
             model_config_measurement)
+
+        model_config_measurement._metric_weights = {"perf_throughput": 1}
 
         return model_config_measurement
 
@@ -237,10 +240,6 @@ class ModelConfigMeasurement:
             -1
                 if self < other (is worse than)
         """
-
-        if not self._metric_weights:
-            return 0
-
         weighted_score = self._calculate_weighted_score(other)
 
         if weighted_score > COMPARISON_SCORE_THRESHOLD:

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -68,7 +68,8 @@ class ModelConfigMeasurement:
         model_config_measurement._non_gpu_data_from_tag = cls._get_non_gpu_data_from_tag(
             model_config_measurement)
 
-        model_config_measurement._metric_weights = {"perf_throughput": 1}
+        model_config_measurement._metric_weights = model_config_measurement_dict[
+            '_metric_weights']
 
         return model_config_measurement
 

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -531,4 +531,6 @@ class RunConfigMeasurement:
             model_config_measurements.append(
                 ModelConfigMeasurement.from_dict(mcm_dict))
 
+            self._model_config_weights.append(1)
+
         return model_config_measurements

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -108,6 +108,9 @@ class RunConfigMeasurement:
             ModelConfigMeasurement(model_config_name, model_specific_pa_params,
                                    non_gpu_data))
 
+        # By default setting all models to have equal weighting
+        self._model_config_weights.append(1)
+
     def set_metric_weightings(self, metric_objectives):
         """
         Sets the metric weighting for all non-GPU measurements
@@ -260,6 +263,9 @@ class RunConfigMeasurement:
                 or None if tag not found
         
         """
+        assert len(self._model_config_weights) == len(
+            self._model_config_measurements)
+
         return [
             model_config_measurement.get_metric(tag) *
             self._model_config_weights[index]
@@ -347,6 +353,9 @@ class RunConfigMeasurement:
             Weighted average of the values of the metric Record corresponding 
             to the tag, default_value if tag not found.
         """
+        assert len(self._model_config_weights) == len(
+            self._model_config_measurements)
+
         weighted_sum = 0
         for index, metric in enumerate(self.get_metric(tag)):
             weighted_sum += default_value if metric is None else metric.value(
@@ -456,7 +465,6 @@ class RunConfigMeasurement:
         list of floats
             A weighted score for each ModelConfig measurement in the RunConfig
         """
-
         return [
             self_mcm.get_weighted_score(other_mcm)
             for self_mcm, other_mcm in zip(self._model_config_measurements,
@@ -476,6 +484,9 @@ class RunConfigMeasurement:
             The weighted score. A positive value indicates this 
             RunConfig measurement is better than the other
         """
+        if len(self._model_config_weights) != len(weighted_mcm_scores):
+            assert len(self._model_config_weights) == len(weighted_mcm_scores)
+
         return sum([
             weighted_mcm_score * model_config_weight
             for weighted_mcm_score, model_config_weight in zip(

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -72,6 +72,9 @@ class RunConfigMeasurement:
             run_config_measurement,
             run_config_measurement_dict['_model_config_measurements'])
 
+        run_config_measurement._model_config_weights = run_config_measurement_dict[
+            '_model_config_weights']
+
         return run_config_measurement
 
     def set_model_config_weighting(self, model_config_weights):
@@ -529,7 +532,5 @@ class RunConfigMeasurement:
         for mcm_dict in serialized_model_config_measurements:
             model_config_measurements.append(
                 ModelConfigMeasurement.from_dict(mcm_dict))
-
-            self._model_config_weights.append(1)
 
         return model_config_measurements

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -484,8 +484,7 @@ class RunConfigMeasurement:
             The weighted score. A positive value indicates this 
             RunConfig measurement is better than the other
         """
-        if len(self._model_config_weights) != len(weighted_mcm_scores):
-            assert len(self._model_config_weights) == len(weighted_mcm_scores)
+        assert len(self._model_config_weights) == len(weighted_mcm_scores)
 
         return sum([
             weighted_mcm_score * model_config_weight

--- a/qa/L0_analyze/test.sh
+++ b/qa/L0_analyze/test.sh
@@ -20,7 +20,7 @@ rm -f *.log
 # Set test parameters
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_22"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/qa/L0_output_fields/test.sh
+++ b/qa/L0_output_fields/test.sh
@@ -24,7 +24,7 @@ python3 config_generator.py
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_22"}
 EXPORT_PATH="`pwd`/results"
 FILENAME_SERVER_ONLY="server-metrics.csv"
 FILENAME_INFERENCE_MODEL="model-metrics-inference.csv"

--- a/qa/L0_results/test.sh
+++ b/qa/L0_results/test.sh
@@ -22,7 +22,7 @@ rm -rf results && mkdir -p results
 MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
-CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_08"}
+CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_04_22"}
 QA_MODELS="vgg19_libtorch resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -156,10 +156,13 @@ def construct_perf_analyzer_config(model_name='my-model',
     return pa_config
 
 
-def construct_run_config_measurement(model_name, model_config_names,
+def construct_run_config_measurement(model_name,
+                                     model_config_names,
                                      model_specific_pa_params,
-                                     gpu_metric_values, non_gpu_metric_values,
-                                     metric_objectives, model_config_weights):
+                                     gpu_metric_values,
+                                     non_gpu_metric_values,
+                                     metric_objectives=None,
+                                     model_config_weights=None):
     """
     Construct a RunConfig measurement from the given data
 
@@ -204,8 +207,11 @@ def construct_run_config_measurement(model_name, model_config_names,
             model_specific_pa_params=model_specific_pa_params[index],
             non_gpu_data=non_gpu_data[index])
 
-    rc_measurement.set_model_config_weighting(model_config_weights)
-    rc_measurement.set_metric_weightings(metric_objectives)
+    if model_config_weights:
+        rc_measurement.set_model_config_weighting(model_config_weights)
+
+    if metric_objectives:
+        rc_measurement.set_metric_weightings(metric_objectives)
 
     return rc_measurement
 
@@ -214,7 +220,8 @@ def construct_run_config_result(avg_gpu_metric_values,
                                 avg_non_gpu_metric_values_list,
                                 comparator,
                                 value_step=1,
-                                model_name="fake_model_name",
+                                model_name="test_model",
+                                model_config_names=["test_model"],
                                 run_config=None):
     """
     Takes a dictionary whose values are average
@@ -277,9 +284,8 @@ def construct_run_config_result(avg_gpu_metric_values,
                 key: metric_values[key][i] for key in metric_values
             }
 
-    non_gpu_metrics = []
-    for non_gpu_metric_values in non_gpu_metric_values_list:
-        for i in range(2 * num_vals):
+        non_gpu_metrics = []
+        for non_gpu_metric_values in non_gpu_metric_values_list:
             non_gpu_metrics.append({
                 key: non_gpu_metric_values[key][i]
                 for key in non_gpu_metric_values
@@ -289,15 +295,14 @@ def construct_run_config_result(avg_gpu_metric_values,
         run_config_result.add_run_config_measurement(
             construct_run_config_measurement(
                 model_name=model_name,
-                model_config_names=[model_name],
+                model_config_names=model_config_names,
                 model_specific_pa_params=[{
                     'batch_size': 1,
                     'concurrency': 1
-                }],
+                } for model_config_name in model_config_names],
                 gpu_metric_values=gpu_metrics,
                 non_gpu_metric_values=non_gpu_metrics,
-                metric_objectives=comparator._metric_weights,
-                model_config_weights=[1]))
+                metric_objectives=comparator._metric_weights))
 
     return run_config_result
 

--- a/tests/test_model_config_generator.py
+++ b/tests/test_model_config_generator.py
@@ -615,9 +615,7 @@ class TestModelConfigGenerator(trc.TestResultCollector):
             gpu_metric_values=MagicMock(),
             non_gpu_metric_values=[{
                 "perf_throughput": self._fake_throughput
-            }],
-            metric_objectives=MagicMock(),
-            model_config_weights=MagicMock())
+            }])
 
         return [measurement]
 

--- a/tests/test_model_config_measurement.py
+++ b/tests/test_model_config_measurement.py
@@ -148,19 +148,6 @@ class TestModelConfigMeasurement(trc.TestResultCollector):
         self.assertFalse(self.mcmC.is_better_than(self.mcmA))
         self.assertTrue(self.mcmC == self.mcmD)
 
-    def test_no_metric_set(self):
-        """
-        Test that the measurements are equal if no weighting is set
-        """
-        self.assertFalse(self.mcmA.is_better_than(self.mcmB))
-        self.assertTrue(self.mcmA == self.mcmB)
-
-        self.mcmA.set_metric_weighting({"perf_latency_p99": 1})
-
-        # latency: 20 is better than 40
-        self.assertTrue(self.mcmA.is_better_than(self.mcmB))
-        self.assertTrue(self.mcmA < self.mcmB)
-
     def test__eq__(self):
         """
         Test that individual metric equality works as expected

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -72,9 +72,7 @@ class MetricsManagerSubclass(MetricsManager):
                 gpu_metric_values=MagicMock(),
                 non_gpu_metric_values=[{
                     "perf_throughput": throughput_value
-                }],
-                metric_objectives=MagicMock(),
-                model_config_weights=MagicMock())
+                }])
 
     def _get_next_perf_throughput_value(self):
         self._perf_throughput *= 2

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -64,8 +64,7 @@ class TestPlotMethods(trc.TestResultCollector):
             model_specific_pa_params=MagicMock(),
             gpu_metric_values=gpu_metric_values,
             non_gpu_metric_values=[non_gpu_metric_values],
-            metric_objectives=[objective_spec],
-            model_config_weights=MagicMock())
+            metric_objectives=[objective_spec])
 
         # Add above measurement
         plot.add_run_config_measurement('test_model_label1', measurement)
@@ -116,8 +115,7 @@ class TestPlotMethods(trc.TestResultCollector):
             model_specific_pa_params=MagicMock(),
             gpu_metric_values=gpu_metric_values,
             non_gpu_metric_values=[non_gpu_metric_values],
-            metric_objectives=[objective_spec],
-            model_config_weights=MagicMock())
+            metric_objectives=[objective_spec])
 
         plot.add_run_config_measurement('test_model_label', measurement)
 

--- a/tests/test_run_config_generator.py
+++ b/tests/test_run_config_generator.py
@@ -499,9 +499,7 @@ class TestRunConfigGenerator(trc.TestResultCollector):
             gpu_metric_values=MagicMock(),
             non_gpu_metric_values=[{
                 "perf_throughput": throughput_value
-            }],
-            metric_objectives=MagicMock(),
-            model_config_weights=MagicMock())
+            }])
 
         return [measurement]
 

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -248,6 +248,9 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self.assertEqual(rcm0_from_dict._model_config_measurements,
                          self.rcm0._model_config_measurements)
 
+        # Catchall in case something new is added
+        self.assertEqual(rcm0_from_dict, self.rcm0)
+
     def _construct_rcm0(self):
         self.model_name = "modelA,modelB"
         self.model_config_name = ["modelA_config_0", "modelB_config_1"]

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -248,9 +248,6 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self.assertEqual(rcm0_from_dict._model_config_measurements,
                          self.rcm0._model_config_measurements)
 
-        # Catchall in case something new is added
-        self.assertEqual(rcm0_from_dict, self.rcm0)
-
     def _construct_rcm0(self):
         self.model_name = "modelA,modelB"
         self.model_config_name = ["modelA_config_0", "modelB_config_1"]

--- a/tests/test_run_config_result.py
+++ b/tests/test_run_config_result.py
@@ -289,11 +289,7 @@ class TestRunConfigResult(trc.TestResultCollector):
             non_gpu_metric_values=[{
                 'perf_throughput': throughput_value,
                 'perf_latency_p99': latency_value
-            }],
-            metric_objectives=[{
-                'perf_throughput': 1
-            }],
-            model_config_weights=[1])
+            }])
 
     def _construct_multi_model_rcm(self, throughput_values, latency_values):
         return construct_run_config_measurement(
@@ -307,13 +303,7 @@ class TestRunConfigResult(trc.TestResultCollector):
             }, {
                 'perf_throughput': throughput_values[1],
                 'perf_latency_p99': latency_values[1]
-            }],
-            metric_objectives=[{
-                'perf_throughput': 1
-            }, {
-                'perf_throughput': 1
-            }],
-            model_config_weights=[1])
+            }])
 
 
 if __name__ == '__main__':

--- a/tests/test_run_config_result_comparator.py
+++ b/tests/test_run_config_result_comparator.py
@@ -55,7 +55,9 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
             avg_non_gpu_metrics1=self.avg_non_gpu_metrics_multi1,
             avg_gpu_metrics2=self.avg_gpu_metrics2,
             avg_non_gpu_metrics2=self.avg_non_gpu_metrics_multi2,
-            expected_result=False)
+            expected_result=False,
+            model_name="test_model",
+            model_config_names=["test_model_config0", "test_model_config1"])
 
     def test_latency_driven(self):
         objective_spec = [
@@ -88,7 +90,9 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
             avg_non_gpu_metrics1=self.avg_non_gpu_metrics_multi1,
             avg_gpu_metrics2=self.avg_gpu_metrics2,
             avg_non_gpu_metrics2=self.avg_non_gpu_metrics_multi2,
-            expected_result=True)
+            expected_result=True,
+            model_name="test_model",
+            model_config_names=["test_model_config0", "test_model_config1"])
 
     def test_equal_weight(self):
         objective_spec = [{'perf_throughput': 1, 'perf_latency_p99': 1}]
@@ -118,7 +122,9 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
             avg_gpu_metrics2=self.avg_gpu_metrics2,
             avg_non_gpu_metrics2=self.avg_non_gpu_metrics_multi2,
             value_step2=2,
-            expected_result=False)
+            expected_result=False,
+            model_name="test_model",
+            model_config_names=["test_model_config0", "test_model_config1"])
 
     def _check_run_config_result_comparison(self,
                                             objective_spec,
@@ -128,7 +134,9 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
                                             avg_non_gpu_metrics2,
                                             value_step1=1,
                                             value_step2=1,
-                                            expected_result=0):
+                                            expected_result=0,
+                                            model_name="test_model",
+                                            model_config_names=["test_model"]):
         """
         Helper function that takes all the data needed to
         construct two RunConfigResults, constructs and runs a
@@ -144,14 +152,18 @@ class TestRunConfigResultComparatorMethods(trc.TestResultCollector):
             avg_non_gpu_metric_values_list=avg_non_gpu_metrics1,
             comparator=result_comparator,
             value_step=value_step1,
-            run_config=MagicMock())
+            run_config=MagicMock(),
+            model_name=model_name,
+            model_config_names=model_config_names)
 
         result2 = construct_run_config_result(
             avg_gpu_metric_values=avg_gpu_metrics2,
             avg_non_gpu_metric_values_list=avg_non_gpu_metrics2,
             comparator=result_comparator,
             value_step=value_step2,
-            run_config=MagicMock())
+            run_config=MagicMock(),
+            model_name=model_name,
+            model_config_names=model_config_names)
 
         self.assertEqual(result_comparator.is_better_than(result1, result2),
                          expected_result)


### PR DESCRIPTION
Add the following default values:

- All models equally weighted (in RunConfigMeasurement)
- ModelConfigs metrics are compared against using perf_throughput (in ModelConfigMeasurement)

Added an assertion to ensure that the correct number of model/metric weightings are set before any comparisons are done.
Updated failing unit tests.