### PR TITLE
Invert polarity of data stored in minheap

### DIFF
--- a/model_analyzer/config/generate/perf_analyzer_config_generator.py
+++ b/model_analyzer/config/generate/perf_analyzer_config_generator.py
@@ -112,8 +112,7 @@ class PerfAnalyzerConfigGenerator(ConfigGeneratorInterface):
         # Remove 'NONE' cases, and find single max measurement from the list
         measurements = [m for m in measurements if m]
 
-        # TMA-634 - convert to max
-        measurement = [min(measurements)] if measurements else [None]
+        measurement = [max(measurements)] if measurements else [None]
 
         self._last_results = measurement
         self._all_results.extend(measurement)

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -421,7 +421,8 @@ class ReportManager:
                                         title="Report Table")
 
         sorted_measurements = sorted(self._summary_data[report_key],
-                                     key=lambda x: x[1])
+                                     key=lambda x: x[1],
+                                     reverse=True)
 
         # Construct summary sentence using best config
         best_config = sorted_measurements[0][0]

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -74,34 +74,6 @@ class ModelConfigMeasurement:
 
         return model_config_measurement
 
-    @classmethod
-    def invert_values(cls, model_config_measurement):
-        """
-        Inverts the non-gpu data values
-        
-        Parameters
-        ----------
-        model_config_measurement : ModelConfigMeasurement
-        
-        Returns
-        -------
-        ModelConfigMeasurment with all non-gpu data values inverted
-        """
-
-        inverted_non_gpu_data = deepcopy(model_config_measurement._non_gpu_data)
-        for entry in inverted_non_gpu_data:
-            entry._value = -entry._value
-
-        inverted_mcm = ModelConfigMeasurement(
-            model_config_name=model_config_measurement._model_config_name,
-            model_specific_pa_params=model_config_measurement.
-            _model_specific_pa_params,
-            non_gpu_data=inverted_non_gpu_data)
-
-        inverted_mcm._metric_weights = model_config_measurement._metric_weights
-
-        return inverted_mcm
-
     def set_metric_weighting(self, metric_objectives):
         """
         Sets the metric weighting for this measurement based

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -17,7 +17,6 @@ from model_analyzer.constants import LOGGER_NAME
 
 from model_analyzer.record.record import RecordType
 
-from copy import deepcopy
 from functools import total_ordering
 import logging
 

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -26,7 +26,6 @@ from .results import Results
 
 import re
 import os
-import heapq
 from collections import defaultdict
 import logging
 
@@ -490,13 +489,12 @@ class ResultManager:
 
         for (measurements, passes) in [(passing_measurements, True),
                                        (failing_measurements, False)]:
-            while measurements:
-                next_best_measurement = heapq.heappop(measurements)
+            for measurement in measurements:
                 self._tabulate_measurement(
                     model_name=model_name,
                     instance_group=instance_group,
                     dynamic_batching=dynamic_batching,
-                    run_config_measurement=next_best_measurement,
+                    run_config_measurement=measurement,
                     passes=passes,
                     cpu_only=cpu_only,
                     backend_parameters=backend_parameters)

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -20,7 +20,6 @@ from model_analyzer.record.record import RecordType
 
 from statistics import mean
 
-from copy import deepcopy
 from functools import total_ordering
 import logging
 

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -78,37 +78,6 @@ class RunConfigMeasurement:
 
         return run_config_measurement
 
-    @classmethod
-    def invert_values(cls, run_config_measurement):
-        """
-        Inverts all GPU and non-GPU data values
-        
-        Parameters
-        ----------
-        run_config_measurement : RunConfigMeasurement
-        
-        Returns
-        -------
-        RunConfigMeasurment with all GPU and non-GPU data values inverted
-        """
-
-        inverted_gpu_data = deepcopy(run_config_measurement._gpu_data)
-        for gpu in inverted_gpu_data.values():
-            for entry in gpu:
-                entry._value = -entry._value
-
-        inverted_rcm = RunConfigMeasurement(
-            model_variants_name=run_config_measurement._model_variants_name,
-            gpu_data=inverted_gpu_data)
-
-        for mcm in run_config_measurement._model_config_measurements:
-            inverted_rcm._model_config_measurements.append(
-                ModelConfigMeasurement.invert_values(mcm))
-
-        inverted_rcm._model_config_weights = run_config_measurement._model_config_weights
-
-        return inverted_rcm
-
     def set_model_config_weighting(self, model_config_weights):
         """
         Sets the model config weightings used when calculating 

--- a/model_analyzer/result/run_config_result.py
+++ b/model_analyzer/result/run_config_result.py
@@ -119,7 +119,10 @@ class RunConfigResult:
             of RunConfigMeasurements in this RunConfigResult
         """
 
-        return self._measurements
+        return [
+            RunConfigMeasurement.invert_values(measurement)
+            for measurement in self._measurements
+        ]
 
     def passing_measurements(self):
         """
@@ -129,7 +132,10 @@ class RunConfigResult:
             of passing measurements in this RunConfigResult
         """
 
-        return self._passing_measurements
+        return [
+            RunConfigMeasurement.invert_values(passing_measurement)
+            for passing_measurement in self._passing_measurements
+        ]
 
     def failing_measurements(self):
         """
@@ -139,7 +145,10 @@ class RunConfigResult:
             of failing measurements in this RunConfigResult
         """
 
-        return self._failing_measurements
+        return [
+            RunConfigMeasurement.invert_values(failing_measurements)
+            for failing_measurements in self._failing_measurements
+        ]
 
     def top_n_measurements(self, n):
         """

--- a/model_analyzer/result/run_config_result_comparator.py
+++ b/model_analyzer/result/run_config_result_comparator.py
@@ -59,12 +59,10 @@ class RunConfigResultComparator:
            True: if result1 is better than result2
         """
 
-        ########## IMPORTANT measurment comparators return 1 on a < b (for min heap) ###########
-        ########## Here we want the max measurement, we must pass in min() ###########
         agg_run_config_measurement1 = self._aggregate_run_config_measurements(
-            run_config_result1, aggregation_func=min)
+            run_config_result1, aggregation_func=max)
         agg_run_config_measurement2 = self._aggregate_run_config_measurements(
-            run_config_result2, aggregation_func=min)
+            run_config_result2, aggregation_func=max)
 
         return agg_run_config_measurement1.is_better_than(
             agg_run_config_measurement2)

--- a/tests/test_model_config_measurement.py
+++ b/tests/test_model_config_measurement.py
@@ -187,19 +187,6 @@ class TestModelConfigMeasurement(trc.TestResultCollector):
         # Catchall in case something new is added
         self.assertEqual(mcmA_from_dict, self.mcmA)
 
-    def test_invert_values(self):
-        """
-        Test that non-gpu values are properly inverted
-        """
-        inverted_mcmA = ModelConfigMeasurement.invert_values(self.mcmA)
-
-        inverted_mcmA_non_gpu_data = inverted_mcmA.non_gpu_data()
-        mcmA_non_gpu_data = self.mcmA.non_gpu_data()
-
-        for index, non_gpu_data in enumerate(mcmA_non_gpu_data):
-            self.assertEqual(inverted_mcmA_non_gpu_data[index]._value,
-                             -non_gpu_data._value)
-
     def _construct_model_config_measurement(self, model_config_name,
                                             model_specific_pa_params,
                                             non_gpu_metric_values):

--- a/tests/test_model_config_measurement.py
+++ b/tests/test_model_config_measurement.py
@@ -116,13 +116,13 @@ class TestModelConfigMeasurement(trc.TestResultCollector):
 
         # throughput: 1000 is not better than 2000
         self.assertFalse(self.mcmA.is_better_than(self.mcmB))
-        self.assertFalse(self.mcmA < self.mcmB)
+        self.assertTrue(self.mcmA < self.mcmB)
 
         self.mcmA.set_metric_weighting({"perf_latency_p99": 1})
 
         # latency: 20 is better than 40
         self.assertTrue(self.mcmA.is_better_than(self.mcmB))
-        self.assertTrue(self.mcmA < self.mcmB)
+        self.assertFalse(self.mcmA < self.mcmB)
 
     def test_is_better_than_combo(self):
         """
@@ -186,6 +186,19 @@ class TestModelConfigMeasurement(trc.TestResultCollector):
 
         # Catchall in case something new is added
         self.assertEqual(mcmA_from_dict, self.mcmA)
+
+    def test_invert_values(self):
+        """
+        Test that non-gpu values are properly inverted
+        """
+        inverted_mcmA = ModelConfigMeasurement.invert_values(self.mcmA)
+
+        inverted_mcmA_non_gpu_data = inverted_mcmA.non_gpu_data()
+        mcmA_non_gpu_data = self.mcmA.non_gpu_data()
+
+        for index, non_gpu_data in enumerate(mcmA_non_gpu_data):
+            self.assertEqual(inverted_mcmA_non_gpu_data[index]._value,
+                             -non_gpu_data._value)
 
     def _construct_model_config_measurement(self, model_config_name,
                                             model_specific_pa_params,

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -252,20 +252,6 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         # Catchall in case something new is added
         self.assertEqual(rcm0_from_dict, self.rcm0)
 
-    def test_invert_values(self):
-        """
-        Test that GPU and non-GPU values are properly inverted
-        """
-        inverted_rcm0 = RunConfigMeasurement.invert_values(self.rcm0)
-
-        inverted_rcm0_gpu_data = inverted_rcm0.gpu_data()
-        rcm0_gpu_data = self.rcm0.gpu_data()
-
-        for tag, value in rcm0_gpu_data.items():
-            for index, gpu_data in enumerate(value):
-                self.assertEqual(inverted_rcm0_gpu_data[tag][index]._value,
-                                 -gpu_data._value)
-
     def _construct_rcm0(self):
         self.model_name = "modelA,modelB"
         self.model_config_name = ["modelA_config_0", "modelB_config_1"]

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -230,6 +230,7 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         # This tips the scale in the favor of RCM0 (0.2, -0.15)
         self.rcm0.set_model_config_weighting([2, 3])
         self.assertTrue(self.rcm0.is_better_than(self.rcm1))
+        self.assertFalse(self.rcm0 < self.rcm1)
 
     def test_from_dict(self):
         """
@@ -250,6 +251,20 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
 
         # Catchall in case something new is added
         self.assertEqual(rcm0_from_dict, self.rcm0)
+
+    def test_invert_values(self):
+        """
+        Test that GPU and non-GPU values are properly inverted
+        """
+        inverted_rcm0 = RunConfigMeasurement.invert_values(self.rcm0)
+
+        inverted_rcm0_gpu_data = inverted_rcm0.gpu_data()
+        rcm0_gpu_data = self.rcm0.gpu_data()
+
+        for tag, value in rcm0_gpu_data.items():
+            for index, gpu_data in enumerate(value):
+                self.assertEqual(inverted_rcm0_gpu_data[tag][index]._value,
+                                 -gpu_data._value)
 
     def _construct_rcm0(self):
         self.model_name = "modelA,modelB"


### PR DESCRIPTION
The issue is that because we use a minheap, the `__lt__` methods in MCM/RCM have to return the opposite of the users expected value. This creates problems if the user does comparisons outside of the heap.

To solve this I inverted the data going "in to/out of" the heap. This allows me to reverse the __lt__ methods in MCM/RCM. I've fixed the usages in perf_config_generator and report_manager and updated comments/unit tests.