### PR TITLE
Replace get metric value calls

### DIFF
--- a/model_analyzer/config/generate/automatic_model_config_generator.py
+++ b/model_analyzer/config/generate/automatic_model_config_generator.py
@@ -114,7 +114,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
 
     def _get_last_results_max_throughput(self):
         throughputs = [
-            m.get_metric_value('perf_throughput')
+            m.get_non_gpu_metric_value('perf_throughput')
             for m in self._last_results
             if m is not None
         ]

--- a/model_analyzer/config/generate/perf_analyzer_config_generator.py
+++ b/model_analyzer/config/generate/perf_analyzer_config_generator.py
@@ -242,4 +242,4 @@ class PerfAnalyzerConfigGenerator(ConfigGeneratorInterface):
         return gain
 
     def _get_throughput(self, measurement):
-        return measurement.get_metric_value('perf_throughput')
+        return measurement.get_non_gpu_metric_value('perf_throughput')

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -125,7 +125,7 @@ class DetailedPlot:
                 tag='perf_throughput'))
 
         for metric in self.detailed_metrics:
-            if MetricsManager.is_gpu_metric(tag):
+            if MetricsManager.is_gpu_metric(tag=metric):
                 self._data[metric].append(
                     run_config_measurement.get_gpu_metric_value(tag=metric))
             else:

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -121,7 +121,8 @@ class DetailedPlot:
             ['concurrency-range'])
 
         self._data['perf_throughput'].append(
-            run_config_measurement.get_metric_value(tag='perf_throughput'))
+            run_config_measurement.get_non_gpu_metric_value(
+                tag='perf_throughput'))
 
         for metric in self.detailed_metrics:
             self._data[metric].append(

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -125,8 +125,12 @@ class DetailedPlot:
                 tag='perf_throughput'))
 
         for metric in self.detailed_metrics:
-            self._data[metric].append(
-                run_config_measurement.get_metric_value(tag=metric))
+            if MetricsManager.is_gpu_metric(tag):
+                self._data[metric].append(
+                    run_config_measurement.get_gpu_metric_value(tag=metric))
+            else:
+                self._data[metric].append(
+                    run_config_measurement.get_non_gpu_metric_value(tag=metric))
 
     def plot_data(self):
         """

--- a/model_analyzer/plots/simple_plot.py
+++ b/model_analyzer/plots/simple_plot.py
@@ -82,9 +82,14 @@ class SimplePlot:
                 run_config_measurement.model_specific_pa_params()[0][
                     self._x_axis.replace('_', '-')])
         else:
-            # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
-            self._data[label]['x_data'].append(
-                run_config_measurement.get_metric_value(tag=self._x_axis))
+            if MetricsManager.is_gpu_metric(tag=self._x_axis):
+                self._data[label]['x_data'].append(
+                    run_config_measurement.get_gpu_metric_value(
+                        tag=self._x_axis))
+            else:
+                self._data[label]['x_data'].append(
+                    run_config_measurement.get_non_gpu_metric_value(
+                        tag=self._x_axis))
 
         # TODO-TMA-568: This needs to be updated because there will be multiple model configs
         if self._y_axis.replace('_', '-') in PerfAnalyzerConfig.allowed_keys():
@@ -92,9 +97,14 @@ class SimplePlot:
                 run_config_measurement.model_specific_pa_params()[0][
                     self._y_axis.replace('_', '-')])
         else:
-            # TODO-TMA-566: replace with get_metric_gpu/non_gpu_value()
-            self._data[label]['y_data'].append(
-                run_config_measurement.get_metric_value(tag=self._y_axis))
+            if MetricsManager.is_gpu_metric(tag=self._y_axis):
+                self._data[label]['y_data'].append(
+                    run_config_measurement.get_gpu_metric_value(
+                        tag=self._y_axis))
+            else:
+                self._data[label]['y_data'].append(
+                    run_config_measurement.get_non_gpu_metric_value(
+                        tag=self._y_axis))
 
     def clear(self):
         """
@@ -135,9 +145,8 @@ class SimplePlot:
 
         for model_config_name, data in self._data.items():
             # Sort the data by x-axis
-            x_data, y_data = (
-                list(t)
-                for t in zip(*sorted(zip(data['x_data'], data['y_data']))))
+            x_data, y_data = (list(t) for t in zip(
+                *sorted(zip(data['x_data'], data['y_data']))))
 
             if self._monotonic:
                 filtered_x, filtered_y = [x_data[0]], [y_data[0]]

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -450,11 +450,12 @@ class ReportManager:
                 row = [
                     model_config.get_field('name'), max_batch_size,
                     model_config.dynamic_batching_string(), instance_group_str,
-                    measurement.get_metric_value('perf_latency_p99'),
-                    measurement.get_metric_value('perf_throughput'),
-                    measurement.get_metric_value('cpu_used_ram'),
-                    measurement.get_metric_value('gpu_used_memory'),
-                    round(measurement.get_metric_value('gpu_utilization'), 1)
+                    measurement.get_non_gpu_metric_value('perf_latency_p99'),
+                    measurement.get_non_gpu_metric_value('perf_throughput'),
+                    measurement.get_non_gpu_metric_value('cpu_used_ram'),
+                    measurement.get_gpu_metric_value('gpu_used_memory'),
+                    round(measurement.get_gpu_metric_value('gpu_utilization'),
+                          1)
                 ]
                 summary_table.insert_row_by_index(row)
         else:
@@ -464,9 +465,9 @@ class ReportManager:
                 row = [
                     model_config.get_field('name'), max_batch_size,
                     model_config.dynamic_batching_string(), instance_group_str,
-                    measurement.get_metric_value('perf_latency_p99'),
-                    measurement.get_metric_value('perf_throughput'),
-                    measurement.get_metric_value('cpu_used_ram')
+                    measurement.get_non_gpu_metric_value('perf_latency_p99'),
+                    measurement.get_non_gpu_metric_value('perf_throughput'),
+                    measurement.get_non_gpu_metric_value('cpu_used_ram')
                 ]
                 summary_table.insert_row_by_index(row)
         return summary_table, summary_sentence
@@ -479,9 +480,10 @@ class ReportManager:
         model_config, measurements = self._detailed_report_data[
             model_config_name]
         sort_by_tag = 'perf_latency_p99' if self._mode == 'online' else 'perf_throughput'
-        measurements = sorted(measurements,
-                              key=lambda x: x.get_metric_value(sort_by_tag),
-                              reverse=True)
+        measurements = sorted(
+            measurements,
+            key=lambda x: x.get_non_gpu_metric_value(sort_by_tag),
+            reverse=True)
         cpu_only = model_config.cpu_only()
 
         first_column_header = 'Request Concurrency' if self._mode == 'online' else 'Client Batch Size'
@@ -509,15 +511,19 @@ class ReportManager:
                 row = [
                     # TODO-TMA-568: This needs to be updated because there will be multiple model configs
                     measurement.model_specific_pa_params()[0][first_column_tag],
-                    measurement.get_metric_value('perf_latency_p99'),
-                    measurement.get_metric_value('perf_client_response_wait'),
-                    measurement.get_metric_value('perf_server_queue'),
-                    measurement.get_metric_value('perf_server_compute_input'),
-                    measurement.get_metric_value('perf_server_compute_infer'),
-                    measurement.get_metric_value('perf_throughput'),
-                    measurement.get_metric_value('cpu_used_ram'),
-                    measurement.get_metric_value('gpu_used_memory'),
-                    round(measurement.get_metric_value('gpu_utilization'), 1)
+                    measurement.get_non_gpu_metric_value('perf_latency_p99'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_client_response_wait'),
+                    measurement.get_non_gpu_metric_value('perf_server_queue'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_server_compute_input'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_server_compute_infer'),
+                    measurement.get_non_gpu_metric_value('perf_throughput'),
+                    measurement.get_non_gpu_metric_value('cpu_used_ram'),
+                    measurement.get_gpu_metric_value('gpu_used_memory'),
+                    round(measurement.get_gpu_metric_value('gpu_utilization'),
+                          1)
                 ]
                 detailed_table.insert_row_by_index(row)
         else:
@@ -525,13 +531,16 @@ class ReportManager:
                 row = [
                     # TODO-TMA-568: This needs to be updated because there will be multiple model configs
                     measurement.model_specific_pa_params()[0][first_column_tag],
-                    measurement.get_metric_value('perf_latency_p99'),
-                    measurement.get_metric_value('perf_client_response_wait'),
-                    measurement.get_metric_value('perf_server_queue'),
-                    measurement.get_metric_value('perf_server_compute_input'),
-                    measurement.get_metric_value('perf_server_compute_infer'),
-                    measurement.get_metric_value('perf_throughput'),
-                    measurement.get_metric_value('cpu_used_ram')
+                    measurement.get_non_gpu_metric_value('perf_latency_p99'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_client_response_wait'),
+                    measurement.get_non_gpu_metric_value('perf_server_queue'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_server_compute_input'),
+                    measurement.get_non_gpu_metric_value(
+                        'perf_server_compute_infer'),
+                    measurement.get_non_gpu_metric_value('perf_throughput'),
+                    measurement.get_non_gpu_metric_value('cpu_used_ram')
                 ]
                 detailed_table.insert_row_by_index(row)
         return detailed_table

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -133,7 +133,7 @@ class ModelConfigMeasurement:
             return self._non_gpu_data_from_tag[tag]
         else:
             logger.warning(
-                f"No metric corresponding to tag '{tag}' "
+                f"No non-GPU metric corresponding to tag '{tag}' "
                 "found in the model's measurement. Possibly comparing "
                 "measurements across devices.")
             return None

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -289,8 +289,6 @@ class RunConfigMeasurement:
             Average of the values of the GPU metric Records 
             corresponding to the tag, default_value if tag not found.
         """
-        foo = self.get_gpu_metric(tag)
-
         return default_value if self.get_gpu_metric(
             tag) is None else self.get_gpu_metric(tag).value()
 

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -318,28 +318,6 @@ class RunConfigMeasurement:
         return default_value if self.get_gpu_metric(
             tag) is None else self.get_gpu_metric(tag).value()
 
-    #TODO-TMA-569: Remove this function
-    def get_metric_value(self, tag, default_value=0):
-        """
-        Parameters
-        ----------
-        tag : str
-            A human readable tag that corresponds
-            to a particular metric
-        default_value : any
-            Value to return if tag is not found
-
-        Returns
-        -------
-        list of Records
-            Average of the values of the metric Record corresponding 
-            to the tag, default_value if tag not found.
-        """
-        return mean([
-            default_value if m is None else m.value()
-            for m in self.get_metric(tag)
-        ])
-
     def get_weighted_metric_value(self, tag, default_value=0):
         """
         Parameters

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -196,7 +196,14 @@ class RunConfigMeasurement:
             of average GPU metric Records corresponding to this tag,
             or None if tag not found
         """
-        return self._avg_gpu_data_from_tag[tag]
+        if tag in self._avg_gpu_data_from_tag:
+            return self._avg_gpu_data_from_tag[tag]
+        else:
+            logger.warning(
+                f"No GPU metric corresponding to tag '{tag}' "
+                "found in the model's measurement. Possibly comparing "
+                "measurements across devices.")
+            return None
 
     def get_non_gpu_metric(self, tag):
         """

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -219,37 +219,6 @@ class RunConfigMeasurement:
             for model_config_measurement in self._model_config_measurements
         ]
 
-    #TODO-TMA-569: Remove this function
-    def get_metric(self, tag):
-        """
-        Returns the Records associated with this metric,
-        for GPU data this is a list of Records,
-        for non-GPU data there is one list per model
-        
-        Parameters
-        ----------
-        tag : str
-            A human readable tag that corresponds
-            to a particular metric
-
-        Returns
-        -------
-        GPU data:     list of   list of Records
-        non-GPU data: per model list of Records
-            metric Record corresponding to
-            the tag, in this measurement, 
-            None if tag not found.
-        """
-
-        if tag in self._avg_gpu_data_from_tag:
-            return [self._avg_gpu_data_from_tag[tag]]
-        else:
-            # Non-GPU metrics
-            return [
-                model_config_measurement.get_metric(tag)
-                for model_config_measurement in self._model_config_measurements
-            ]
-
     def get_weighted_non_gpu_metric(self, tag):
         """
         Parameters
@@ -318,7 +287,7 @@ class RunConfigMeasurement:
         return default_value if self.get_gpu_metric(
             tag) is None else self.get_gpu_metric(tag).value()
 
-    def get_weighted_metric_value(self, tag, default_value=0):
+    def get_weighted_non_gpu_metric_value(self, tag, default_value=0):
         """
         Parameters
         ----------
@@ -338,7 +307,7 @@ class RunConfigMeasurement:
             self._model_config_measurements)
 
         weighted_sum = 0
-        for index, metric in enumerate(self.get_metric(tag)):
+        for index, metric in enumerate(self.get_non_gpu_metric(tag)):
             weighted_sum += default_value if metric is None else metric.value(
             ) * self._model_config_weights[index]
 

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -171,8 +171,6 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         """
         Test that the model specific PA params are correct
         """
-        foo = self.rcm0.model_specific_pa_params()
-
         self.assertEqual(self.rcm0.model_specific_pa_params(),
                          self.model_specific_pa_params)
 

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -94,6 +94,12 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self.assertEqual(self.rcm0.get_gpu_metric("gpu_utilization"),
                          avg_gpu_data["gpu_utilization"])
 
+    def test_gpu_gpu_metric_not_found(self):
+        """
+        Test that an incorrect metric search returns None
+        """
+        self.assertEqual(self.rcm0.get_gpu_metric("XXXXX"), None)
+
     def test_get_non_gpu_metric(self):
         """
         Test that the non-gpu metric data is correct

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -158,7 +158,7 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
              self.weights[1])) / sum(self.weights)
 
         self.assertEqual(
-            self.rcm0.get_weighted_metric_value("perf_latency_p99"),
+            self.rcm0.get_weighted_non_gpu_metric_value("perf_latency_p99"),
             weighted_metric_value)
 
     def test_model_specific_pa_params(self):

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -110,40 +110,6 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self.assertEqual(self.rcm0.get_non_gpu_metric("cpu_used_ram"),
                          [non_gpu_data[0][2], non_gpu_data[1][2]])
 
-    #TODO-TMA-569: Remove this test
-    def test_get_metric_non_gpu(self):
-        """
-        Test that the non-gpu metric data is correct
-        """
-        non_gpu_data = [
-            convert_non_gpu_metrics_to_data(non_gpu_metric_value)
-            for non_gpu_metric_value in self.rcm0_non_gpu_metric_values
-        ]
-
-        self.assertEqual(self.rcm0.get_metric("perf_throughput"),
-                         [non_gpu_data[0][0], non_gpu_data[1][0]])
-        self.assertEqual(self.rcm0.get_metric("perf_latency_p99"),
-                         [non_gpu_data[0][1], non_gpu_data[1][1]])
-        self.assertEqual(self.rcm0.get_metric("cpu_used_ram"),
-                         [non_gpu_data[0][2], non_gpu_data[1][2]])
-
-    #TODO-TMA-569: Remove this test
-    def test_get_metric_gpu(self):
-        """
-        Test that the gpu metric data is correct
-        
-        """
-        avg_gpu_data = convert_avg_gpu_metrics_to_data(
-            self.avg_gpu_metric_values)
-
-        self.assertEqual(
-            self.rcm0.get_metric("gpu_used_memory")[0],
-            avg_gpu_data["gpu_used_memory"])
-
-        self.assertEqual(
-            self.rcm0.get_metric("gpu_utilization")[0],
-            avg_gpu_data["gpu_utilization"])
-
     def test_get_weighted_non_gpu_metric(self):
         """
         Test that the weighted non-gpu metric data is correct
@@ -180,18 +146,6 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         """
         self.assertEqual(self.rcm0.get_gpu_metric_value("gpu_used_memory"),
                          self.avg_gpu_metric_values['gpu_used_memory'])
-
-    #TODO-TMA-569: Remove this test
-    def test_get_metric_value(self):
-        """
-        Test that the non-gpu metric value is correct
-        """
-        self.assertEqual(
-            self.rcm0.get_metric_value("perf_throughput"),
-            mean([
-                self.rcm0_non_gpu_metric_values[0]['perf_throughput'],
-                self.rcm0_non_gpu_metric_values[1]['perf_throughput']
-            ]))
 
     def test_get_weighted_non_gpu_metric_value(self):
         """


### PR DESCRIPTION
Replace all calls to get_metric/get_metric_value() with gpu/non-gpu specific methods.
Remove these methods from RunConfigMeasurement