### PR TITLE
consistent model variant naming

### DIFF
--- a/model_analyzer/config/generate/automatic_model_config_generator.py
+++ b/model_analyzer/config/generate/automatic_model_config_generator.py
@@ -14,7 +14,7 @@
 
 from .base_model_config_generator import BaseModelConfigGenerator
 
-from model_analyzer.constants import LOGGER_NAME
+from model_analyzer.constants import LOGGER_NAME, DEFAULT_CONFIG_PARAMS
 import logging
 
 logger = logging.getLogger(LOGGER_NAME)
@@ -133,7 +133,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
 
     def _get_curr_param_combo(self):
         if self._default_only:
-            return self.DEFAULT_PARAM_COMBO
+            return DEFAULT_CONFIG_PARAMS
 
         config = {
             'dynamic_batching': {},

--- a/model_analyzer/config/generate/automatic_model_config_generator.py
+++ b/model_analyzer/config/generate/automatic_model_config_generator.py
@@ -23,18 +23,21 @@ logger = logging.getLogger(LOGGER_NAME)
 class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
     """ Given a model, generates model configs in automatic search mode """
 
-    def __init__(self, config, model, client, default_only):
+    def __init__(self, config, model, client, variant_name_manager,
+                 default_only):
         """
         Parameters
         ----------
         config: ModelAnalyzerConfig
         model: The model to generate ModelConfigs for
         client: TritonClient
+        variant_name_manager: ModelVariantNameManager
         default_only: Bool 
             If true, only the default config will be generated
             If false, the default config will NOT be generated
         """
-        super().__init__(config, model, client, default_only)
+        super().__init__(config, model, client, variant_name_manager,
+                         default_only)
 
         self._max_instance_count = config.run_config_search_max_instance_count
         self._min_instance_count = config.run_config_search_min_instance_count

--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -25,11 +25,6 @@ logger = logging.getLogger(LOGGER_NAME)
 class BaseModelConfigGenerator(ConfigGeneratorInterface):
     """ Base class for generating model configs """
 
-    # Dict of parameters to apply on top of the default config to result
-    # in the default config (none)
-    #
-    DEFAULT_PARAM_COMBO = {}
-
     def __init__(self, config, model, client, variant_name_manager,
                  default_only):
         """

--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -30,18 +30,21 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
     #
     DEFAULT_PARAM_COMBO = {}
 
-    def __init__(self, config, model, client, default_only):
+    def __init__(self, config, model, client, variant_name_manager,
+                 default_only):
         """
         Parameters
         ----------
         config: ModelAnalyzerConfig
         model: The model to generate ModelConfigs for
         client: TritonClient
+        variant_name_manager: ModelVariantNameManager
         default_only: Bool 
             If true, only the default config will be generated
             If false, the default config will NOT be generated
         """
         self._client = client
+        self._variant_name_manager = variant_name_manager
         self._model_repository = config.model_repository
         self._base_model = model
         self._base_model_name = model.model_name()
@@ -94,12 +97,8 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
         raise NotImplementedError
 
     def _get_model_variant_name(self, param_combo):
-        if param_combo is self.DEFAULT_PARAM_COMBO:
-            variant_name = f'{self._base_model_name}_config_default'
-        else:
-            variant_name = f'{self._base_model_name}_config_{self._model_name_index}'
-            self._model_name_index += 1
-        return variant_name
+        return self._variant_name_manager.get_model_variant_name(
+            self._base_model_name, param_combo)
 
     def _make_remote_model_config(self):
         if not self._reload_model_disable:

--- a/model_analyzer/config/generate/generator_factory.py
+++ b/model_analyzer/config/generate/generator_factory.py
@@ -25,6 +25,7 @@ class ConfigGeneratorFactory:
     def create_model_config_generator(config,
                                       model,
                                       client,
+                                      variant_name_manager,
                                       default_only=False):
         remote_mode = config.triton_launch_mode == 'remote'
         search_disabled = config.run_config_search_disable
@@ -32,7 +33,9 @@ class ConfigGeneratorFactory:
 
         if (remote_mode or search_disabled or model_config_params):
             return ManualModelConfigGenerator(config, model, client,
+                                              variant_name_manager,
                                               default_only)
         else:
             return AutomaticModelConfigGenerator(config, model, client,
+                                                 variant_name_manager,
                                                  default_only)

--- a/model_analyzer/config/generate/manual_model_config_generator.py
+++ b/model_analyzer/config/generate/manual_model_config_generator.py
@@ -14,6 +14,7 @@
 
 from .base_model_config_generator import BaseModelConfigGenerator
 from .generator_utils import GeneratorUtils
+from model_analyzer.constants import DEFAULT_CONFIG_PARAMS
 
 from model_analyzer.triton.model.model_config import ModelConfig
 
@@ -87,7 +88,7 @@ class ManualModelConfigGenerator(BaseModelConfigGenerator):
         """
 
         if self._default_only:
-            param_combos = [self.DEFAULT_PARAM_COMBO]
+            param_combos = [DEFAULT_CONFIG_PARAMS]
         else:
             model_config_params = self._base_model.model_config_parameters()
             if model_config_params:
@@ -105,4 +106,4 @@ class ManualModelConfigGenerator(BaseModelConfigGenerator):
 
     def _generate_search_disabled_param_combos(self):
         """ Return the configs when we want to search but searching is disabled """
-        return [self.DEFAULT_PARAM_COMBO]
+        return [DEFAULT_CONFIG_PARAMS]

--- a/model_analyzer/config/generate/manual_model_config_generator.py
+++ b/model_analyzer/config/generate/manual_model_config_generator.py
@@ -24,18 +24,21 @@ from model_analyzer.model_analyzer_exceptions \
 class ManualModelConfigGenerator(BaseModelConfigGenerator):
     """ Given a model, generates model configs in manual search mode """
 
-    def __init__(self, config, model, client, default_only):
+    def __init__(self, config, model, client, variant_name_manager,
+                 default_only):
         """
         Parameters
         ----------
         config: ModelAnalyzerConfig
         model: The model to generate ModelConfigs for
         client: TritonClient
+        variant_name_manager: ModelVariantNameManager
         default_only: Bool 
             If true, only the default config will be generated
             If false, the default config will NOT be generated                
         """
-        super().__init__(config, model, client, default_only)
+        super().__init__(config, model, client, variant_name_manager,
+                         default_only)
 
         self._reload_model_disable = config.reload_model_disable
         self._num_retries = config.client_max_retries

--- a/model_analyzer/config/generate/model_run_config_generator.py
+++ b/model_analyzer/config/generate/model_run_config_generator.py
@@ -25,7 +25,8 @@ class ModelRunConfigGenerator(ConfigGeneratorInterface):
     ModelConfig and PerfConfig)
     """
 
-    def __init__(self, config, model, client, default_only):
+    def __init__(self, config, model, client, variant_name_manager,
+                 default_only):
         """
         Parameters
         ----------
@@ -36,11 +37,14 @@ class ModelRunConfigGenerator(ConfigGeneratorInterface):
             
         client: TritonClient
 
+        variant_name_manager: ModelVariantNameManager
+        
         default_only: Bool
         """
         self._config = config
         self._model = model
         self._client = client
+        self._variant_name_manger = variant_name_manager
 
         self._model_name = model.model_name()
 
@@ -54,7 +58,8 @@ class ModelRunConfigGenerator(ConfigGeneratorInterface):
                                                  self._model_parameters)
 
         self._mcg = ConfigGeneratorFactory.create_model_config_generator(
-            self._config, model, self._client, default_only)
+            self._config, model, self._client, self._variant_name_manger,
+            default_only)
 
         self._curr_mc_measurements = []
 

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -14,15 +14,10 @@
 
 import collections.abc
 from copy import deepcopy
+from model_analyzer.constants import DEFAULT_CONFIG_PARAMS
 
 
 class ModelVariantNameManager:
-
-    # FIXME
-    # Dict of parameters to apply on top of the default config to result
-    # in the default config (none)
-    #
-    DEFAULT_PARAM_COMBO = {}
 
     def __init__(self):
 
@@ -65,7 +60,7 @@ class ModelVariantNameManager:
         """
         Create and save a new model variant for this base model
         """
-        if param_combo == self.DEFAULT_PARAM_COMBO:
+        if param_combo == DEFAULT_CONFIG_PARAMS:
             variant_name = f'{base_model_name}_config_default'
         else:
             model_name_index = self._get_next_model_name_index(base_model_name)

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+
+
+class ModelVariantNameManager:
+
+    # FIXME
+    # Dict of parameters to apply on top of the default config to result
+    # in the default config (none)
+    #
+    DEFAULT_PARAM_COMBO = {}
+
+    def __init__(self):
+
+        # Stored as _variant_names[base_model_name][param_combo] = variant_name_string
+        self._variant_names = {}
+
+        # Stored as _model_name_index[base_model_name] = current_count_integer
+        self._model_name_index = {}
+
+    def get_model_variant_name(self, base_model_name, param_combo):
+        """
+        Given a base model name and a dict of parameters to be applied
+        to the base model config, return the name of the model variant
+
+        If the same input values are provided to this function multiple times, 
+        the same value should be returned
+        """
+        if self._model_variant_exists(base_model_name, param_combo):
+            return self._get_model_variant_name(base_model_name, param_combo)
+        else:
+            return self._make_model_variant_name(base_model_name, param_combo)
+
+    def _model_variant_exists(self, base_model_name, param_combo):
+        """ 
+        Returns true if a model variant name already exists for this combination 
+        """
+        hashable_key = self._get_hashable_key(param_combo)
+
+        return base_model_name in self._variant_names \
+           and hashable_key in self._variant_names[base_model_name]
+
+    def _get_model_variant_name(self, base_model_name, param_combo):
+        """
+        Returns the model variant name that already exists for this combination
+        """
+        hashable_key = self._get_hashable_key(param_combo)
+        return self._variant_names[base_model_name][hashable_key]
+
+    def _make_model_variant_name(self, base_model_name, param_combo):
+        """
+        Create and save a new model variant for this base model
+        """
+        if param_combo == self.DEFAULT_PARAM_COMBO:
+            variant_name = f'{base_model_name}_config_default'
+        else:
+            model_name_index = self._get_next_model_name_index(base_model_name)
+            variant_name = f'{base_model_name}_config_{model_name_index}'
+            self._add_model_variant_name(base_model_name, param_combo,
+                                         variant_name)
+        return variant_name
+
+    def _add_model_variant_name(self, base_model_name, param_combo,
+                                variant_name):
+        """ 
+        Save a new model variant name for this base model
+        """
+        if base_model_name not in self._variant_names:
+            self._variant_names[base_model_name] = {}
+
+        hashable_key = self._get_hashable_key(param_combo)
+        self._variant_names[base_model_name][hashable_key] = variant_name
+
+    def _get_next_model_name_index(self, base_model_name):
+        """
+        Get the next index to be used as a unique number for variant naming
+        """
+        if base_model_name not in self._model_name_index:
+            self._model_name_index[base_model_name] = 0
+        else:
+            self._model_name_index[base_model_name] += 1
+
+        return self._model_name_index[base_model_name]
+
+    def _get_hashable_key(self, obj):
+        """
+        Given a list or dict which may have nested dicts/lists, return a key that 
+        is hashable 
+        """
+
+        if isinstance(obj, collections.Hashable):
+            key = obj
+        elif isinstance(obj, collections.Mapping):
+            key = frozenset(
+                (k, self._get_hashable_key(v)) for k, v in obj.items())
+        elif isinstance(obj, collections.Iterable):
+            key = tuple(self._get_hashable_key(item) for item in obj)
+        else:
+            raise TypeError(type(obj))
+
+        return key

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -33,7 +33,7 @@ class ModelVariantNameManager:
         to the base model config, return the name of the model variant
 
         If the same input values are provided to this function multiple times, 
-        the same value should be returned
+        the same value will be returned
         """
         if self._model_variant_exists(base_model_name, param_combo):
             return self._get_model_variant_name(base_model_name, param_combo)

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
+from copy import deepcopy
 
 
 class ModelVariantNameManager:
@@ -96,18 +97,23 @@ class ModelVariantNameManager:
         return self._model_name_index[base_model_name]
 
     def _get_hashable_key(self, obj):
+        obj_copy = deepcopy(obj)
+
+        return self._get_hashable_key_helper(obj_copy)
+
+    def _get_hashable_key_helper(self, obj):
         """
         Given a list or dict which may have nested dicts/lists, return a key that 
         is hashable 
         """
 
-        if isinstance(obj, collections.Hashable):
+        if isinstance(obj, collections.abc.Hashable):
             key = obj
-        elif isinstance(obj, collections.Mapping):
+        elif isinstance(obj, collections.abc.Mapping):
             key = frozenset(
-                (k, self._get_hashable_key(v)) for k, v in obj.items())
-        elif isinstance(obj, collections.Iterable):
-            key = tuple(self._get_hashable_key(item) for item in obj)
+                (k, self._get_hashable_key_helper(v)) for k, v in obj.items())
+        elif isinstance(obj, collections.abc.Iterable):
+            key = tuple(self._get_hashable_key_helper(item) for item in obj)
         else:
             raise TypeError(type(obj))
 

--- a/model_analyzer/config/generate/run_config_generator.py
+++ b/model_analyzer/config/generate/run_config_generator.py
@@ -14,8 +14,9 @@
 
 from .config_generator_interface import ConfigGeneratorInterface
 from model_analyzer.config.run.run_config import RunConfig
-from model_analyzer.config.generate.model_run_config_generator import ModelRunConfigGenerator
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
+from model_analyzer.config.generate.model_run_config_generator import ModelRunConfigGenerator
+from model_analyzer.config.generate.model_variant_name_manager import ModelVariantNameManager
 
 
 class RunConfigGenerator(ConfigGeneratorInterface):
@@ -47,6 +48,8 @@ class RunConfigGenerator(ConfigGeneratorInterface):
         self._curr_generators = [None for n in range(self._num_models)]
         self._default_returned = False
 
+        self._model_variant_name_manager = ModelVariantNameManager()
+
     def is_done(self):
         return    self._default_returned \
               and self._curr_generators[0] is not None \
@@ -73,7 +76,9 @@ class RunConfigGenerator(ConfigGeneratorInterface):
 
     def _generate_subset(self, index, default_only):
         mrcg = ModelRunConfigGenerator(self._config, self._models[index],
-                                       self._client, default_only)
+                                       self._client,
+                                       self._model_variant_name_manager,
+                                       default_only)
         model_run_config_generator = mrcg.next_config()
 
         self._curr_generators[index] = mrcg

--- a/model_analyzer/constants.py
+++ b/model_analyzer/constants.py
@@ -22,6 +22,10 @@ RESULT_TABLE_COLUMN_PADDING = 2
 # Result Comparator Constants
 COMPARISON_SCORE_THRESHOLD = 0.005
 
+# Dict of parameters to apply on top of the default
+# config to result in the default config (empty dict)
+DEFAULT_CONFIG_PARAMS = {}
+
 # Run Search
 THROUGHPUT_MINIMUM_GAIN = 0.05
 THROUGHPUT_MINIMUM_CONSECUTIVE_TRIES = 4

--- a/tests/test_model_config_generator.py
+++ b/tests/test_model_config_generator.py
@@ -27,6 +27,7 @@ from .mocks.mock_os import MockOSMethods
 import unittest
 from unittest.mock import MagicMock
 from model_analyzer.config.generate.base_model_config_generator import BaseModelConfigGenerator
+from model_analyzer.config.generate.model_variant_name_manager import ModelVariantNameManager
 
 
 class TestModelConfigGenerator(trc.TestResultCollector):
@@ -580,7 +581,8 @@ class TestModelConfigGenerator(trc.TestResultCollector):
         fake_client.get_model_config = lambda name, retry_count: {'name': name}
 
         mcg = ConfigGeneratorFactory.create_model_config_generator(
-            config, config.profile_models[0], fake_client)
+            config, config.profile_models[0], fake_client,
+            ModelVariantNameManager())
         mcg_generator = mcg.next_config()
         model_configs = []
         while not mcg.is_done():

--- a/tests/test_model_variant_name_manager.py
+++ b/tests/test_model_variant_name_manager.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from model_analyzer.config.generate.model_variant_name_manager import ModelVariantNameManager
+from .common import test_result_collector as trc
+import unittest
+
+
+class TestModelVariantNameManager(trc.TestResultCollector):
+
+    def test_default(self):
+        """
+        If no param is passed in, it is considered the default config
+        """
+        mvnm = ModelVariantNameManager()
+        name = mvnm.get_model_variant_name("modelA", {})
+        self.assertEqual(name, "modelA_config_default")
+
+    def test_basic(self):
+        """
+        If multiple unique param combos are passed in, the name will keep
+        incrementing
+        """
+        mvnm = ModelVariantNameManager()
+        name0 = mvnm.get_model_variant_name("modelA", {'A': 1})
+        name1 = mvnm.get_model_variant_name("modelA", {'A': 2})
+        name2 = mvnm.get_model_variant_name("modelA", {'A': 4})
+        self.assertEqual(name0, "modelA_config_0")
+        self.assertEqual(name1, "modelA_config_1")
+        self.assertEqual(name2, "modelA_config_2")
+
+    def test_multiple_models(self):
+        """
+        The two models should have no impact on each other's naming or counts
+        """
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {'A': 1})
+        b0 = mvnm.get_model_variant_name("modelB", {'A': 1})
+        a1 = mvnm.get_model_variant_name("modelA", {'A': 2})
+        b1 = mvnm.get_model_variant_name("modelB", {'A': 2})
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_1")
+        self.assertEqual(b0, "modelB_config_0")
+        self.assertEqual(b1, "modelB_config_1")
+
+    def test_combos(self):
+        """
+        Unique combos that share some of the same data should still be considered
+        unique and return new names
+        """
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {'A': 1})
+        a1 = mvnm.get_model_variant_name("modelA", {'B': 1})
+        a2 = mvnm.get_model_variant_name("modelA", {'A': 1, 'B': 1})
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_1")
+        self.assertEqual(a2, "modelA_config_2")
+
+    def test_repeat(self):
+        """
+        Calling with the same param_combo multiple times should result
+        in the same name being returned
+        """
+
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {'A': 1})
+        a1 = mvnm.get_model_variant_name("modelA", {'A': 1})
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_0")
+
+    def test_dict_order(self):
+        """
+        The order of the dict doesn't matter. If the contents are the same
+        then the name should be the same
+        """
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {'A': 1, 'B': 1})
+        a1 = mvnm.get_model_variant_name("modelA", {'B': 1, 'A': 1})
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_0")
+
+    def test_list_order(self):
+        """
+        The order of a list DOES matter. If the contents are the same but
+        in a different order, the name should be different
+        """
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {'A': 1, 'B': [1, 2, 3]})
+        a1 = mvnm.get_model_variant_name("modelA", {'A': 1, 'B': [3, 2, 1]})
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_1")
+
+    def test_nested_combos(self):
+        """
+        Make sure that having more complicated param_combos works as expected
+        """
+        mvnm = ModelVariantNameManager()
+        a0 = mvnm.get_model_variant_name("modelA", {
+            'A': {
+                'C': 5,
+                'D': 6
+            },
+            'B': [3, 2, 1]
+        })
+
+        # Same dict for A, but different order. Should return same as A0
+        a1 = mvnm.get_model_variant_name("modelA", {
+            'A': {
+                'D': 6,
+                'C': 5
+            },
+            'B': [3, 2, 1]
+        })
+
+        # Different dict for A. Should return new name
+        a2 = mvnm.get_model_variant_name("modelA", {
+            'A': {
+                'C': 5,
+                'D': 7
+            },
+            'B': [3, 2, 1]
+        })
+
+        # Different list for B. Should return new name
+        a3 = mvnm.get_model_variant_name("modelA", {
+            'A': {
+                'C': 5,
+                'D': 6
+            },
+            'B': [3, 2, 0]
+        })
+
+        # Same as A. Should return same as A0
+        a4 = mvnm.get_model_variant_name("modelA", {
+            'A': {
+                'C': 5,
+                'D': 6
+            },
+            'B': [3, 2, 1]
+        })
+
+        self.assertEqual(a0, "modelA_config_0")
+        self.assertEqual(a1, "modelA_config_0")
+        self.assertEqual(a2, "modelA_config_1")
+        self.assertEqual(a3, "modelA_config_2")
+        self.assertEqual(a4, "modelA_config_0")
+
+        # Complicated case with all combinations of dict/list inside of dict/list
+        b0 = mvnm.get_model_variant_name(
+            "modelB", {
+                'A': {
+                    'C': {
+                        'F': 4,
+                        'G': 5
+                    },
+                    'D': [1, 2, 3],
+                    'E': "abc"
+                },
+                'B': [{
+                    'H': 4,
+                    'I': 5
+                }, [4, 5, 6], "J", 7]
+            })
+
+        # Same as B0 (with some dict ordering differences). Should return same name
+        b1 = mvnm.get_model_variant_name(
+            "modelB", {
+                'A': {
+                    'E': "abc",
+                    'C': {
+                        'G': 5,
+                        'F': 4
+                    },
+                    'D': [1, 2, 3]
+                },
+                'B': [{
+                    'I': 5,
+                    'H': 4
+                }, [4, 5, 6], "J", 7]
+            })
+
+        self.assertEqual(b0, "modelB_config_0")
+        self.assertEqual(b1, "modelB_config_0")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure that if the same configuration is reused, it will have the same name. This is especially useful for multi-model.

