### PR TITLE
Stop analyze/report if no/bad checkpoint

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -41,7 +41,7 @@ class Analyzer:
     result writing methods.
     """
 
-    def __init__(self, config, server, state_manager, run_without_checkpoint):
+    def __init__(self, config, server, state_manager, checkpoint_required):
         """
         Parameters
         ----------
@@ -51,12 +51,14 @@ class Analyzer:
             Server handle
         state_manager: AnalyzerStateManager
             The object that maintains Model Analyzer State
+        checkpoint_required : bool
+            If true, an existing checkpoint is required to run MA
         """
 
         self._config = config
         self._server = server
         self._state_manager = state_manager
-        state_manager.load_checkpoint(run_without_checkpoint)
+        state_manager.load_checkpoint(checkpoint_required)
 
         self._result_manager = ResultManager(config=config,
                                              state_manager=self._state_manager)

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -41,7 +41,7 @@ class Analyzer:
     result writing methods.
     """
 
-    def __init__(self, config, server, state_manager):
+    def __init__(self, config, server, state_manager, run_without_checkpoint):
         """
         Parameters
         ----------
@@ -56,7 +56,7 @@ class Analyzer:
         self._config = config
         self._server = server
         self._state_manager = state_manager
-        state_manager.load_checkpoint()
+        state_manager.load_checkpoint(run_without_checkpoint)
 
         self._result_manager = ResultManager(config=config,
                                              state_manager=self._state_manager)

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -382,7 +382,7 @@ def main():
             analyzer = Analyzer(config,
                                 server,
                                 state_manager,
-                                checkpoint_required=True)
+                                checkpoint_required=False)
             analyzer.profile(client=client, gpus=gpus)
 
         elif args.subcommand == 'analyze':
@@ -390,7 +390,7 @@ def main():
                                 server,
                                 AnalyzerStateManager(config=config,
                                                      server=server),
-                                checkpoint_required=False)
+                                checkpoint_required=True)
             analyzer.analyze(mode=args.mode, verbose=bool(args.verbose))
         elif args.subcommand == 'report':
 
@@ -398,7 +398,7 @@ def main():
                                 server,
                                 AnalyzerStateManager(config=config,
                                                      server=server),
-                                checkpoint_required=False)
+                                checkpoint_required=True)
             analyzer.report(mode=args.mode)
     finally:
         if server is not None:

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -379,20 +379,26 @@ def main():
             if state_manager.exiting():
                 return
 
-            analyzer = Analyzer(config, server, state_manager)
+            analyzer = Analyzer(config,
+                                server,
+                                state_manager,
+                                run_without_checkpoint=True)
             analyzer.profile(client=client, gpus=gpus)
 
         elif args.subcommand == 'analyze':
-
-            analyzer = Analyzer(
-                config, server,
-                AnalyzerStateManager(config=config, server=server))
+            analyzer = Analyzer(config,
+                                server,
+                                AnalyzerStateManager(config=config,
+                                                     server=server),
+                                run_without_checkpoint=False)
             analyzer.analyze(mode=args.mode, verbose=bool(args.verbose))
         elif args.subcommand == 'report':
 
-            analyzer = Analyzer(
-                config, server,
-                AnalyzerStateManager(config=config, server=server))
+            analyzer = Analyzer(config,
+                                server,
+                                AnalyzerStateManager(config=config,
+                                                     server=server),
+                                run_without_checkpoint=False)
             analyzer.report(mode=args.mode)
     finally:
         if server is not None:

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -382,7 +382,7 @@ def main():
             analyzer = Analyzer(config,
                                 server,
                                 state_manager,
-                                run_without_checkpoint=True)
+                                checkpoint_required=True)
             analyzer.profile(client=client, gpus=gpus)
 
         elif args.subcommand == 'analyze':
@@ -390,7 +390,7 @@ def main():
                                 server,
                                 AnalyzerStateManager(config=config,
                                                      server=server),
-                                run_without_checkpoint=False)
+                                checkpoint_required=False)
             analyzer.analyze(mode=args.mode, verbose=bool(args.verbose))
         elif args.subcommand == 'report':
 
@@ -398,7 +398,7 @@ def main():
                                 server,
                                 AnalyzerStateManager(config=config,
                                                      server=server),
-                                run_without_checkpoint=False)
+                                checkpoint_required=False)
             analyzer.report(mode=args.mode)
     finally:
         if server is not None:

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -361,6 +361,11 @@ class ResultManager:
         for model_name in self._analysis_model_names:
             model_measurements = results.get_model_measurements_dict(model_name)
 
+            if not model_measurements:
+                raise TritonModelAnalyzerException(
+                    f"The model {model_name} was not found in the loaded checkpoint."
+                )
+
             for (run_config,
                  run_config_measurements) in model_measurements.values():
                 run_config_result = RunConfigResult(

--- a/model_analyzer/state/analyzer_state_manager.py
+++ b/model_analyzer/state/analyzer_state_manager.py
@@ -107,7 +107,7 @@ class AnalyzerStateManager:
         self._state_changed = True
         self._current_state.set(name, value)
 
-    def load_checkpoint(self):
+    def load_checkpoint(self, run_without_checkpoint):
         """
         Load the state of the Model Analyzer from
         most recent checkpoint file, also 
@@ -129,7 +129,10 @@ class AnalyzerStateManager:
                         ' directory.')
             self._starting_fresh_run = False
         else:
-            logger.info("No checkpoint file found, starting a fresh run.")
+            if run_without_checkpoint:
+                logger.info("No checkpoint file found, starting a fresh run.")
+            else:
+                raise TritonModelAnalyzerException(f'No checkpoint file found')
 
     def default_encode(self, obj):
         if isinstance(obj, bytes):

--- a/model_analyzer/state/analyzer_state_manager.py
+++ b/model_analyzer/state/analyzer_state_manager.py
@@ -107,11 +107,16 @@ class AnalyzerStateManager:
         self._state_changed = True
         self._current_state.set(name, value)
 
-    def load_checkpoint(self, run_without_checkpoint):
+    def load_checkpoint(self, checkpoint_required):
         """
         Load the state of the Model Analyzer from
         most recent checkpoint file, also 
         set whether we are starting a fresh run
+        
+        Parameters
+        ----------
+        checkpoint_required : bool
+            If true, an existing checkpoint is required to run MA
         """
 
         latest_checkpoint_file = os.path.join(
@@ -129,7 +134,7 @@ class AnalyzerStateManager:
                         ' directory.')
             self._starting_fresh_run = False
         else:
-            if run_without_checkpoint:
+            if checkpoint_required:
                 logger.info("No checkpoint file found, starting a fresh run.")
             else:
                 raise TritonModelAnalyzerException(f'No checkpoint file found')

--- a/model_analyzer/state/analyzer_state_manager.py
+++ b/model_analyzer/state/analyzer_state_manager.py
@@ -135,9 +135,9 @@ class AnalyzerStateManager:
             self._starting_fresh_run = False
         else:
             if checkpoint_required:
-                logger.info("No checkpoint file found, starting a fresh run.")
-            else:
                 raise TritonModelAnalyzerException(f'No checkpoint file found')
+            else:
+                logger.info("No checkpoint file found, starting a fresh run.")
 
     def default_encode(self, obj):
         if isinstance(obj, bytes):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -74,7 +74,10 @@ class TestAnalyzer(trc.TestResultCollector):
         ]
         config = self._evaluate_profile_config(args, '')
         state_manager = AnalyzerStateManager(config, None)
-        analyzer = Analyzer(config, None, state_manager)
+        analyzer = Analyzer(config,
+                            None,
+                            state_manager,
+                            run_without_checkpoint=True)
         self.assertEqual(
             analyzer._get_analyze_command_help_string(),
             'To analyze the profile results and find the best configurations, '
@@ -130,7 +133,10 @@ class TestAnalyzer(trc.TestResultCollector):
         ]
         config = self._evaluate_analyze_config(args, '')
         state_manager = AnalyzerStateManager(config, None)
-        analyzer = Analyzer(config, None, state_manager)
+        analyzer = Analyzer(config,
+                            None,
+                            state_manager,
+                            run_without_checkpoint=True)
         self.assertEqual(
             analyzer._get_report_command_help_string(),
             'To generate detailed reports for the 3 best configurations, run '

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -77,7 +77,7 @@ class TestAnalyzer(trc.TestResultCollector):
         analyzer = Analyzer(config,
                             None,
                             state_manager,
-                            run_without_checkpoint=True)
+                            checkpoint_required=True)
         self.assertEqual(
             analyzer._get_analyze_command_help_string(),
             'To analyze the profile results and find the best configurations, '
@@ -136,7 +136,7 @@ class TestAnalyzer(trc.TestResultCollector):
         analyzer = Analyzer(config,
                             None,
                             state_manager,
-                            run_without_checkpoint=True)
+                            checkpoint_required=True)
         self.assertEqual(
             analyzer._get_report_command_help_string(),
             'To generate detailed reports for the 3 best configurations, run '

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -77,7 +77,7 @@ class TestAnalyzer(trc.TestResultCollector):
         analyzer = Analyzer(config,
                             None,
                             state_manager,
-                            checkpoint_required=True)
+                            checkpoint_required=False)
         self.assertEqual(
             analyzer._get_analyze_command_help_string(),
             'To analyze the profile results and find the best configurations, '
@@ -136,7 +136,7 @@ class TestAnalyzer(trc.TestResultCollector):
         analyzer = Analyzer(config,
                             None,
                             state_manager,
-                            checkpoint_required=True)
+                            checkpoint_required=False)
         self.assertEqual(
             analyzer._get_report_command_help_string(),
             'To generate detailed reports for the 3 best configurations, run '

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -79,7 +79,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
 
     def test_set_get_state_variables(self):
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint(run_without_checkpoint=True)
+        self.state_manager.load_checkpoint(checkpoint_required=True)
 
         vars = [f"test_var{j}" for j in range(10)]
         for i, name in enumerate(vars):
@@ -97,13 +97,13 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
     def test_load_checkpoint(self):
         # Load checkpoint without ckpt files
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint(run_without_checkpoint=True)
+        self.state_manager.load_checkpoint(checkpoint_required=True)
         self.assertTrue(self.state_manager.starting_fresh_run())
 
         # Load checkpoint files with ckpt files
         self.mock_os.set_os_path_exists_return_value(True)
         self.mock_os.set_os_path_join_return_value('0.ckpt')
-        self.state_manager.load_checkpoint(run_without_checkpoint=True)
+        self.state_manager.load_checkpoint(checkpoint_required=True)
         self.assertFalse(self.state_manager.starting_fresh_run())
 
         # Load checkpoint throws error
@@ -114,7 +114,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
                                ' directory.'):
             self.mock_os.set_os_path_exists_return_value(True)
             self.mock_os.set_os_path_join_return_value('0.ckpt')
-            self.state_manager.load_checkpoint(run_without_checkpoint=True)
+            self.state_manager.load_checkpoint(checkpoint_required=True)
             self.assertFalse(self.state_manager.starting_fresh_run())
 
     def test_latest_checkpoint(self):

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -79,7 +79,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
 
     def test_set_get_state_variables(self):
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint()
+        self.state_manager.load_checkpoint(run_without_checkpoint=True)
 
         vars = [f"test_var{j}" for j in range(10)]
         for i, name in enumerate(vars):
@@ -97,13 +97,13 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
     def test_load_checkpoint(self):
         # Load checkpoint without ckpt files
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint()
+        self.state_manager.load_checkpoint(run_without_checkpoint=True)
         self.assertTrue(self.state_manager.starting_fresh_run())
 
         # Load checkpoint files with ckpt files
         self.mock_os.set_os_path_exists_return_value(True)
         self.mock_os.set_os_path_join_return_value('0.ckpt')
-        self.state_manager.load_checkpoint()
+        self.state_manager.load_checkpoint(run_without_checkpoint=True)
         self.assertFalse(self.state_manager.starting_fresh_run())
 
         # Load checkpoint throws error
@@ -114,7 +114,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
                                ' directory.'):
             self.mock_os.set_os_path_exists_return_value(True)
             self.mock_os.set_os_path_join_return_value('0.ckpt')
-            self.state_manager.load_checkpoint()
+            self.state_manager.load_checkpoint(run_without_checkpoint=True)
             self.assertFalse(self.state_manager.starting_fresh_run())
 
     def test_latest_checkpoint(self):

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -79,7 +79,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
 
     def test_set_get_state_variables(self):
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint(checkpoint_required=True)
+        self.state_manager.load_checkpoint(checkpoint_required=False)
 
         vars = [f"test_var{j}" for j in range(10)]
         for i, name in enumerate(vars):
@@ -97,13 +97,13 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
     def test_load_checkpoint(self):
         # Load checkpoint without ckpt files
         self.mock_os.set_os_path_exists_return_value(False)
-        self.state_manager.load_checkpoint(checkpoint_required=True)
+        self.state_manager.load_checkpoint(checkpoint_required=False)
         self.assertTrue(self.state_manager.starting_fresh_run())
 
         # Load checkpoint files with ckpt files
         self.mock_os.set_os_path_exists_return_value(True)
         self.mock_os.set_os_path_join_return_value('0.ckpt')
-        self.state_manager.load_checkpoint(checkpoint_required=True)
+        self.state_manager.load_checkpoint(checkpoint_required=False)
         self.assertFalse(self.state_manager.starting_fresh_run())
 
         # Load checkpoint throws error
@@ -114,7 +114,7 @@ class TestAnalyzerStateManagerMethods(trc.TestResultCollector):
                                ' directory.'):
             self.mock_os.set_os_path_exists_return_value(True)
             self.mock_os.set_os_path_join_return_value('0.ckpt')
-            self.state_manager.load_checkpoint(checkpoint_required=True)
+            self.state_manager.load_checkpoint(checkpoint_required=False)
             self.assertFalse(self.state_manager.starting_fresh_run())
 
     def test_latest_checkpoint(self):


### PR DESCRIPTION
These changes will cause an exception to be raised if we detect a missing checkpoint or if the checkpoint does not contain the model(s) specified by the user on the CLI.

Here is the new output if no checkpoint exists:
![Capture4](https://user-images.githubusercontent.com/92820864/166591100-cb27222f-a2a6-47fc-a9ce-7a4e3118eeea.JPG)

Here is the new output if the checkpoint exists, but the model is not found:
![Capture3](https://user-images.githubusercontent.com/92820864/166591117-e69e8311-7ed2-463c-b040-108792e6b384.JPG)

