### PR TITLE
Remove cpu ram from reports when not collected

### DIFF
--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -155,6 +155,7 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
         logger.info("")
 
         model_config = ModelConfig.create_from_dictionary(model_config_dict)
+        model_config.set_cpu_only(self._cpu_only)
 
         return model_config
 

--- a/model_analyzer/config/generate/manual_model_config_generator.py
+++ b/model_analyzer/config/generate/manual_model_config_generator.py
@@ -126,11 +126,9 @@ class ManualModelConfigGenerator(BaseModelConfigGenerator):
                     param_combo['max_batch_size'] = mbs
                     model_config = self._make_direct_mode_model_config(
                         param_combo)
-                    model_config.set_cpu_only(self._cpu_only)
                     configs_with_max_batch_size.append(model_config)
             else:
                 model_config = self._make_direct_mode_model_config(param_combo)
-                model_config.set_cpu_only(self._cpu_only)
                 configs_with_max_batch_size.append(model_config)
 
             model_configs.append(configs_with_max_batch_size)

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -84,12 +84,13 @@ class MetricsManager:
                 f"Duplicate model names detected: "
                 f"{[model._model_name for model in config.profile_models]}")
         self._first_config_variant = {}
-
         self._config = config
         self._client = client
         self._server = server
         self._result_manager = result_manager
         self._state_manager = state_manager
+
+        self._cpu_warning_printed = False
 
         self._gpu_metrics, self._perf_metrics, self._cpu_metrics = self._categorize_metrics(
             self.metrics, self._config.collect_cpu_metrics)
@@ -567,10 +568,12 @@ class MetricsManager:
             )
         # Warn user about CPU monitor performance issue
         if collect_cpu_metrics_actual:
-            logger.warning("CPU metric(s) are being collected.")
-            logger.warning(
-                "Collecting CPU metric(s) can affect the latency or throughput numbers reported by perf analyzer."
-            )
+            if not self._cpu_warning_printed:
+                self._cpu_warning_printed = True
+                logger.warning("CPU metric(s) are being collected.")
+                logger.warning(
+                    "Collecting CPU metric(s) can affect the latency or throughput numbers reported by perf analyzer."
+                )
 
     @staticmethod
     def get_metric_types(tags):

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -881,8 +881,9 @@ class ReportManager:
             used_ram = None
             if self._detailed_report_data:
                 key = list(self._detailed_report_data.keys())[0]
-                _, measurement = self._detailed_report_data[key][0]
-                used_ram = measurement.get_non_gpu_metric_value('cpu_used_ram')
+                _, measurements = self._detailed_report_data[key]
+                used_ram = measurements[0].get_non_gpu_metric_value(
+                    'cpu_used_ram')
             else:
                 key = list(self._summary_data.keys())[0]
                 _, measurement = self._summary_data[key][0]
@@ -890,7 +891,6 @@ class ReportManager:
 
             # FIXME I would like to use used_ram is not None, and pass None as
             # 2nd option to get_non_gpu_metric_value, but it doesn't work
-
             self._cpu_metrics_gathered_sticky = used_ram != 0
 
         return self._cpu_metrics_gathered_sticky

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -900,8 +900,6 @@ class ReportManager:
                 _, measurement = self._summary_data[key][0]
                 used_ram = measurement.get_non_gpu_metric_value('cpu_used_ram')
 
-            # FIXME I would like to use used_ram is not None, and pass None as
-            # 2nd option to get_non_gpu_metric_value, but it doesn't work
             self._cpu_metrics_gathered_sticky = used_ram != 0
 
         return self._cpu_metrics_gathered_sticky

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -362,6 +362,7 @@ class ReportManager:
             summary.add_images([throughput_plot], [caption_throughput],
                                image_width=66)
             if self._mode == 'online':
+                # FIXME cpu
                 memory_latency_plot = os.path.join(self._config.export_path,
                                                    'plots', 'simple',
                                                    report_key,
@@ -647,6 +648,7 @@ class ReportManager:
         perf_throughput_string = self._create_non_gpu_metric_string(
             run_config_measurement=run_config_measurement,
             non_gpu_metric='perf_throughput')
+        # FIXME cpu case
         cpu_used_ram_string = self._create_non_gpu_metric_string(
             run_config_measurement=run_config_measurement,
             non_gpu_metric='cpu_used_ram')
@@ -744,6 +746,7 @@ class ReportManager:
                     measurement.get_non_gpu_metric_value(
                         'perf_server_compute_infer'),
                     measurement.get_non_gpu_metric_value('perf_throughput'),
+                    # FIXME cpu
                     measurement.get_non_gpu_metric_value('cpu_used_ram'),
                     measurement.get_gpu_metric_value('gpu_used_memory'),
                     round(measurement.get_gpu_metric_value('gpu_utilization'),
@@ -764,6 +767,7 @@ class ReportManager:
                     measurement.get_non_gpu_metric_value(
                         'perf_server_compute_infer'),
                     measurement.get_non_gpu_metric_value('perf_throughput'),
+                    # FIXME cpu
                     measurement.get_non_gpu_metric_value('cpu_used_ram')
                 ]
                 detailed_table.insert_row_by_index(row)


### PR DESCRIPTION
- If no CPU metrics, do not print "Max CPU Memory Usage" to table for both detailed and summary reports
- If no CPU metrics, do not print "RAM usage vs latency" plot for both detailed and summary reports
- Fixed a bug where "cpu_only" was not put into checkpoint properly, and thus the GPU plots were printed for CPU cases
- Reduce the number of times the CPU warning is printed

I manually compared the resulting reports of all 16 combinations of the following {detailed vs summary}{online vs offline}{model run on cpu vs gpu}{cpu metrics being collected vs not} and confirmed all changes are as expected.



Showing the table and chart no longer being printed when CPU info not gathered:

![412_compare](https://user-images.githubusercontent.com/50968584/168100187-a9b6eb98-6e84-4291-9434-753b70854591.png)


Showing the cpu_only bug fix that now correctly shows CPU information and charts instead of GPU:

![412_bug_fix](https://user-images.githubusercontent.com/50968584/168100208-58be2bfa-aa68-4dc7-b560-2bc29325f262.png)


Before and after of warning changes:

![412-warnings](https://user-images.githubusercontent.com/50968584/168106446-cbfafd15-aea4-4cea-86df-e56a0c2c3a43.JPG)
![412-less-warnings](https://user-images.githubusercontent.com/50968584/168106464-5dc8a92c-5d1e-4cd8-b9aa-7644be0743f8.JPG)

