### PR TITLE
Reduce wall clock time for unit tests - configurable sleep timer

### DIFF
--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -28,7 +28,7 @@ class TritonClient:
     TritonClientFactory
     """
 
-    def wait_for_server_ready(self, num_retries):
+    def wait_for_server_ready(self, num_retries, sleep_time=1):
         """
         Parameters
         ----------
@@ -47,13 +47,13 @@ class TritonClient:
         while retries > 0:
             try:
                 if self._client.is_server_ready():
-                    time.sleep(1)
+                    time.sleep(sleep_time)
                     return
                 else:
-                    time.sleep(1)
+                    time.sleep(sleep_time)
                     retries -= 1
             except Exception as e:
-                time.sleep(1)
+                time.sleep(sleep_time)
                 retries -= 1
                 if retries == 0:
                     raise TritonModelAnalyzerException(e)
@@ -109,7 +109,7 @@ class TritonClient:
             logger.info(f'Model {model_name} unload failed: {e}')
             return -1
 
-    def wait_for_model_ready(self, model_name, num_retries):
+    def wait_for_model_ready(self, model_name, num_retries, sleep_time=1):
         """
         Returns when model is ready.
 
@@ -136,11 +136,11 @@ class TritonClient:
                 if self._client.is_model_ready(model_name):
                     return
                 else:
-                    time.sleep(1)
+                    time.sleep(sleep_time)
                     retries -= 1
             except Exception as e:
                 error = e
-                time.sleep(1)
+                time.sleep(sleep_time)
                 retries -= 1
 
         logger.info(

--- a/tests/test_cpu_monitor.py
+++ b/tests/test_cpu_monitor.py
@@ -50,7 +50,7 @@ class TestCPUMonitor(trc.TestResultCollector):
         ]
 
         frequency = 1
-        monitoring_time = 2
+        monitoring_time = 0.1
         metrics = [CPUAvailableRAM, CPUUsedRAM]
 
         server = TritonServerFactory.create_server_local(
@@ -89,7 +89,7 @@ class TestCPUMonitor(trc.TestResultCollector):
         ]
 
         frequency = 1
-        monitoring_time = 2
+        monitoring_time = 0.1
         metrics = []
 
         server = TritonServerFactory.create_server_local(

--- a/tests/test_dcgm_monitor.py
+++ b/tests/test_dcgm_monitor.py
@@ -57,7 +57,7 @@ class TestDCGMMonitor(trc.TestResultCollector):
     def test_record_memory(self):
         # One measurement every 0.01 seconds
         frequency = 1
-        monitoring_time = 2
+        monitoring_time = 0.1
         metrics = [GPUUsedMemory, GPUFreeMemory]
         dcgm_monitor = DCGMMonitor(self._gpus, frequency, metrics)
         dcgm_monitor.start_recording_metrics()
@@ -89,7 +89,7 @@ class TestDCGMMonitor(trc.TestResultCollector):
     def test_record_power(self):
         # One measurement every 0.01 seconds
         frequency = 1
-        monitoring_time = 2
+        monitoring_time = 1.1
         metrics = [GPUPowerUsage]
         dcgm_monitor = DCGMMonitor(self._gpus, frequency, metrics)
         dcgm_monitor.start_recording_metrics()
@@ -114,7 +114,7 @@ class TestDCGMMonitor(trc.TestResultCollector):
     def test_record_utilization(self):
         # One measurement every 0.01 seconds
         frequency = 1
-        monitoring_time = 2
+        monitoring_time = 1.1
         metrics = [GPUUtilization]
         dcgm_monitor = DCGMMonitor(self._gpus, frequency, metrics)
         dcgm_monitor.start_recording_metrics()

--- a/tests/test_remote_monitor.py
+++ b/tests/test_remote_monitor.py
@@ -80,7 +80,7 @@ class TestRemoteMonitor(trc.TestResultCollector):
     def test_record_memory(self):
         # One measurement every 0.1 seconds
         frequency = 0.1
-        monitoring_time = 1
+        monitoring_time = 0.1
         metrics = [GPUUsedMemory, GPUFreeMemory]
         gpu_monitor = RemoteMonitor(TEST_METRICS_URL, frequency, metrics)
         gpu_monitor.start_recording_metrics()
@@ -115,7 +115,7 @@ class TestRemoteMonitor(trc.TestResultCollector):
     def test_record_power(self):
         # One measurement every 0.01 seconds
         frequency = 0.1
-        monitoring_time = 1
+        monitoring_time = 0.1
         metrics = [GPUPowerUsage]
         gpu_monitor = RemoteMonitor(TEST_METRICS_URL, frequency, metrics)
         gpu_monitor.start_recording_metrics()
@@ -138,7 +138,7 @@ class TestRemoteMonitor(trc.TestResultCollector):
     def test_record_utilization(self):
         # One measurement every 0.01 seconds
         frequency = 0.1
-        monitoring_time = 1
+        monitoring_time = 0.1
         metrics = [GPUUtilization]
         gpu_monitor = RemoteMonitor(TEST_METRICS_URL, frequency, metrics)
         gpu_monitor.start_recording_metrics()

--- a/tests/test_triton_client.py
+++ b/tests/test_triton_client.py
@@ -83,17 +83,17 @@ class TestTritonClientMethods(trc.TestResultCollector):
                                    " wait for server ready"):
                 self.tritonclient_mock.raise_exception_on_wait_for_server_ready(
                 )
-                client.wait_for_server_ready(num_retries=1)
+                client.wait_for_server_ready(num_retries=1, sleep_time=0.1)
             self.tritonclient_mock.reset()
 
             with self.assertRaises(TritonModelAnalyzerException,
                                    msg="Expected Exception on"
                                    " server not ready"):
                 self.tritonclient_mock.set_server_not_ready()
-                client.wait_for_server_ready(num_retries=5)
+                client.wait_for_server_ready(num_retries=1, sleep_time=0.1)
 
             self.tritonclient_mock.reset()
-            client.wait_for_server_ready(num_retries=1)
+            client.wait_for_server_ready(num_retries=1, sleep_time=0.1)
 
         # HTTP client
         client = TritonClientFactory.create_http_client(server_url=HTTP_URL)
@@ -112,16 +112,19 @@ class TestTritonClientMethods(trc.TestResultCollector):
         # For reuse
         def _test_with_client(self, client):
             client.wait_for_model_ready(model_name=TEST_MODEL_NAME,
-                                        num_retries=1)
+                                        num_retries=1,
+                                        sleep_time=0.1)
             self.tritonclient_mock.reset()
 
             self.tritonclient_mock.set_model_not_ready()
             self.assertTrue(
                 client.wait_for_model_ready(model_name=TEST_MODEL_NAME,
-                                            num_retries=2), -1)
+                                            num_retries=2,
+                                            sleep_time=0.1), -1)
             self.tritonclient_mock.reset()
             client.wait_for_model_ready(model_name=TEST_MODEL_NAME,
-                                        num_retries=1)
+                                        num_retries=1,
+                                        sleep_time=0.1)
 
         # HTTP client
         client = TritonClientFactory.create_http_client(server_url=HTTP_URL)
@@ -145,7 +148,7 @@ class TestTritonClientMethods(trc.TestResultCollector):
 
         # Start the server and wait till it is ready
         self.server.start()
-        client.wait_for_server_ready(num_retries=1)
+        client.wait_for_server_ready(num_retries=1, sleep_time=0.1)
 
         # Try to load a dummy model and expect error
         self.tritonclient_mock.raise_exception_on_load()
@@ -155,7 +158,9 @@ class TestTritonClientMethods(trc.TestResultCollector):
 
         # Load the test model
         client.load_model(TEST_MODEL_NAME)
-        client.wait_for_model_ready(TEST_MODEL_NAME, num_retries=1)
+        client.wait_for_model_ready(TEST_MODEL_NAME,
+                                    num_retries=1,
+                                    sleep_time=0.1)
 
         # Try to unload a dummy model and expect error
         self.tritonclient_mock.raise_exception_on_unload()
@@ -175,7 +180,7 @@ class TestTritonClientMethods(trc.TestResultCollector):
 
         # Start the server and wait till it is ready
         self.server.start()
-        client.wait_for_server_ready(num_retries=1)
+        client.wait_for_server_ready(num_retries=1, sleep_time=0.1)
 
         # Set model config, and try to get it
         test_model_config_dict = {'config': 'test_config'}


### PR DESCRIPTION
I've added a configurable sleep time to the wait_for methods, that lowers this from 1 second to 100ms for unit tests. 
I've also reduced the monitoring times where possible. 

The end result is that unit test time drops from 105 to 76 seconds!