### PR TITLE
Fail if server already running

### DIFF
--- a/model_analyzer/device/gpu_device_factory.py
+++ b/model_analyzer/device/gpu_device_factory.py
@@ -47,7 +47,7 @@ class GPUDeviceFactory:
         """
 
         if numba.cuda.is_available():
-            logger.info("Initiliazing GPUDevice handles")
+            logger.info("Initializing GPUDevice handles")
             structs._dcgmInit(dcgmPath)
             dcgm_agent.dcgmInit()
 

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -271,6 +271,7 @@ def get_triton_handles(config, gpus):
     """
 
     client = get_client_handle(config)
+    fail_if_server_already_running(client)
     server = get_server_handle(config, gpus)
 
     return client, server
@@ -343,6 +344,24 @@ def create_output_model_repository(config):
             logger.warning('Overriding the output model repo path '
                            f'"{config.output_model_repository_path}"')
             os.mkdir(config.output_model_repository_path)
+
+
+def fail_if_server_already_running(client):
+    """ 
+    Checks if there is already a Triton server running
+    If so, it will throw an exception
+    If not, nothing will happen
+    """
+    is_server_running = True
+    try:
+        client._client.is_server_ready()
+    except:
+        is_server_running = False
+    finally:
+        if is_server_running:
+            raise TritonModelAnalyzerException(
+                "Detected Triton server already running. Model Analyzer will launch a Triton server for you and requires that a server is not already running."
+            )
 
 
 def main():

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -271,7 +271,7 @@ def get_triton_handles(config, gpus):
     """
 
     client = get_client_handle(config)
-    fail_if_server_already_running(client)
+    fail_if_server_already_running(client, config)
     server = get_server_handle(config, gpus)
 
     return client, server
@@ -346,12 +346,15 @@ def create_output_model_repository(config):
             os.mkdir(config.output_model_repository_path)
 
 
-def fail_if_server_already_running(client):
+def fail_if_server_already_running(client, config):
     """ 
     Checks if there is already a Triton server running
-    If so, it will throw an exception
-    If not, nothing will happen
+    If there is and the launch mode is not 'remote', throw an exception
+    Else, nothing will happen
     """
+    if config.triton_launch_mode == 'remote':
+        return
+
     is_server_running = True
     try:
         client._client.is_server_ready()

--- a/qa/L0_server_launch_modes/check_gpus.py
+++ b/qa/L0_server_launch_modes/check_gpus.py
@@ -36,7 +36,7 @@ def check_gpus(analyzer_log, gpus, check_visible):
         else:
             sys.exit(0)
 
-    token = "Initiliazing GPUDevice handles"
+    token = "Initializing GPUDevice handles"
     gpus_start = log_contents.rfind(token)
     if gpus_start == -1:
         print(


### PR DESCRIPTION
Check and fail if a Triton server is already running (unless launch-mode is remote)

Old:
```
[Model Analyzer] Initiliazing GPUDevice handles
[Model Analyzer] Using GPU 0 NVIDIA TITAN RTX with UUID GPU-aaf4fea0-a814-e92a-6162-5852d329510f
[Model Analyzer] Starting a local Triton Server
[Model Analyzer] No checkpoint file found, starting a fresh run.
[Model Analyzer] Profiling server only metrics...
[Model Analyzer]
[Model Analyzer] Creating model config: add_sub_config_default
[Model Analyzer]
[Model Analyzer] Model add_sub_config_default load failed: [StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled
[Model Analyzer]
[Model Analyzer] Creating model config: add_sub_config_0
[Model Analyzer]   Enabling dynamic_batching
[Model Analyzer]   Setting instance_group to [{'count': 1, 'kind': 'KIND_GPU'}]
[Model Analyzer]   Setting max_batch_size to 1
[Model Analyzer]
[Model Analyzer] Model add_sub_config_0 load failed: [StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled
[Model Analyzer]
[Model Analyzer] Creating model config: add_sub_config_1
[Model Analyzer]   Enabling dynamic_batching
[Model Analyzer]   Setting instance_group to [{'count': 1, 'kind': 'KIND_GPU'}]
[Model Analyzer]   Setting max_batch_size to 2
[Model Analyzer]
[Model Analyzer] Model add_sub_config_1 load failed: [StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled
[Model Analyzer] No longer increasing max_batch_size because throughput has plateaued
...
[Model Analyzer] Model add_sub_config_9 load failed: [StatusCode.UNAVAILABLE] explicit model load / unload is not allowed if polling is enabled
[Model Analyzer] No longer increasing max_batch_size because throughput has plateaued
[Model Analyzer] Saved checkpoint to /opt/triton-model-analyzer/results/checkpoints/0.ckpt
[Model Analyzer] Profile complete. Profiled 0 configurations for models: []
[Model Analyzer]
[Model Analyzer] To analyze the profile results and find the best configurations, run `model-analyzer analyze --analysis-models `

```


New:
```
[Model Analyzer] Initializing GPUDevice handles
[Model Analyzer] Using GPU 0 NVIDIA TITAN RTX with UUID GPU-aaf4fea0-a814-e92a-6162-5852d329510f
Traceback (most recent call last):
  File "/usr/local/bin/model-analyzer", line 8, in <module>
    sys.exit(main())
  File "/ma/model_analyzer/entrypoint.py", line 393, in main
    client, server = get_triton_handles(config, gpus)
  File "/ma/model_analyzer/entrypoint.py", line 276, in get_triton_handles
    fail_if_server_already_running(client)
  File "/ma/model_analyzer/entrypoint.py", line 363, in fail_if_server_already_running
    raise TritonModelAnalyzerException("Detected Triton server already running. Model Analyzer will launch a Triton server for you and requires that a server is not already running.")
model_analyzer.model_analyzer_exceptions.TritonModelAnalyzerException: Detected Triton server already running. Model Analyzer will launch a Triton server for you and requires that a server is not already running.
```