### PR TITLE
Recommend SDK in install and quick start

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,89 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Installation
+# Recommended Installation Method
 
-There are 4 ways to use Triton Model Analyzer:
+<br>
 
-## Building the Dockerfile
+## Triton SDK Container with Docker Launch Mode
 
-The recommended way to use Model Analyzer is by building the Model Analyzer's
-docker yourself. This installation method uses `--triton-launch-mode=local` by
-default, as all the dependencies will be available. First, clone the Model
-Analyzer's git repository, then build the docker image.
+---
 
-```
-$ git clone https://github.com/triton-inference-server/model_analyzer.git -b <rXX.YY>
-
-$ cd ./model_analyzer
-
-$ docker build --pull -t model-analyzer .
-```
-
-The above command will pull all the containers that Model Analyzer needs to run.
-The Model Analyzer's Dockerfile bases the container on the latest `tritonserver`
-containers from NGC. Now you can run the container with:
-
-```
-$ docker run -it --rm --gpus all \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      -v <path-to-triton-model-repository>:<path-to-triton-model-repository> \
-      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
-      --net=host model-analyzer
-
-root@hostname:/opt/triton-model-analyzer# 
-```
-
-If you want to build Model Analyzer on the `main` branch, you need to also build the Triton
-SDK container. To build the SDK container you can refer to the
-[Build SDK Image](https://github.com/triton-inference-server/server/blob/main/docs/test.md#build-sdk-image)
-instructions. After you have built the SDK container, you can build the Model
-Analyzer's Docker image with:
-
-```
-$ git clone https://github.com/triton-inference-server/model_analyzer.git -b main
-
-$ cd ./model_analyzer
-
-$ docker build -t model-analyzer --build-arg TRITONSDK_BASE_IMAGE=<name of the built SDK image> .
-```
-
-## Triton SDK Container
-
-You can also use the Triton SDK docker
+The recommended way to install Model Analyzer is from the Triton SDK docker
 container available on the [NVIDIA GPU Cloud
-Catalog](https://ngc.nvidia.com/catalog/containers/nvidia:tritonserver). You can
-pull and run the SDK container with the following commands:
+Catalog](https://ngc.nvidia.com/catalog/containers/nvidia:tritonserver).<br><br>
+**1. Pull the SDK container:**
 
 ```
 $ docker pull nvcr.io/nvidia/tritonserver:22.05-py3-sdk
 ```
 
-If you are not planning to run Model Analyzer with
-`--triton-launch-mode=docker`, You can run the SDK container with the following
-command: 
-
-```
-$ docker run -it --gpus all --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
-```
-
-You will need to build and install the Triton server binary inside the SDK
-container if you want to use the local mode. See the Triton [Installation
-docs](https://github.com/triton-inference-server/server/blob/main/docs/build.md)
-for more details. 
-
-If you intend to use `--triton-launch-mode=docker`, which is recommended with 
-this method of using Model Analyzer when using the SDK container,
-you will need to mount the following: 
-   * `-v /var/run/docker.sock:/var/run/docker.sock` allows running docker
-      containers as sibling containers from inside the Triton SDK container.
-      Model Analyzer will require this if run  with
-      `--triton-launch-mode=docker`.
-   * `-v <path-to-output-model-repo>:<path-to-output-model-repo>` The
-      ***absolute*** path to the directory where the output model repository
-      will be located (i.e. parent directory of the output model repository).
-      This is so that the launched Triton container has access to the model
-      config variants that Model Analyzer creates.
+**2. Run the SDK container**
 
 ```
 $ docker run -it --gpus all \
@@ -105,24 +40,132 @@ $ docker run -it --gpus all \
       --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
 ```
 
-Model Analyzer uses `pdfkit` for report generation. If you are running Model
-Analyzer inside the Triton SDK container, then you will need to download
-`wkhtmltopdf`.
+**Replacing** `<path-to-output-model-repo>` with the
+**_absolute_ _path_** to the directory where the output model repository
+will be located.
+This ensures the Triton SDK container has access to the model
+config variants that Model Analyzer creates.  
+fasdfa
+dfdasfasdfasdf
+
+**3. Add PDF support to the container**  
+Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
+`wkhtmltopdf`:
 
 ```
-$ sudo apt-get update && sudo apt-get install wkhtmltopdf
+$ apt-get update && apt-get install wkhtmltopdf
 ```
 
-Once you do this, Model Analyzer will able to use `pdfkit` to generate reports.
+**4. Run Model Analyzer with Docker Launch Mode**  
+Be sure to use `--triton-launch-mode=docker`, when running Model Analyzer.<br><br>
 
-## Using `pip3`
+# Alternative Installation Methods
+
+- [Specific Version with Local Launch Mode](##Specific-Version-with-Local-Launch-Mode)
+- [Main with Local Launch Mode](##Main-with-Local-Launch-Mode)
+- [Using Pip](##Using-Pip)
+- [From the Source](##From-the-Source)
+
+<br>
+
+## Specific Version with Local Launch Mode
+
+---
+
+This method allows you build a specific version of Model Analyzer's
+docker.  
+This installation method uses `--triton-launch-mode=local` by
+default, as all the dependencies will be available.<br><br>
+
+**1. Clone Model Analyzer's Git Repository**
+
+```
+$ git clone https://github.com/triton-inference-server/model_analyzer.git -b <rXX.YY>
+```
+
+**Replacing** `<rXX.YY>` with the version of Model Analyzer you want to install<br><br>
+
+**2. Build the Docker Image**
+
+```
+$ cd ./model_analyzer
+
+$ docker build --pull -t model-analyzer .
+```
+
+Model Analyzer's Dockerfile bases the container on the latest `tritonserver`
+containers from NGC.<br><br>
+
+**3. Run the Container**
+
+```
+$ docker run -it --rm --gpus all \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
+      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+      --net=host model-analyzer
+```
+
+**Replacing** `<path-to-triton-model-repo>` with the
+**_absolute_ _path_** to the directory where the `Triton` model repository
+will be located.  
+**Replacing** `<path-to-output-model-repo>` with the
+**_absolute_ _path_** to the directory where the `output` model repository
+will be located.<br><br>
+
+## Main with Local Launch Mode
+
+---
+
+This method allows you build the `main` branch of Model Analyzer.  
+This installation method uses `--triton-launch-mode=local` by
+default, as all the dependencies will be available.<br><br>
+
+**1. Build Triton SDK Container**  
+Follow the instructions found at
+[Build SDK Image](https://github.com/triton-inference-server/server/blob/main/docs/test.md#build-sdk-image)<br><br>
+
+**2. Build Model Analyzer's Main Docker Image**
+
+```
+$ git clone https://github.com/triton-inference-server/model_analyzer.git -b main
+
+$ cd ./model_analyzer
+
+$ docker build -t model-analyzer --build-arg TRITONSDK_BASE_IMAGE=<built-sdk-image> .
+```
+
+**Replacing** `<built-sdk-image>` with the **_absolute_ _path_** to the directory where the Triton SDK image is located<br><br>
+
+**3. Run the Container**
+
+```
+$ docker run -it --rm --gpus all \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
+      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+      --net=host model-analyzer
+```
+
+**Replacing** `<path-to-triton-model-repo>` with the
+**_absolute_ _path_** to the directory where the `Triton` model repository
+will be located.  
+**Replacing** `<path-to-output-model-repo>` with the
+**_absolute_ _path_** to the directory where the `output` model repository
+will be located.<br><br>
+
+## Pip3
+
+---
 
 You can install pip using:
+
 ```
 $ sudo apt-get update && sudo apt-get install python3-pip
 ```
 
-Model analyzer can be installed with: 
+Model analyzer can be installed with:
+
 ```
 $ pip3 install triton-model-analyzer
 ```
@@ -139,17 +182,22 @@ You can then try installing model analyzer again.
 If you are using this approach you need to install DCGM on your machine.
 
 For installing DCGM on Ubuntu 20.04 you can use the following commands:
+
 ```
 $ export DCGM_VERSION=2.0.13
 $ wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
    dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
 ```
 
-## Building from source
+<br>
 
-To build model analyzer form source, you'll need to install the same
-dependencies (tritonclient and DCGM) mentioned in the "Using pip section". After
-that, you can use the following commands:
+## From the Source
+
+---
+
+To build model analyzer from the source. You'll need to install the same
+dependencies (tritonclient and DCGM) mentioned in [Using Pip](##Using-Pip).<br>
+After that, you can use the following commands:
 
 ```
 $ git clone https://github.com/triton-inference-server/model_analyzer
@@ -173,8 +221,8 @@ $ pip3 install wheels/triton-model-analyzer-*.whl
 After these steps, `model-analyzer` executable should be available in `$PATH`.
 
 **Notes:**
-* Triton Model Analyzer supports all the GPUs supported by the DCGM library. See
+
+- Triton Model Analyzer supports all the GPUs supported by the DCGM library. See
   [DCGM Supported
   GPUs](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-user-guide/getting-started.html#supported-platforms)
   for more information.
-

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,32 +28,31 @@ Catalog](https://ngc.nvidia.com/catalog/containers/nvidia:tritonserver).<br><br>
 **1. Pull the SDK container:**
 
 ```
-$ docker pull nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+docker pull nvcr.io/nvidia/tritonserver:22.05-py3-sdk
 ```
 
 **2. Run the SDK container**
 
 ```
-$ docker run -it --gpus all \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
-      --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+docker run -it --gpus all \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+    --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
 ```
 
 **Replacing** `<path-to-output-model-repo>` with the
 **_absolute_ _path_** to the directory where the output model repository
 will be located.
 This ensures the Triton SDK container has access to the model
-config variants that Model Analyzer creates.  
-fasdfa
-dfdasfasdfasdf
+config variants that Model Analyzer creates.<br><br>
+**Important:** You must ensure the `<path-to-output-model-repo>` is identical on both sides of the mount<br><br>
 
 **3. Add PDF support to the container**  
 Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
 `wkhtmltopdf`:
 
 ```
-$ apt-get update && apt-get install wkhtmltopdf
+apt-get update && apt-get install wkhtmltopdf
 ```
 
 **4. Run Model Analyzer with Docker Launch Mode**  
@@ -80,7 +79,7 @@ default, as all the dependencies will be available.<br><br>
 **1. Clone Model Analyzer's Git Repository**
 
 ```
-$ git clone https://github.com/triton-inference-server/model_analyzer.git -b <rXX.YY>
+git clone https://github.com/triton-inference-server/model_analyzer.git -b <rXX.YY>
 ```
 
 **Replacing** `<rXX.YY>` with the version of Model Analyzer you want to install<br><br>
@@ -88,9 +87,9 @@ $ git clone https://github.com/triton-inference-server/model_analyzer.git -b <rX
 **2. Build the Docker Image**
 
 ```
-$ cd ./model_analyzer
+cd ./model_analyzer
 
-$ docker build --pull -t model-analyzer .
+docker build --pull -t model-analyzer .
 ```
 
 Model Analyzer's Dockerfile bases the container on the latest `tritonserver`
@@ -99,11 +98,11 @@ containers from NGC.<br><br>
 **3. Run the Container**
 
 ```
-$ docker run -it --rm --gpus all \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
-      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
-      --net=host model-analyzer
+docker run -it --rm --gpus all \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
+    -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+    --net=host model-analyzer
 ```
 
 **Replacing** `<path-to-triton-model-repo>` with the
@@ -128,11 +127,11 @@ Follow the instructions found at
 **2. Build Model Analyzer's Main Docker Image**
 
 ```
-$ git clone https://github.com/triton-inference-server/model_analyzer.git -b main
+git clone https://github.com/triton-inference-server/model_analyzer.git -b main
 
-$ cd ./model_analyzer
+cd ./model_analyzer
 
-$ docker build -t model-analyzer --build-arg TRITONSDK_BASE_IMAGE=<built-sdk-image> .
+docker build -t model-analyzer --build-arg TRITONSDK_BASE_IMAGE=<built-sdk-image> .
 ```
 
 **Replacing** `<built-sdk-image>` with the **_absolute_ _path_** to the directory where the Triton SDK image is located<br><br>
@@ -140,11 +139,11 @@ $ docker build -t model-analyzer --build-arg TRITONSDK_BASE_IMAGE=<built-sdk-ima
 **3. Run the Container**
 
 ```
-$ docker run -it --rm --gpus all \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
-      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
-      --net=host model-analyzer
+docker run -it --rm --gpus all \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v <path-to-triton-model-repo>:<path-to-triton-model-repo> \
+    -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+    --net=host model-analyzer
 ```
 
 **Replacing** `<path-to-triton-model-repo>` with the
@@ -161,20 +160,20 @@ will be located.<br><br>
 You can install pip using:
 
 ```
-$ sudo apt-get update && sudo apt-get install python3-pip
+sudo apt-get update && sudo apt-get install python3-pip
 ```
 
 Model analyzer can be installed with:
 
 ```
-$ pip3 install triton-model-analyzer
+pip3 install triton-model-analyzer
 ```
 
 If you encounter any errors installing dependencies like `numba`, make sure that
 you have the latest version of `pip` using:
 
 ```
-$ pip3 install --upgrade pip
+pip3 install --upgrade pip
 ```
 
 You can then try installing model analyzer again.
@@ -184,9 +183,9 @@ If you are using this approach you need to install DCGM on your machine.
 For installing DCGM on Ubuntu 20.04 you can use the following commands:
 
 ```
-$ export DCGM_VERSION=2.0.13
-$ wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
-   dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
+export DCGM_VERSION=2.0.13
+wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
+ dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
 ```
 
 <br>
@@ -200,9 +199,9 @@ dependencies (tritonclient and DCGM) mentioned in [Using Pip](##Using-Pip).<br>
 After that, you can use the following commands:
 
 ```
-$ git clone https://github.com/triton-inference-server/model_analyzer
-$ cd model_analyzer
-$ ./build_wheel.sh <path to perf_analyzer> true
+git clone https://github.com/triton-inference-server/model_analyzer
+cd model_analyzer
+./build_wheel.sh <path to perf_analyzer> true
 ```
 
 In the final command above we are building the triton-model-analyzer wheel. You
@@ -215,7 +214,7 @@ This will create a wheel file in the `wheels` directory named
 install this with:
 
 ```
-$ pip3 install wheels/triton-model-analyzer-*.whl
+pip3 install wheels/triton-model-analyzer-*.whl
 ```
 
 After these steps, `model-analyzer` executable should be available in `$PATH`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,19 +25,29 @@ limitations under the License.
 The recommended way to install Model Analyzer is from the Triton SDK docker
 container available on the [NVIDIA GPU Cloud
 Catalog](https://ngc.nvidia.com/catalog/containers/nvidia:tritonserver).<br><br>
-**1. Pull the SDK container:**
+
+**1. Choose a release version**  
+The format is `<rYY.MM>` where, `YY`=year and `MM`=month
+
+For example, the release from May of 2022 is `<r22.05>`
 
 ```
-docker pull nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+export RELEASE=<rYY:MM>
 ```
 
-**2. Run the SDK container**
+**2. Pull the SDK container**
+
+```
+docker pull nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
+```
+
+**3. Run the SDK container**
 
 ```
 docker run -it --gpus all \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v <path-to-output-model-repo>:<path-to-output-model-repo> \
-    --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+    --net=host nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 ```
 
 **Replacing** `<path-to-output-model-repo>` with the
@@ -47,7 +57,7 @@ This ensures the Triton SDK container has access to the model
 config variants that Model Analyzer creates.<br><br>
 **Important:** You must ensure the `<path-to-output-model-repo>` is identical on both sides of the mount<br><br>
 
-**3. Add PDF support to the container**  
+**4. Add PDF support to the container**  
 Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
 `wkhtmltopdf`:
 
@@ -55,7 +65,7 @@ Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK c
 apt-get update && apt-get install wkhtmltopdf
 ```
 
-**4. Run Model Analyzer with Docker Launch Mode**  
+**5. Run Model Analyzer with Docker Launch Mode**  
 Be sure to use `--triton-launch-mode=docker`, when running Model Analyzer.<br><br>
 
 # Alternative Installation Methods
@@ -79,10 +89,11 @@ default, as all the dependencies will be available.<br><br>
 **1. Clone Model Analyzer's Git Repository**
 
 ```
-git clone https://github.com/triton-inference-server/model_analyzer.git -b <rXX.YY>
+git clone https://github.com/triton-inference-server/model_analyzer.git -b <rYY.MM>
 ```
 
-**Replacing** `<rXX.YY>` with the version of Model Analyzer you want to install<br><br>
+**Replacing** `<rYY.MM>` with the version of Model Analyzer you want to install.  
+For example, `r22.05` is the release for May of 2022<br><br>
 
 **2. Build the Docker Image**
 
@@ -112,15 +123,15 @@ will be located.
 **_absolute_ _path_** to the directory where the `output` model repository
 will be located.<br><br>
 
-## Main with Local Launch Mode
+## Main Branch with Local Launch Mode
 
 ---
 
-This method allows you build the `main` branch of Model Analyzer.  
+This method allows you build a docker container using the `main` branch of Model Analyzer.  
 This installation method uses `--triton-launch-mode=local` by
 default, as all the dependencies will be available.<br><br>
 
-**1. Build Triton SDK Container**  
+**1. Build Triton SDK Container from Main**  
 Follow the instructions found at
 [Build SDK Image](https://github.com/triton-inference-server/server/blob/main/docs/test.md#build-sdk-image)<br><br>
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 The steps below will guide you through using model analyzer to analyze a simple PyTorch model: add_sub.
 
-## Download the add_sub model
+## `Step 1:` Download the add_sub model
 
 ---
 
@@ -42,7 +42,7 @@ echo 'examples' >> .git/info/sparse-checkout && \
 git pull origin main
 ```
 
-## Build and Run Model Analyzer Container
+## `Step 2:` Build and Run Model Analyzer Container
 
 ---
 
@@ -77,7 +77,9 @@ Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK c
 apt-get update && apt-get install wkhtmltopdf
 ```
 
-## Step 2: Profile the `add_sub` model
+## `Step 3:` Profile the `add_sub` model
+
+---
 
 The [examples/quick-start](../examples/quick-start) directory contains a simple
 libtorch model which calculates the sum and difference of two inputs. Run the
@@ -117,7 +119,9 @@ configuration:
 
 With these options, model analyzer will test 5 configs (4 new configs as well as the unmodified default add_sub config), and each config will have 2 experiments run on Perf Analyzer (concurrency=1 and concurrency=2). This significantly reduces the search space, and therefore, model analyzer's runtime.
 
-## Step 3: Generate Tables and Summary Reports
+## `Step 4:` Generate Tables and Summary Reports
+
+---
 
 In order to generate tables and summary reports, use the `analyze` subcommand as
 follows.
@@ -156,7 +160,9 @@ $HOME
                               .                |--- result_summary.pdf
 ```
 
-## Step 4: Generate a Detailed Report
+## `Step 5:` Generate a Detailed Report
+
+---
 
 Model analyzer's report subcommand allows you to examine the performance of a
 model config variant in detail. For example, it can show you the latency

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -178,7 +178,7 @@ $ model-analyzer report --report-model-configs add_sub_config_default,add_sub_co
 ```
 
 This will create directories named after each of the model configs under
-`.analysis_results/reports/detailed` containing the detailed report PDF files as
+`./analysis_results/reports/detailed` containing the detailed report PDF files as
 shown below.
 
 ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -16,25 +16,65 @@ limitations under the License.
 
 # Quick Start
 
-The steps below will guide you through using model analyzer to analyze a simple PyTorch model.
+The steps below will guide you through using model analyzer to analyze a simple PyTorch model: add_sub.
 
-## Step 1: Build and Run Model Analyzer Container
+## Download the add_sub model
 
-1. Clone the repository and build the docker:
+---
+
+**1. Create a new directory and enter it**
+
 ```
-$ git clone https://github.com/triton-inference-server/model_analyzer.git -b r22.05
-
-$ cd ./model_analyzer
-
-$ docker build --pull -t model-analyzer .
+mkdir <new_dir> && cd <new_dir>
 ```
 
-2. Run the docker:
+**2. Start a git repository**
+
 ```
-$ docker run -it --rm --gpus all \
-    -v $(pwd)/examples/quick-start:/quick_start_repository \
-    --net=host --name model-analyzer \
-    model-analyzer /bin/bash
+git init && git remote add -f https://github.com/triton-inference-server/model_analyzer.git
+```
+
+**3. Enable sparse checkout, and download the examples directory, which contains the add_sub model**
+
+```
+git config core.sparseCheckout true && \
+echo 'examples' >> .git/info/sparse-checkout && \
+git pull origin main
+```
+
+## Build and Run Model Analyzer Container
+
+---
+
+**1. Pull the SDK container:**
+
+```
+docker pull nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+```
+
+**2. Run the SDK container**
+
+```
+docker run -it --gpus all \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v $(pwd)/examples/quick-start:$(pwd)/examples/quick-start \
+      -v <path-to-output-model-repo>:<path-to-output-model-repo> \
+      --net=host nvcr.io/nvidia/tritonserver:22.05-py3-sdk
+```
+
+**Replacing** `<path-to-output-model-repo>` with the
+**_absolute_ _path_** to the directory where the output model repository
+will be located.
+This ensures the Triton SDK container has access to the model
+config variants that Model Analyzer creates.<br><br>
+**Important:** You must ensure the absolutes paths are identical on both sides of the mounts<br><br>
+
+**3. Add PDF support to the container**  
+Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
+`wkhtmltopdf`:
+
+```
+apt-get update && apt-get install wkhtmltopdf
 ```
 
 ## Step 2: Profile the `add_sub` model
@@ -44,10 +84,15 @@ libtorch model which calculates the sum and difference of two inputs. Run the
 Model Analyzer `profile` subcommand inside the container with:
 
 ```
-$ model-analyzer profile --model-repository /quick_start_repository --profile-models add_sub
+model-analyzer profile --model-repository <path-to-examples-quick-start> --profile-models add_sub --triton-launch-mode=docker --output-model-repository-path <path-to-output-model-repo>/<output_dir>
 ```
 
-If you already ran this earlier in the container, you can use the `--override-output-model-repository` option to overwrite the earlier results.
+**Important:** You must specify an `<output_dir>` subdirectory. You cannot have `--output-model-repository-path` point directly to `<path-to-output-model-repo>`
+
+**Important:** If you already ran this earlier in the container, you can use the `--override-output-model-repository` option to overwrite the earlier results.
+
+**Important:** The checkpoint directory should be removed between consecutive runs of
+the `model-analyzer profile` command.<br><br>
 
 This will perform a search across limited configurable model parameters on the
 `add_sub` model. This can take up to 60 minutes to finish. If you want a shorter
@@ -61,14 +106,16 @@ configuration:
 --run-config-search-max-instance-count 2
 ```
 
-`--run-config-search-max-concurrency` sets the max concurrency value that run
-config search will not go beyond. `--run-config-search-max-model-batch-size` sets the highest max_batch_size that run config search will not go beyond.  `--run-config-search-max-instance-count`
-sets the max instance count value that run config search will not go beyond. With these options, model analyzer will test 5 configs (4 new configs as well as the unmodified default add_sub config), and each config will have 2 experiments run on Perf Analyzer (concurrency=1 and concurrency=2). This significantly reduces the search space, and therefore, model analyzer's runtime.
+- `--run-config-search-max-concurrency` sets the max concurrency value that run
+  config search will not go beyond. <br>
+- `--run-config-search-max-model-batch-size` sets the highest max_batch_size that run config search will not go beyond.
+- `--run-config-search-max-instance-count`
+  sets the max instance count value that run config search will not go beyond.<br><br>
 
-**Note**: The checkpoint directory should be removed between consecutive runs of
-the `model-analyzer profile` command.
+With these options, model analyzer will test 5 configs (4 new configs as well as the unmodified default add_sub config), and each config will have 2 experiments run on Perf Analyzer (concurrency=1 and concurrency=2). This significantly reduces the search space, and therefore, model analyzer's runtime.
 
-## Generate tables and summary reports
+## Step 3: Generate Tables and Summary Reports
+
 In order to generate tables and summary reports, use the `analyze` subcommand as
 follows.
 
@@ -94,30 +141,31 @@ $HOME
                       |             |--- add_sub
                       |                     |--- gpu_mem_v_latency.png
                       |                     |--- throughput_v_latency.png
-                      | 
+                      |
                       |--- results
-                      |       |--- metrics-model-inference.csv 
-                      |       |--- metrics-model-gpu.csv 
+                      |       |--- metrics-model-inference.csv
+                      |       |--- metrics-model-gpu.csv
                       |       |--- metrics-server-only.csv
                       |
                       |--- reports
-                              |--- summaries 
+                              |--- summaries
                               .        |--- add_sub
                               .                |--- result_summary.pdf
 ```
 
-## Generate a detailed report
+## Step 4: Generate a Detailed Report
 
 Model analyzer's report subcommand allows you to examine the performance of a
 model config variant in detail. For example, it can show you the latency
 breakdown of your model to help you identify potential bottlenecks in your model
-performance. The detailed reports also contain other configurable plots and a
+performance.<br><br>
+The detailed reports also contain other configurable plots and a
 table of measurements taken of that particular config. You can generate a
 detailed report for the two `add_sub` model configs `add_sub_config_default` and
 `add_sub_config_0` using:
 
 ```
-$ model-analyzer report --report-model-configs add_sub_config_default,add_sub_config_0 -e analysis_results 
+$ model-analyzer report --report-model-configs add_sub_config_default,add_sub_config_0 -e analysis_results
 ```
 
 This will create directories named after each of the model configs under

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -84,7 +84,10 @@ libtorch model which calculates the sum and difference of two inputs. Run the
 Model Analyzer `profile` subcommand inside the container with:
 
 ```
-model-analyzer profile --model-repository <path-to-examples-quick-start> --profile-models add_sub --triton-launch-mode=docker --output-model-repository-path <path-to-output-model-repo>/<output_dir>
+model-analyzer profile \
+    --model-repository <path-to-examples-quick-start> \
+    --profile-models add_sub --triton-launch-mode=docker \
+    --output-model-repository-path <path-to-output-model-repo>/<output_dir>
 ```
 
 **Important:** You must specify an `<output_dir>` subdirectory. You cannot have `--output-model-repository-path` point directly to `<path-to-output-model-repo>`


### PR DESCRIPTION
Updated the install document to recommend the Triton SDK with docker launch mode
Updated the quick start document to use Triton SDK with docker launch mode