### PR TITLE
Expose experiment knobs

### DIFF
--- a/experiments/config_command_experiment.py
+++ b/experiments/config_command_experiment.py
@@ -1,0 +1,33 @@
+from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from model_analyzer.config.input.config_field import ConfigField
+from model_analyzer.config.input.config_primitive import ConfigPrimitive
+
+
+class ConfigCommandExperiment(ConfigCommandProfile):
+    """ 
+    Extended ConfigCommandProfile with extra options for experiment algorithm configuration
+    """
+
+    def _fill_config(self):
+        super()._fill_config()
+        self._add_config(
+            ConfigField('radius',
+                        field_type=ConfigPrimitive(int),
+                        flags=['--radius'],
+                        default_value=2,
+                        description='The size of the neighborhood radius'))
+        self._add_config(
+            ConfigField('magnitude',
+                        field_type=ConfigPrimitive(int),
+                        flags=['--magnitude'],
+                        default_value=2,
+                        description='The size of each step'))
+        self._add_config(
+            ConfigField(
+                'min_initialized',
+                field_type=ConfigPrimitive(int),
+                flags=['--min-initialized'],
+                default_value=2,
+                description=
+                'The minimum number of datapoints needed in a neighborhood before stepping'
+            ))

--- a/experiments/evaluate_config_generator.py
+++ b/experiments/evaluate_config_generator.py
@@ -25,10 +25,10 @@ class EvaluateConfigGenerator:
     existing checkpoint of raw measurement data
     """
 
-    def __init__(self, model_name, data_path):
+    def __init__(self, model_name, data_path, other_args):
         self._model_name = model_name
         self._config_command = ExperimentConfigCommandCreator.make_config(
-            data_path, model_name)
+            data_path, model_name, other_args)
 
         self._checkpoint_data = CheckpointExperimentData(self._config_command)
         self._profile_data = ExperimentData()

--- a/experiments/experiment_config_command_creator.py
+++ b/experiments/experiment_config_command_creator.py
@@ -16,7 +16,7 @@ from tests.common.test_utils import convert_to_bytes
 from tests.mocks.mock_config import MockConfig
 from tests.mocks.mock_model_config import MockModelConfig
 from model_analyzer.cli.cli import CLI
-from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from config_command_experiment import ConfigCommandExperiment
 
 
 class ExperimentConfigCommandCreator:
@@ -25,7 +25,7 @@ class ExperimentConfigCommandCreator:
     """
 
     @staticmethod
-    def make_config(data_path, model_name):
+    def make_config(data_path, model_name, other_args):
         mock_model_config = MockModelConfig("")
         mock_model_config.start()
 
@@ -39,20 +39,13 @@ class ExperimentConfigCommandCreator:
             '--checkpoint-directory', checkpoint_dir,
             '-f', 'path-to-config-file'
         ]
+        args += other_args
 
         yaml_content = convert_to_bytes("")
 
-        # TODO: Add a way to overload yaml data here
-        #yaml_content = convert_to_bytes("""
-        #    run_config_search_max_concurrency: 2
-        #    run_config_search_max_instance_count: 2
-        #    run_config_search_max_model_batch_size: 2
-        #    """)
-        #yapf: enable
-
         mock_config = MockConfig(args, yaml_content)
         mock_config.start()
-        config = ConfigCommandProfile()
+        config = ConfigCommandExperiment()
         cli = CLI()
         cli.add_subcommand(
             cmd='profile',

--- a/experiments/generator_experiment_factory.py
+++ b/experiments/generator_experiment_factory.py
@@ -24,10 +24,17 @@ class GeneratorExperimentFactory:
     @staticmethod
     def create_generator(generator_name, config_command):
         """ 
-        Given a generator name, create and return it
-
+        Create and return a RunConfig generator of the requested name
+        
         As a side-effect, some patching may occur to allow the generator
-        to run in an offline scenario.
+        to run offline (without Perf Analyzer)
+
+        Parameters
+        ----------
+        generator_name : string
+            Name of the generator class to create
+        config_command : ConfigCommandExperiment
+            The config for model analyzer algorithm experiment
         """
 
         if generator_name == "RunConfigGenerator":
@@ -51,9 +58,9 @@ class GeneratorExperimentFactory:
                     SearchDimension("concurrency",
                                     SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
                 ],
-                radius=2,
-                step_magnitude=2,
-                min_initialized=3
+                radius=config_command.radius,
+                step_magnitude=config_command.magnitude,
+                min_initialized=config_command.min_initialized
             )
             #yapf: enable
             generator = UndirectedRunConfigGenerator(

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -16,8 +16,8 @@
 #
 # Example usage:
 #
-# python3 main.py --model-name resnet50_libtorch --generator RunConfigGenerator
-#
+# python3 main.py --model-name resnet50_libtorch --generator RunConfigGenerator --run-config-search-max-model-batch-size 2
+# python3 main.py --model-name resnet50_libtorch --generator UndirectedRunConfigGenerator --magnitude 5
 #####################
 
 from evaluate_config_generator import EvaluateConfigGenerator
@@ -43,7 +43,7 @@ parser.add_argument("--generator",
                     type=str,
                     required=True,
                     help="The name of the config generator to evaluate")
-args = parser.parse_args()
+args, other_args = parser.parse_known_args()
 
 if args.verbose:
     import logging
@@ -51,6 +51,6 @@ if args.verbose:
     logger.setLevel(level=logging.DEBUG)
     logging.basicConfig(format="[Model Analyzer] %(message)s")
 
-ecg = EvaluateConfigGenerator(args.model_name, args.data_path)
+ecg = EvaluateConfigGenerator(args.model_name, args.data_path, other_args)
 ecg.execute_generator(args.generator)
 ecg.print_results()


### PR DESCRIPTION
Added ability to set algorithm-specific knobs on the experiments command line.

For example, standard profile option of max model batch size can be specified:
`python3 main.py --model-name resnet50_libtorch --generator RunConfigGenerator --run-config-search-max-model-batch-size 2`

Also, new options for Undirected algorithm can be set:
`python3 main.py --model-name resnet50_libtorch --generator UndirectedRunConfigGenerator --magnitude 5`