### PR TITLE
Fix bug and add testing for setting metrics-interval-ms

### DIFF
--- a/model_analyzer/triton/server/server_config.py
+++ b/model_analyzer/triton/server/server_config.py
@@ -51,6 +51,7 @@ class TritonServerConfig:
         'grpc-root-cert',
         'allow-metrics',
         'allow-gpu-metrics',
+        'metrics-interval-ms',
         'metrics-port',
         # Tracing
         'trace-file',

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from model_analyzer.device.gpu_device_factory import GPUDeviceFactory
-
 from .server_docker import TritonServerDocker
 from .server_local import TritonServerLocal
 from .server_config import TritonServerConfig
 
+from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 from model_analyzer.config.input.config_utils import binary_path_validator
 
 from model_analyzer.constants import CONFIG_PARSER_FAILURE, LOGGER_NAME
@@ -181,7 +180,7 @@ class TritonServerFactory:
         triton_config['grpc-port'] = config.triton_grpc_endpoint.split(':')[-1]
         triton_config['metrics-port'] = urlparse(config.triton_metrics_url).port
         triton_config['model-control-mode'] = 'explicit'
-        if config.use_local_gpu_monitor:
+        if not config.use_local_gpu_monitor:
             triton_config['metrics-interval-ms'] = int(
                 config.monitoring_interval * 1e3)
         logger.info('Starting a local Triton Server')
@@ -212,7 +211,7 @@ class TritonServerFactory:
         triton_config['grpc-port'] = config.triton_grpc_endpoint.split(':')[-1]
         triton_config['metrics-port'] = urlparse(config.triton_metrics_url).port
         triton_config['model-control-mode'] = 'explicit'
-        if config.use_local_gpu_monitor:
+        if not config.use_local_gpu_monitor:
             triton_config['metrics-interval-ms'] = int(
                 config.monitoring_interval * 1e3)
         logger.info('Starting a Triton Server using docker')

--- a/tests/test_triton_server_factory.py
+++ b/tests/test_triton_server_factory.py
@@ -55,14 +55,15 @@ class TestTritonServerFactory(trc.TestResultCollector):
 
         config = ConfigCommandProfile()
         config.triton_launch_mode = launch_mode
-        config.triton_http_endpoint = "1:2"
-        config.triton_grpc_endpoint = "3:4"
+        config.triton_http_endpoint = "fake_address:2345"
+        config.triton_grpc_endpoint = "fake_address:4567"
         config.monitoring_interval = 0.5
         config.use_local_gpu_monitor = use_dcgm
 
-        expected_http_port = '2'
-        expected_grpc_port = '4'
-        expected_metrics_interval_ms = 500
+        expected_http_port = '2345'
+        expected_grpc_port = '4567'
+        # Convert seconds to ms
+        expected_metrics_interval_ms = config.monitoring_interval * 1000
 
         with patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_local') as mocked_local, \
              patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_docker') as mocked_docker, \

--- a/tests/test_triton_server_factory.py
+++ b/tests/test_triton_server_factory.py
@@ -32,57 +32,27 @@ class TestTritonServerFactory(trc.TestResultCollector):
             mock_paths=['model_analyzer.triton.server.server_factory'])
         self.mock_os.start()
 
-    def test_get_server_handle_remote(self):
-        self._test_get_server_handle_helper(launch_mode="remote",
-                                            use_dcgm=False,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=False)
-        self._test_get_server_handle_helper(launch_mode="remote",
-                                            use_dcgm=True,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=False)
+    def _test_get_server_handle_helper(self, launch_mode, expect_local,
+                                       expect_docker, expect_config, use_dcgm):
+        """
+        Test get_server_handle() calls the correct Triton Server create function with the
+        correct Triton Server Config options
 
-    def test_get_server_handle_c_api(self):
-        self._test_get_server_handle_helper(launch_mode="c_api",
-                                            use_dcgm=False,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=False)
-        self._test_get_server_handle_helper(launch_mode="c_api",
-                                            use_dcgm=True,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=False)
+        Parameters:
+        ----------
+        launch_mode: str
+            which launch mode to use
+        use_dcgm: bool
+            If true, set use_local_gpu_monitor in the input config
+        expect_local: bool
+            If true, assert that create_server_local() is called
+        expect_docker: bool
+            If true, assert that create_server_docker() is called
+        expect_config: bool
+            If true, verify that certain Triton Server args are passed to the create function as expected
+            If false, verify that those args are NOT passed
+        """
 
-    def test_get_server_handle_local(self):
-        self._test_get_server_handle_helper(launch_mode="local",
-                                            use_dcgm=False,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=True)
-        self._test_get_server_handle_helper(launch_mode="local",
-                                            use_dcgm=True,
-                                            expected_local=1,
-                                            expected_docker=0,
-                                            expect_config=True)
-
-    def test_get_server_handle_docker(self):
-        self._test_get_server_handle_helper(launch_mode="docker",
-                                            use_dcgm=False,
-                                            expected_local=0,
-                                            expected_docker=1,
-                                            expect_config=True)
-        self._test_get_server_handle_helper(launch_mode="docker",
-                                            use_dcgm=True,
-                                            expected_local=0,
-                                            expected_docker=1,
-                                            expect_config=True)
-
-    def _test_get_server_handle_helper(self, launch_mode, expected_local,
-                                       expected_docker, expect_config,
-                                       use_dcgm):
         config = ConfigCommandProfile()
         config.triton_launch_mode = launch_mode
         config.triton_http_endpoint = "1:2"
@@ -90,30 +60,70 @@ class TestTritonServerFactory(trc.TestResultCollector):
         config.monitoring_interval = 0.5
         config.use_local_gpu_monitor = use_dcgm
 
+        expected_http_port = '2'
+        expected_grpc_port = '4'
+        expected_metrics_interval_ms = 500
+
         with patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_local') as mocked_local, \
              patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_docker') as mocked_docker, \
              patch('model_analyzer.triton.server.server_factory.TritonServerFactory._validate_triton_install_path'), \
              patch('model_analyzer.triton.server.server_factory.TritonServerFactory._validate_triton_server_path'):
             _ = TritonServerFactory.get_server_handle(config, MagicMock(),
                                                       False)
-            self.assertEqual(mocked_local.call_count, expected_local)
-            self.assertEqual(mocked_docker.call_count, expected_docker)
+            self.assertEqual(mocked_local.call_count, expect_local)
+            self.assertEqual(mocked_docker.call_count, expect_docker)
 
-            if expected_local:
-                args, kwargs = mocked_local.call_args
+            if expect_local:
+                _, kwargs = mocked_local.call_args
             else:
-                args, kwargs = mocked_docker.call_args
+                _, kwargs = mocked_docker.call_args
             triton_config = kwargs['config']
 
             if expect_config:
-                self.assertEqual(triton_config['http-port'], '2')
-                self.assertEqual(triton_config['grpc-port'], '4')
-                if not use_dcgm:
-                    self.assertEqual(triton_config['metrics-interval-ms'], 500)
+                self.assertEqual(triton_config['http-port'], expected_http_port)
+                self.assertEqual(triton_config['grpc-port'], expected_grpc_port)
+                if use_dcgm:
+                    self.assertEqual(triton_config['metrics-interval-ms'], None)
+                else:
+                    self.assertEqual(triton_config['metrics-interval-ms'],
+                                     expected_metrics_interval_ms)
+
             else:
                 self.assertEqual(triton_config['http-port'], None)
                 self.assertEqual(triton_config['grpc-port'], None)
                 self.assertEqual(triton_config['metrics-interval-ms'], None)
+
+    def test_get_server_handle_remote(self):
+        for use_dcgm in [True, False]:
+            self._test_get_server_handle_helper(launch_mode="remote",
+                                                use_dcgm=use_dcgm,
+                                                expect_local=1,
+                                                expect_docker=0,
+                                                expect_config=False)
+
+    def test_get_server_handle_c_api(self):
+        for use_dcgm in [True, False]:
+            self._test_get_server_handle_helper(launch_mode="c_api",
+                                                use_dcgm=use_dcgm,
+                                                expect_local=1,
+                                                expect_docker=0,
+                                                expect_config=False)
+
+    def test_get_server_handle_local(self):
+        for use_dcgm in [True, False]:
+            self._test_get_server_handle_helper(launch_mode="local",
+                                                use_dcgm=use_dcgm,
+                                                expect_local=1,
+                                                expect_docker=0,
+                                                expect_config=True)
+
+    def test_get_server_handle_docker(self):
+        for use_dcgm in [True, False]:
+            self._test_get_server_handle_helper(launch_mode="docker",
+                                                use_dcgm=use_dcgm,
+                                                expect_local=0,
+                                                expect_docker=1,
+                                                expect_config=True)
 
     def tearDown(self):
         patch.stopall()

--- a/tests/test_triton_server_factory.py
+++ b/tests/test_triton_server_factory.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from .common import test_result_collector as trc
+
+from model_analyzer.triton.server.server_factory import TritonServerFactory
+from unittest.mock import patch, MagicMock
+from .mocks.mock_config import MockConfig
+from .mocks.mock_os import MockOSMethods
+
+from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from model_analyzer.cli.cli import CLI
+
+
+class TestTritonServerFactory(trc.TestResultCollector):
+
+    def setUp(self):
+        # Mock path validation
+        self.mock_os = MockOSMethods(
+            mock_paths=['model_analyzer.triton.server.server_factory'])
+        self.mock_os.start()
+
+    def test_get_server_handle_remote(self):
+        self._test_get_server_handle_helper(launch_mode="remote",
+                                            use_dcgm=False,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=False)
+        self._test_get_server_handle_helper(launch_mode="remote",
+                                            use_dcgm=True,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=False)
+
+    def test_get_server_handle_c_api(self):
+        self._test_get_server_handle_helper(launch_mode="c_api",
+                                            use_dcgm=False,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=False)
+        self._test_get_server_handle_helper(launch_mode="c_api",
+                                            use_dcgm=True,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=False)
+
+    def test_get_server_handle_local(self):
+        self._test_get_server_handle_helper(launch_mode="local",
+                                            use_dcgm=False,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=True)
+        self._test_get_server_handle_helper(launch_mode="local",
+                                            use_dcgm=True,
+                                            expected_local=1,
+                                            expected_docker=0,
+                                            expect_config=True)
+
+    def test_get_server_handle_docker(self):
+        self._test_get_server_handle_helper(launch_mode="docker",
+                                            use_dcgm=False,
+                                            expected_local=0,
+                                            expected_docker=1,
+                                            expect_config=True)
+        self._test_get_server_handle_helper(launch_mode="docker",
+                                            use_dcgm=True,
+                                            expected_local=0,
+                                            expected_docker=1,
+                                            expect_config=True)
+
+    def _test_get_server_handle_helper(self, launch_mode, expected_local,
+                                       expected_docker, expect_config,
+                                       use_dcgm):
+        config = ConfigCommandProfile()
+        config.triton_launch_mode = launch_mode
+        config.triton_http_endpoint = "1:2"
+        config.triton_grpc_endpoint = "3:4"
+        config.monitoring_interval = 0.5
+        config.use_local_gpu_monitor = use_dcgm
+
+        with patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_local') as mocked_local, \
+             patch('model_analyzer.triton.server.server_factory.TritonServerFactory.create_server_docker') as mocked_docker, \
+             patch('model_analyzer.triton.server.server_factory.TritonServerFactory._validate_triton_install_path'), \
+             patch('model_analyzer.triton.server.server_factory.TritonServerFactory._validate_triton_server_path'):
+            _ = TritonServerFactory.get_server_handle(config, MagicMock(),
+                                                      False)
+            self.assertEqual(mocked_local.call_count, expected_local)
+            self.assertEqual(mocked_docker.call_count, expected_docker)
+
+            if expected_local:
+                args, kwargs = mocked_local.call_args
+            else:
+                args, kwargs = mocked_docker.call_args
+            triton_config = kwargs['config']
+
+            if expect_config:
+                self.assertEqual(triton_config['http-port'], '2')
+                self.assertEqual(triton_config['grpc-port'], '4')
+                if not use_dcgm:
+                    self.assertEqual(triton_config['metrics-interval-ms'], 500)
+            else:
+                self.assertEqual(triton_config['http-port'], None)
+                self.assertEqual(triton_config['grpc-port'], None)
+                self.assertEqual(triton_config['metrics-interval-ms'], None)
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _evaluate_profile_config(self, args, yaml_content):
+        mock_config = MockConfig(args, yaml_content)
+        mock_config.start()
+        config = ConfigCommandProfile()
+        cli = CLI()
+        cli.add_subcommand(
+            cmd='profile',
+            help='Run model inference profiling based on specified CLI or '
+            'config options.',
+            config=config)
+        cli.parse()
+        mock_config.stop()
+        return config
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There were two bugs in setting of metrics-interval-ms:
1: the triton config class in MA didn't recognize metrics-interval-ms as a valid option
2: the value was being set when we were using local_gpu_monitor, when it should have been set when we were NOT using local_gpu_monitor

Fixed those bugs and added unit testing around the TritonServerFactory
