### PR TITLE
Fix issue where PA would hang until timeout

### DIFF
--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -38,13 +38,14 @@ from model_analyzer.constants import \
     MEASUREMENT_WINDOW_STEP, PERF_ANALYZER_MEASUREMENT_WINDOW, \
     PERF_ANALYZER_MINIMUM_REQUEST_COUNT
 
-from subprocess import Popen, PIPE, DEVNULL
+from subprocess import Popen, STDOUT
 import psutil
 import re
 import logging
 import signal
 import os
 import csv
+import tempfile
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -100,7 +101,7 @@ class PerfAnalyzer:
         self._config = config
         self._max_retries = max_retries
         self._timeout = timeout
-        self._output = None
+        self._output = ""
         self._perf_records = {}
         self._max_cpu_util = max_cpu_util
 
@@ -232,11 +233,12 @@ class PerfAnalyzer:
         return perf_analyzer_env
 
     def _create_process(self, cmd, perf_analyzer_env):
+        self._cmd_log = tempfile.NamedTemporaryFile()
         try:
             process = Popen(cmd,
                             start_new_session=True,
-                            stdout=PIPE,
-                            stderr=DEVNULL,
+                            stdout=self._cmd_log,
+                            stderr=STDOUT,
                             encoding='utf-8',
                             env=perf_analyzer_env)
         except FileNotFoundError as e:
@@ -271,7 +273,7 @@ class PerfAnalyzer:
 
         while current_timeout > 0:
             if process.poll() is not None:
-                self._output, _ = process.communicate()
+                self._output = self._get_process_output()
                 break
 
             # perf_analyzer using too much CPU?
@@ -280,8 +282,8 @@ class PerfAnalyzer:
                 logger.info(
                     f'perf_analyzer used significant amount of CPU resources ({cpu_util}%), killing perf_analyzer'
                 )
+                self._output = self._get_process_output()
                 process.kill()
-                self._output, _ = process.communicate()
 
                 return self.PA_FAIL
 
@@ -290,11 +292,16 @@ class PerfAnalyzer:
             logger.info(
                 'perf_analyzer took very long to exit, killing perf_analyzer')
             process.kill()
-            self._output, _ = process.communicate()
 
             return self.PA_FAIL
 
         return self.PA_SUCCESS
+
+    def _get_process_output(self):
+        self._cmd_log.seek(0)
+        tmp_output = self._cmd_log.read()
+        self._cmd_log.close()
+        return tmp_output.decode('utf-8')
 
     def _auto_adjust_parameters(self, process):
         """
@@ -312,8 +319,9 @@ class PerfAnalyzer:
 
             return self.PA_SUCCESS
         else:
+            clamped_output = self._output[:1000]
             logger.info(f"Running perf_analyzer failed with"
-                        f" exit status {process.returncode} : {self._output}")
+                        f" exit status {process.returncode}:\n{clamped_output}")
             return self.PA_FAIL
 
     def _auto_adjust_parameters_for_perf_config(self, perf_config, log):

--- a/tests/mocks/mock_perf_analyzer.py
+++ b/tests/mocks/mock_perf_analyzer.py
@@ -38,11 +38,10 @@ class MockPerfAnalyzerMethods(MockBase):
         self.mock_popen = MagicMock()
         self.mock_popen.pid = 10
         self.mock_popen.returncode = 0
+        self.mock_popen.communicate.return_value = ["", None]
         self.patcher_popen_stdout_read = patch(
             'model_analyzer.perf_analyzer.perf_analyzer.Popen',
             Mock(return_value=self.mock_popen))
-        self.patcher_stdout = patch(
-            'model_analyzer.perf_analyzer.perf_analyzer.STDOUT', MagicMock())
         self.patcher_pipe = patch(
             'model_analyzer.perf_analyzer.perf_analyzer.PIPE', MagicMock())
         super().__init__()
@@ -53,7 +52,6 @@ class MockPerfAnalyzerMethods(MockBase):
         """
 
         self.popen_stdout_read = self.patcher_popen_stdout_read.start()
-        self.stdout_mock = self.patcher_stdout.start()
         self.pipe_mock = self.patcher_pipe.start()
 
     def _fill_patchers(self):
@@ -62,33 +60,21 @@ class MockPerfAnalyzerMethods(MockBase):
         """
 
         self._patchers.append(self.patcher_popen_stdout_read)
-        self._patchers.append(self.patcher_stdout)
         self._patchers.append(self.patcher_pipe)
-
-    def assert_perf_analyzer_run_as(self, cmd):
-        """
-        Checks that Popen was run with the given command.
-        """
-
-        self.popen_stdout_read.assert_called_with(cmd,
-                                                  start_new_session=True,
-                                                  stdout=self.pipe_mock,
-                                                  stderr=self.stdout_mock,
-                                                  encoding='utf-8')
 
     def set_perf_analyzer_result_string(self, output_string):
         """
         Sets the return value of mock_popen
         """
 
-        self.mock_popen.stdout.read.return_value = output_string
+        self.mock_popen.communicate.return_value = [output_string, None]
 
-    def get_perf_analyzer_popen_read_call_count(self):
+    def get_perf_analyzer_popen_communicate_call_count(self):
         """
-        Get perf_analyzer popen read count
+        Get perf_analyzer popen.communicate() call count
         """
 
-        return self.mock_popen.stdout.read.call_count
+        return self.mock_popen.communicate.call_count
 
     def set_perf_analyzer_return_code(self, returncode):
         """
@@ -103,6 +89,5 @@ class MockPerfAnalyzerMethods(MockBase):
         and return values of the
         mocks in this module
         """
-
-        self.mock_popen.stdout.read.side_effect = None
-        self.mock_popen.stdout.read.return_value = None
+        self.mock_popen.communicate.return_value = ["", None]
+        self.mock_popen.communicate.side_effect = None

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -421,7 +421,7 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         perf_metrics = [PerfThroughput, PerfLatencyP99]
         perf_analyzer.run(perf_metrics)
         self.assertEqual(
-            self.perf_mock.get_perf_analyzer_popen_read_call_count(), 10)
+            self.perf_mock.get_perf_analyzer_popen_communicate_call_count(), 10)
 
     def test_measurement_request_count_increase(self):
         server_config = TritonServerConfig()
@@ -447,7 +447,7 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         perf_metrics = [PerfThroughput, PerfLatencyP99]
         perf_analyzer.run(perf_metrics)
         self.assertEqual(
-            self.perf_mock.get_perf_analyzer_popen_read_call_count(), 10)
+            self.perf_mock.get_perf_analyzer_popen_communicate_call_count(), 10)
 
     def test_is_multi_model(self):
         """ 

--- a/tests/test_perf_analyzer.py
+++ b/tests/test_perf_analyzer.py
@@ -420,8 +420,8 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         self.perf_mock.set_perf_analyzer_return_code(1)
         perf_metrics = [PerfThroughput, PerfLatencyP99]
         perf_analyzer.run(perf_metrics)
-        self.assertEqual(
-            self.perf_mock.get_perf_analyzer_popen_communicate_call_count(), 10)
+        self.assertEqual(self.perf_mock.get_perf_analyzer_popen_call_count(),
+                         10)
 
     def test_measurement_request_count_increase(self):
         server_config = TritonServerConfig()
@@ -446,8 +446,8 @@ class TestPerfAnalyzerMethods(trc.TestResultCollector):
         self.perf_mock.set_perf_analyzer_return_code(1)
         perf_metrics = [PerfThroughput, PerfLatencyP99]
         perf_analyzer.run(perf_metrics)
-        self.assertEqual(
-            self.perf_mock.get_perf_analyzer_popen_communicate_call_count(), 10)
+        self.assertEqual(self.perf_mock.get_perf_analyzer_popen_call_count(),
+                         10)
 
     def test_is_multi_model(self):
         """ 


### PR DESCRIPTION
When PA aborts with GPU OOM, each of its threads dumps a huge error string.  Piping the result of STDERR was overflowing the buffer, resulting in the subprocess to hang.

The red warning below in the Popen documentation tells us that this can happen. It says that the solution is to use communicate(), but communicate blocks until finished and the code needs to continue gathering CPU utilization

![image](https://user-images.githubusercontent.com/50968584/176730022-c1e70bb9-2c1b-4a5e-acf2-c04e672e221c.png)

The solution is to pipe both stderr and stdout to a (temporary) file