### PR TITLE
Update documentation for model repository

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,7 @@ various metrics at fixed time intervals during these perf analyzer runs. Each
 perf analyzer run generates a single measurement, which corresponds to a row in
 the output tables. After completing the runs for all configurations for each
 model, the Model Analyzer will save the measurements it has collected into the
-**checkpoint directory** as a *pickle* file. See the
+**checkpoint directory**. See the
 [Checkpointing](./checkpoints.md) section for more details on checkpoints
 
 ### Examples

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,7 +62,7 @@ converting the `snake_case` options to `--kebab-case`. For example,
 
 
 ```yaml
-# Path to the Triton Model Repository
+# Path to the Triton Model Repository (https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md)
 model_repository: <string>
 
 # List of the model names to be profiled

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,7 +62,7 @@ converting the `snake_case` options to `--kebab-case`. For example,
 
 
 ```yaml
-# Path to the Model Repository
+# Path to the Triton Model Repository
 model_repository: <string>
 
 # List of the model names to be profiled

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -81,9 +81,11 @@ apt-get update && apt-get install wkhtmltopdf
 
 ---
 
-The [examples/quick-start](../examples/quick-start) directory contains a simple
-libtorch model which calculates the sum and difference of two inputs. Run the
-Model Analyzer `profile` subcommand inside the container with:
+The [examples/quick-start](../examples/quick-start) directory is an example 
+[Triton Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) that contains a simple libtorch model which calculates 
+the sum and difference of two inputs. 
+ 
+Run the Model Analyzer `profile` subcommand inside the container with:
 
 ```
 model-analyzer profile \

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -232,7 +232,7 @@ class ConfigCommandProfile(ConfigCommand):
                         flags=['-m', '--model-repository'],
                         field_type=ConfigPrimitive(
                             str, required=True, validator=file_path_validator),
-                        description='Model repository location'))
+                        description='Triton Model repository location'))
         self._add_config(
             ConfigField(
                 'output_model_repository_path',


### PR DESCRIPTION
Add link to Triton documentation of Model Repository.
Remove incorrect mention of pickle.