### PR TITLE
RunConfigMeasurement new public methods

### DIFF
--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -16,6 +16,7 @@ from model_analyzer.constants import COMPARISON_SCORE_THRESHOLD
 from model_analyzer.constants import LOGGER_NAME
 
 from model_analyzer.result.model_config_measurement import ModelConfigMeasurement
+from model_analyzer.result.constraint_manager import ConstraintManager
 from model_analyzer.record.record import RecordType
 
 from statistics import mean
@@ -394,7 +395,12 @@ class RunConfigMeasurement:
         return not self.is_better_than(other)
 
     def is_passing_constraints(self):
-        NotImplemented
+        """
+        Returns true if all model measurements pass
+        their respective constraints
+        """
+        return ConstraintManager.satisfies_constraints(
+            self._model_config_constraints, self)
 
     def compare_measurements(self, other):
         """

--- a/model_analyzer/result/run_config_measurement.py
+++ b/model_analyzer/result/run_config_measurement.py
@@ -76,9 +76,6 @@ class RunConfigMeasurement:
         run_config_measurement._model_config_weights = run_config_measurement_dict[
             '_model_config_weights']
 
-        run_config_measurement._model_config_constraints = run_config_measurement_dict[
-            '_model_config_constraints']
-
         return run_config_measurement
 
     def set_model_config_weighting(self, model_config_weights):

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -222,6 +222,31 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         rcm4_vs_rcm5 = self.rcm4.compare_measurements(self.rcm5)
         self.assertEqual(rcm4_vs_rcm5, 1000 / 1500)
 
+    def test_is_passing_constraints_none(self):
+        """
+        Test to ensure constraints are reported as passing
+        if none were specified
+        """
+        self.assertTrue(self.rcm5.is_passing_constraints())
+
+    def test_is_passing_constraints(self):
+        """
+        Test to ensure constraints are reported as
+        passing/failing if model is above/below
+        throughput threshold
+        """
+        self.rcm5.set_model_config_constraints(
+            {"perf_throughput": {
+                "min": 500
+            }})
+        self.assertTrue(self.rcm5.is_passing_constraints())
+
+        self.rcm5.set_model_config_constraints(
+            {"perf_throughput": {
+                "min": 3000
+            }})
+        self.assertFalse(self.rcm5.is_passing_constraints())
+
     def test_from_dict(self):
         """
         Test to ensure class can be correctly restored from a dictionary

--- a/tests/test_run_config_measurement.py
+++ b/tests/test_run_config_measurement.py
@@ -36,6 +36,8 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self._construct_rcm1()
         self._construct_rcm2()
         self._construct_rcm3()
+        self._construct_rcm4()
+        self._construct_rcm5()
 
     def tearDown(self):
         patch.stopall()
@@ -207,6 +209,18 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         # Therefore, RCM2 is (very slightly) better than RCM3
         self.assertTrue(self.rcm2.is_better_than(self.rcm3))
         self.assertFalse(self.rcm3.is_better_than(self.rcm2))
+
+    def test_compare_measurements(self):
+        """
+        Test to ensure compare measurement function returns
+        the correct magnitude
+        # RCM4's throughput is 1000
+        # RCM5's throughput is 2000
+        # Therefore, the magnitude is (RCM5 - RCM4) / avg throughput
+        #                             (2000 - 1000) / 1500
+        """
+        rcm4_vs_rcm5 = self.rcm4.compare_measurements(self.rcm5)
+        self.assertEqual(rcm4_vs_rcm5, 1000 / 1500)
 
     def test_from_dict(self):
         """
@@ -455,6 +469,106 @@ class TestRunConfigMeasurement(trc.TestResultCollector):
         self.rcm3 = construct_run_config_measurement(
             model_name, model_config_name, model_specific_pa_params,
             gpu_metric_values, self.rcm3_non_gpu_metric_values,
+            metric_objectives, weights)
+
+    def _construct_rcm4(self):
+        model_name = "modelA"
+        model_config_name = ["modelA_config_0"]
+        model_variants_name = "".join(self.model_config_name)
+        model_specific_pa_params = [{
+            "batch_size": 1,
+            "concurrency": 1
+        }, {
+            "batch_size": 2,
+            "concurrency": 2
+        }]
+
+        gpu_metric_values = {
+            '0': {
+                "gpu_used_memory": 6000,
+                "gpu_utilization": 60
+            },
+            '1': {
+                "gpu_used_memory": 10000,
+                "gpu_utilization": 20
+            }
+        }
+        avg_gpu_metric_values = {"gpu_used_memory": 8000, "gpu_utilization": 40}
+
+        self.rcm4_non_gpu_metric_values = [
+            {
+                # modelA_config_0
+                "perf_throughput": 1000,
+                "perf_latency_p99": 20,
+                "cpu_used_ram": 1000
+            },
+        ]
+
+        metric_objectives = [{"perf_throughput": 1}]
+
+        weights = [1]
+
+        self.rcm4_weighted_non_gpu_metric_values = []
+        for index, non_gpu_metric_values in enumerate(
+                self.rcm4_non_gpu_metric_values):
+            self.rcm4_weighted_non_gpu_metric_values.append({
+                objective: value * self.weights[index] / sum(self.weights)
+                for (objective, value) in non_gpu_metric_values.items()
+            })
+
+        self.rcm4 = construct_run_config_measurement(
+            model_name, model_config_name, model_specific_pa_params,
+            gpu_metric_values, self.rcm4_non_gpu_metric_values,
+            metric_objectives, weights)
+
+    def _construct_rcm5(self):
+        model_name = "modelA"
+        model_config_name = ["modelA_config_0"]
+        model_variants_name = "".join(self.model_config_name)
+        model_specific_pa_params = [{
+            "batch_size": 1,
+            "concurrency": 1
+        }, {
+            "batch_size": 2,
+            "concurrency": 2
+        }]
+
+        gpu_metric_values = {
+            '0': {
+                "gpu_used_memory": 6000,
+                "gpu_utilization": 60
+            },
+            '1': {
+                "gpu_used_memory": 10000,
+                "gpu_utilization": 20
+            }
+        }
+        avg_gpu_metric_values = {"gpu_used_memory": 8000, "gpu_utilization": 40}
+
+        self.rcm5_non_gpu_metric_values = [
+            {
+                # modelA_config_0
+                "perf_throughput": 2000,
+                "perf_latency_p99": 20,
+                "cpu_used_ram": 1000
+            },
+        ]
+
+        metric_objectives = [{"perf_throughput": 1}]
+
+        weights = [1]
+
+        self.rcm5_weighted_non_gpu_metric_values = []
+        for index, non_gpu_metric_values in enumerate(
+                self.rcm5_non_gpu_metric_values):
+            self.rcm5_weighted_non_gpu_metric_values.append({
+                objective: value * self.weights[index] / sum(self.weights)
+                for (objective, value) in non_gpu_metric_values.items()
+            })
+
+        self.rcm5 = construct_run_config_measurement(
+            model_name, model_config_name, model_specific_pa_params,
+            gpu_metric_values, self.rcm5_non_gpu_metric_values,
             metric_objectives, weights)
 
 


### PR DESCRIPTION
Added three new public methods to support quick algorithm:

- compare_measurements(other) - takes a second RCM and returns a positive value if new RCM is better, negative if worse. The greater the magnitude the better/worse the measurement is
- is_passing_constraints() - returns a bool indicating the RCM is passing all constraints
- set_model_config_constraints(constraints) - sets the constraints for the RCM

Added basic unit testing to cover the new methods
   