### PR TITLE
Remove measurement-request-count from representation

### DIFF
--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -93,10 +93,29 @@ class ModelRunConfig:
 
     def representation(self):
         """
-        Returns a representation string for the ModelRunConfig that can be used
+        Returns a representation string, containing model name, batch size, 
+        and concurrency for the ModelRunConfig that can be used
         as a key to uniquely identify it
         """
-        return self.perf_config().representation()
+        pc_string = self.perf_config().representation()
+        pc_list = pc_string.split()
+
+        repr_list = []
+        if '-m' in pc_list:
+            repr_list.append(pc_list[pc_list.index('-m')])
+            repr_list.append(pc_list[pc_list.index('-m') + 1])
+
+        if '-b' in pc_list:
+            repr_list.append(pc_list[pc_list.index('-b')])
+            repr_list.append(pc_list[pc_list.index('-b') + 1])
+
+        if '--concurrency' in pc_list:
+            repr_list.append(
+                next((str for str in pc_list if '--concurrency' in str), None))
+
+        repr_str = ' '.join(repr_list)
+
+        return repr_str
 
     def is_legal_combination(self):
         """

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -97,13 +97,8 @@ class ModelRunConfig:
         Returns a representation string for the ModelRunConfig that can be used
         as a key to uniquely identify it
         """
-        repr_string = self.perf_config().representation()
-        repr_list = self._remove_mrc_from_list(repr_string.split())
 
-        return ' '.join(repr_list)
-
-    def _remove_mrc_from_list(self, repr_list: List[str]):
-        return [s for s in repr_list if '--measurement-request-count' not in s]
+        return self.perf_config().representation()
 
     def is_legal_combination(self):
         """

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 from model_analyzer.constants import LOGGER_NAME
 import logging
 

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 from model_analyzer.constants import LOGGER_NAME
 import logging
 
@@ -93,29 +94,16 @@ class ModelRunConfig:
 
     def representation(self):
         """
-        Returns a representation string, containing model name, batch size, 
-        and concurrency for the ModelRunConfig that can be used
+        Returns a representation string for the ModelRunConfig that can be used
         as a key to uniquely identify it
         """
-        pc_string = self.perf_config().representation()
-        pc_list = pc_string.split()
+        repr_string = self.perf_config().representation()
+        repr_list = self._remove_mrc_from_list(repr_string.split())
 
-        repr_list = []
-        if '-m' in pc_list:
-            repr_list.append(pc_list[pc_list.index('-m')])
-            repr_list.append(pc_list[pc_list.index('-m') + 1])
+        return ' '.join(repr_list)
 
-        if '-b' in pc_list:
-            repr_list.append(pc_list[pc_list.index('-b')])
-            repr_list.append(pc_list[pc_list.index('-b') + 1])
-
-        if '--concurrency' in pc_list:
-            repr_list.append(
-                next((str for str in pc_list if '--concurrency' in str), None))
-
-        repr_str = ' '.join(repr_list)
-
-        return repr_str
+    def _remove_mrc_from_list(self, repr_list: List[str]):
+        return [s for s in repr_list if '--measurement-request-count' not in s]
 
     def is_legal_combination(self):
         """

--- a/model_analyzer/perf_analyzer/perf_config.py
+++ b/model_analyzer/perf_analyzer/perf_config.py
@@ -185,9 +185,11 @@ class PerfAnalyzerConfig:
             a string representation that does not include the url
             Useful for mapping measurements across systems.
         """
+        cli_string = self.to_cli_string()
+        cli_string = PerfAnalyzerConfig.remove_url_from_cli_string(cli_string)
+        cli_string = PerfAnalyzerConfig.remove_mrc_from_cli_string(cli_string)
 
-        return PerfAnalyzerConfig.remove_url_from_cli_string(
-            self.to_cli_string())
+        return cli_string
 
     def extract_model_specific_parameters(self):
         """
@@ -225,6 +227,30 @@ class PerfAnalyzerConfig:
             perf_str_tokens.pop(url_index)
         except ValueError:
             pass
+
+        return ' '.join(perf_str_tokens)
+
+    @classmethod
+    def remove_mrc_from_cli_string(cls, cli_string):
+        """
+        utility function strips the measruement request count
+        from a cli string representation
+
+        Parameters
+        ----------
+        cli_string : str
+            The cli string representation
+        """
+
+        perf_str_tokens = cli_string.split(' ')
+
+        mrc_index = [
+            i for i, s in enumerate(perf_str_tokens)
+            if '--measurement-request-count' in s
+        ]
+
+        if mrc_index:
+            perf_str_tokens.pop(mrc_index[0])
 
         return ' '.join(perf_str_tokens)
 

--- a/model_analyzer/perf_analyzer/perf_config.py
+++ b/model_analyzer/perf_analyzer/perf_config.py
@@ -182,8 +182,10 @@ class PerfAnalyzerConfig:
         Returns
         -------
         str
-            a string representation that does not include the url
-            Useful for mapping measurements across systems.
+            a string representation of the PA config 
+            that removes values which can vary between
+            runs, but should be ignored when determining
+            if a previous (checkpointed) run can be used
         """
         cli_string = self.to_cli_string()
         cli_string = PerfAnalyzerConfig.remove_url_from_cli_string(cli_string)

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -72,6 +72,19 @@ class TestRunConfig(trc.TestResultCollector):
         expected_representation = pc1.representation() + pc2.representation()
         self.assertEqual(rc.representation(), expected_representation)
 
+    def test_representation_mrc_removal(self):
+        """
+        Test that representation removes measurement request count
+        """
+        pc = PerfAnalyzerConfig()
+        pc.update_config({'model-name': "TestModel1"})
+        pc.update_config({'measurement-request-count': "500"})
+
+        mrc = ModelRunConfig("model1", MagicMock(), pc)
+
+        expected_represenation = "-m TestModel1"
+        self.assertEqual(mrc.representation(), expected_represenation)
+
     def test_cpu_only(self):
         """
         Test that cpu_only() is only true if all ModelConfigs are cpu_only() 


### PR DESCRIPTION
Removes measurement-request-count from PA representation field. This way on a checkpoint restore we will treat find/match on this entry even if a non-default MRC was needed.