### PR TITLE
Skip unload/reload and server restart

### DIFF
--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -92,6 +92,8 @@ class ModelManager:
                 measurement = None
             rcg.set_last_results([measurement])
 
+        self._metrics_manager.finalize()
+
         # Reset the server args to global config
         self._server.update_config(params=server_config_copy.server_args())
 

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -185,12 +185,11 @@ class MetricsManager:
 
         current_model_variants = run_config.model_variants_name()
         if current_model_variants != self._loaded_models:
-            logger.debug(f"Loaded model: {self._loaded_models}")
-            logger.debug(f"Next model to load: {current_model_variants}")
             self._server.stop()
             self._server.start(env=run_config.triton_environment())
 
             if not self._load_model_variants(run_config):
+                self._server.stop()
                 self._loaded_models = None
                 return
 
@@ -267,6 +266,9 @@ class MetricsManager:
                 run_config, run_config_measurement)
 
         return run_config_measurement
+
+    def finalize(self):
+        self._server.stop()
 
     def _create_model_variants(self, run_config):
         """

--- a/qa/L0_perf_analyzer/test.sh
+++ b/qa/L0_perf_analyzer/test.sh
@@ -63,7 +63,7 @@ for CONFIG_FILE in ${LIST_OF_CONFIG_FILES[@]}; do
         TEST_NAME="count_window"
     elif [[ "$CONFIG_FILE" == "config-additive-args-count-no-adjust.yml" ]]; then
         TEST_NAME="count_window"
-    elif [[ "$CONFIG_FILE" == "config_perf_output_timeout.yml" ]]; then
+    elif [[ "$CONFIG_FILE" == "config-perf-output-timeout.yml" ]]; then
         TEST_NAME="perf_output_timeout"
     fi
 


### PR DESCRIPTION
When calling PA, if the model config is the same as the previous one (and we are only changing PA attributes like concurrency) then do not tear down the server and start from scratch. Instead utilizing the server that is already up with the proper model config loaded.