### PR TITLE
Fix failing L0 PA test

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -108,13 +108,13 @@ class Analyzer:
         if (self._state_manager.exiting()):
             sys.exit(1)
 
-        # TODO: TMA-792: This won't be needed once the Results class is used in profile
-        self._analyze_models()
-
         logger.info(self._get_profile_complete_string())
         logger.info("")
 
         if not self._config.skip_summary_reports:
+            # TODO: TMA-792: This won't be needed once the Results class is used in profile
+            self._analyze_models()
+
             self._create_summary_tables(verbose)
             self._create_summary_reports(mode)
             logger.info(self._get_report_command_help_string())

--- a/qa/L0_perf_analyzer/test.sh
+++ b/qa/L0_perf_analyzer/test.sh
@@ -24,7 +24,7 @@ MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_V
 BATCH_SIZES="1"
 CONCURRENCY="1"
 TRITON_LAUNCH_MODE="local"
-CLIENT_PROTOCOL="http"
+CLIENT_PROTOCOL="grpc"
 PORTS=(`find_available_ports 3`)
 GPUS=(`get_all_gpus_uuids`)
 OUTPUT_MODEL_REPOSITORY=${OUTPUT_MODEL_REPOSITORY:=`get_output_directory`}

--- a/qa/L0_perf_analyzer/test_config_generator.py
+++ b/qa/L0_perf_analyzer/test_config_generator.py
@@ -93,6 +93,7 @@ class TestConfigGenerator:
     def generate_perf_output_timeout(self):
         model_config = {
             'profile_models': ['vgg19_libtorch'],
+            'skip_summary_reports': True,  # Don't fail analyzing no results
             'perf_output': True,
             'perf_analyzer_timeout': 2,
             'perf_analyzer_flags': {


### PR DESCRIPTION
The test has always been "failing" because streaming is not allowed with http, but changes to run analyze in the profile step exposed the failure.
This fixes the test to run properly and actually test what it was intended to test.
