### PR TITLE
Clean up cpu-only mode

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -93,7 +93,7 @@ profile_models: <comma-delimited-string-list>
 # Specifies how long (seconds) to gather server-only metrics
 [ duration_seconds: <int> | default: 3 ]
 
-# Specify whether DCGM should be used by Model Analyzer to collect GPU metricss
+# Specify whether DCGM should be used by Model Analyzer to collect GPU metrics
 [ use_local_gpu_monitor: <bool> | default: False ]
 
 # Duration of waiting time between each metric measurement in seconds

--- a/docs/install.md
+++ b/docs/install.md
@@ -189,16 +189,6 @@ pip3 install --upgrade pip
 
 You can then try installing model analyzer again.
 
-If you are using this approach you need to install DCGM on your machine.
-
-For installing DCGM on Ubuntu 20.04 you can use the following commands:
-
-```
-export DCGM_VERSION=2.0.13
-wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb && \
- dpkg -i datacenter-gpu-manager_${DCGM_VERSION}_amd64.deb
-```
-
 <br>
 
 ## From the Source
@@ -206,7 +196,7 @@ wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_
 ---
 
 To build model analyzer from the source. You'll need to install the same
-dependencies (tritonclient and DCGM) mentioned in [Using Pip](##Using-Pip).<br>
+dependencies (tritonclient) mentioned in [Pip Install](#Pip).<br>
 After that, you can use the following commands:
 
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -49,7 +49,7 @@ for more info on these
 
 ## GPU metrics
 
-These are metrics currently captured using DCGM. They are recorded for each GPU
+These are metrics captured by the tritonserver using DCGM. They are recorded for each GPU
 in fixed intervals during perf analyzer runs and then aggregated across all the
 records for a run. 
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -49,7 +49,7 @@ for more info on these
 
 ## GPU metrics
 
-These are metrics captured by the tritonserver using DCGM. They are recorded for each GPU
+These are metrics captured by the tritonserver. They are recorded for each GPU
 in fixed intervals during perf analyzer runs and then aggregated across all the
 records for a run. 
 

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -250,7 +250,6 @@ class Analyzer:
     def _create_summary_tables(self, verbose: bool):
         self._result_table_manager = ResultTableManager(self._config,
                                                         self._result_manager)
-
         self._result_table_manager.create_tables()
         self._result_table_manager.tabulate_results()
         self._result_table_manager.export_results()

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -563,9 +563,11 @@ class MetricsManager:
         collect_cpu_metrics_expect = cpu_only or len(self._gpus) == 0
         collect_cpu_metrics_actual = len(self._cpu_metrics) > 0
         if collect_cpu_metrics_expect and not collect_cpu_metrics_actual:
-            logger.info(
-                "CPU metric(s) are not being collected, while this profiling will run on CPU(s)."
-            )
+            if not self._cpu_warning_printed:
+                self._cpu_warning_printed = True
+                logger.warning(
+                    "CPU metric(s) are not being collected, while this profiling will run on CPU(s)."
+                )
         # Warn user about CPU monitor performance issue
         if collect_cpu_metrics_actual:
             if not self._cpu_warning_printed:

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -566,15 +566,14 @@ class MetricsManager:
             if not self._cpu_warning_printed:
                 self._cpu_warning_printed = True
                 logger.warning(
-                    "CPU metric(s) are not being collected, while this profiling will run on CPU(s)."
+                    "One or more models are running on the CPU, but CPU metric(s) are not being collected"
                 )
         # Warn user about CPU monitor performance issue
         if collect_cpu_metrics_actual:
             if not self._cpu_warning_printed:
                 self._cpu_warning_printed = True
-                logger.warning("CPU metric(s) are being collected.")
                 logger.warning(
-                    "Collecting CPU metric(s) can affect the latency or throughput numbers reported by perf analyzer."
+                    "CPU metrics are being collected. This can affect the latency or throughput numbers reported by perf analyzer."
                 )
 
     @staticmethod

--- a/model_analyzer/result/model_config_measurement.py
+++ b/model_analyzer/result/model_config_measurement.py
@@ -137,10 +137,6 @@ class ModelConfigMeasurement:
         if tag in self._non_gpu_data_from_tag:
             return self._non_gpu_data_from_tag[tag]
         else:
-            logger.warning(
-                f"No non-GPU metric corresponding to tag '{tag}' "
-                "found in the model's measurement. Possibly comparing "
-                "measurements across devices.")
             return None
 
     def get_metric_value(self, tag, default_value=0):

--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -182,7 +182,7 @@ class TritonServerDocker(TritonServer):
             self._tritonserver_container.stop()
             self._tritonserver_container.remove(force=True)
             self._tritonserver_container = None
-            logger.info('Stopped Triton Server.')
+            logger.debug('Stopped Triton Server.')
         self._docker_client.close()
 
     def cpu_stats(self):


### PR DESCRIPTION
- Remove mention of DCGM requirement in docs
- Downgrade "stopped triton server" print to debug for docker mode (just like it is for local mode)
- Only print "CPU metrics are not being collected" once
- Refactor csv printing. Don't print files with no data
- Removed warning about "No non-gpu metric", as it provided no value
 
I did NOT fix the following warning, because I think it is legit as it comes from the options of what fields to print in the csv files:
- Analysis step printed a ton of warnings about GPU and Server output fields gpu_used_memory, gpu_utilization, and gpu_power_usage
