### PR TITLE
Don't enable dynamic batching if no max_batch_size in config

### DIFF
--- a/model_analyzer/config/generate/automatic_model_config_generator.py
+++ b/model_analyzer/config/generate/automatic_model_config_generator.py
@@ -53,7 +53,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
         self._curr_instance_count = self._min_instance_count
         self._curr_max_batch_size = 0
 
-        self._sweep_max_batch_size_disabled = self._determine_sweep_max_batch_size_disabled(
+        self._max_batch_size_disabled = self._determine_max_batch_size_disabled(
         )
 
         self._reset_max_batch_size()
@@ -101,7 +101,7 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
     def _reset_max_batch_size(self):
         super()._reset_max_batch_size()
 
-        if self._sweep_max_batch_size_disabled:
+        if self._max_batch_size_disabled:
             self._curr_max_batch_size = self._max_model_batch_size
         else:
             self._curr_max_batch_size = self._min_model_batch_size
@@ -116,19 +116,19 @@ class AutomaticModelConfigGenerator(BaseModelConfigGenerator):
             return DEFAULT_CONFIG_PARAMS
 
         config = {
-            'dynamic_batching': {},
             'instance_group': [{
                 'count': self._curr_instance_count,
                 'kind': self._instance_kind
             }]
         }
 
-        if not self._sweep_max_batch_size_disabled:
+        if not self._max_batch_size_disabled:
             config['max_batch_size'] = self._curr_max_batch_size
+            config['dynamic_batching'] = {}
 
         return config
 
-    def _determine_sweep_max_batch_size_disabled(self):
+    def _determine_max_batch_size_disabled(self):
         config = BaseModelConfigGenerator.get_base_model_config_dict(
             self._config, self._client, self._gpus, self._model_repository,
             self._base_model_name)

--- a/tests/test_model_config_generator.py
+++ b/tests/test_model_config_generator.py
@@ -290,6 +290,81 @@ class TestModelConfigGenerator(trc.TestResultCollector):
 
         self._run_and_test_model_config_generator(yaml_str, expected_configs)
 
+    def test_direct_max_batch_size_0(self):
+        '''
+        Test direct mode with the the default config stating max_batch_size=0
+
+        max_batch_size and dynamic_batching should not be part of the resulting configs
+        '''
+
+        # yapf: disable
+        protobuf = """
+            platform: "fake_platform"
+            max_batch_size: 0
+            instance_group [
+            {
+                kind: KIND_CPU
+                count: 1
+            }
+            ]
+            """
+
+        yaml_str = ("""
+            run_config_search_max_instance_count: 4
+            run_config_search_min_model_batch_size: 8
+            run_config_search_max_model_batch_size: 8
+            profile_models:
+                - my-model
+            """)
+
+        expected_configs = [
+            {'platform': "fake_platform", 'instance_group': [{'count': 1, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 2, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 3, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 4, 'kind': 'KIND_GPU'}]}
+        ]
+        # yapf: enable
+
+        self._run_and_test_model_config_generator(yaml_str, expected_configs,
+                                                  protobuf)
+
+    def test_direct_max_batch_size_unspecified(self):
+        '''
+        Test direct mode with the the default config not specifying max_batch_size
+
+        max_batch_size and dynamic_batching should not be part of the resulting configs
+        '''
+
+        # yapf: disable
+        protobuf = """
+            platform: "fake_platform"
+            instance_group [
+            {
+                kind: KIND_CPU
+                count: 1
+            }
+            ]
+            """
+
+        yaml_str = ("""
+            run_config_search_max_instance_count: 4
+            run_config_search_min_model_batch_size: 8
+            run_config_search_max_model_batch_size: 8
+            profile_models:
+                - my-model
+            """)
+
+        expected_configs = [
+            {'platform': "fake_platform", 'instance_group': [{'count': 1, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 2, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 3, 'kind': 'KIND_GPU'}]},
+            {'platform': "fake_platform", 'instance_group': [{'count': 4, 'kind': 'KIND_GPU'}]}
+        ]
+        # yapf: enable
+
+        self._run_and_test_model_config_generator(yaml_str, expected_configs,
+                                                  protobuf)
+
     def test_direct_nonempty_default_config(self):
         '''
         Test direct mode with the the default config containing some values

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -933,7 +933,7 @@ class TestModelManager(trc.TestResultCollector):
     def test_no_max_batch_size_sweep_if_protobuf_0(self):
         """
         Test that if the max_batch_size is 0 in the original model config, 
-        then do not sweep max batch size
+        then do not sweep max batch size or dynamic batching
         """
 
         self._model_config_protobuf = """
@@ -951,7 +951,7 @@ class TestModelManager(trc.TestResultCollector):
         expected_ranges = [{
             'instances': [1],
             'kind': ["KIND_GPU"],
-            'batching': [0],
+            'batching': [None],
             'batch_sizes': [1],
             'concurrency': [1, 2, 4]
         }, {


### PR DESCRIPTION
If max_batch_size is not specified or is set to 0 in the default config, do not sweep over max_batch_size, and do not enable dynamic batching.