### PR TITLE
Fail if an option is specified in both the CLI and the yaml file

### DIFF
--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -101,6 +101,12 @@ class ConfigCommand:
         for key, value in self._fields.items():
             self._fields[key].set_name(key)
             if key in args:
+                if yaml_config is not None and key in yaml_config:
+                    raise TritonModelAnalyzerException(
+                        f'\n  Config for {value.name()} is specified on both '
+                        'the CLI and the yaml config file.'
+                        '\n  Please remove the option from one of the locations and try again'
+                    )
                 self._fields[key].set_value(getattr(args, key))
             elif yaml_config is not None and key in yaml_config:
                 self._fields[key].set_value(yaml_config[key])

--- a/qa/L0_config_range/config_generator.py
+++ b/qa/L0_config_range/config_generator.py
@@ -38,7 +38,6 @@ def _get_range_configs():
         'profile_models': [['resnet50_libtorch']],
         'run_config_search_disable': [True],
         'perf_analyzer_cpu_util': [600],
-        'triton_launch_mode': ['docker'],
         'batch_sizes': [{
             'start': begin,
             'stop': end,


### PR DESCRIPTION
If a user specifies an option in both the yaml config as well as the CLI, fail with an error message.

This has been common in the past with `profile_models`, where the CLI option overwrites the entire set of options specified in the YAML.  Now we will immediately fail and tell the user instead of prioritizing what is on the CLI.