### PR TITLE
Documentation updates due to profile-analysis being combined

### DIFF
--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -23,10 +23,10 @@ Defaults](./config.md#config-defaults) section for default location). Checkpoint
 ## When is Checkpointing Done?
 
 Model Analyzer saves a checkpoint in multiple circumstances:
+
 1. Model Analyzer will save a checkpoint after all the perf
    analyzer runs for a given model are complete.
-2. The user can initiate an early exit from profiling using `CTRL-C
-   (SIGINT)`. This will wait for the current perf analyzer run to finish and
+2. The user can initiate an early exit from profiling using `CTRL-C (SIGINT)`. This will wait for the current perf analyzer run to finish and
    then save a checkpoint before exiting.
 3. If the user needs to exit immediately, they send the `SIGINT` 3 times. In
    this case, Model Analyzer will save a checkpoint and exit immediately.
@@ -59,9 +59,10 @@ $ ls -l checkpoints
 Checkpoints are named using consecutive non-negative integers. On startup, Model
 Analyzer identifies the latest checkpoint (highest integer) and loads it. If
 there are any changes to the data in the checkpoint, the checkpoint index is
-incremented before it is saved again, thus creating a new latest checkpoint. 
+incremented before it is saved again, thus creating a new latest checkpoint.
 
 **Note**: Model analyzer does not clean up old checkpoints. It merely guarantees
 that the checkpoint with the highest integer index is the one with the most
 up-to-date measurements. The checkpoint directory should be removed between
-consecutive runs of the `model-analyzer profile` command.
+consecutive runs of the `model-analyzer profile` command if you want to start
+a fresh run.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,6 +126,10 @@ $ model-analyzer profile -m /home/model_repo --output-model-repository-path=/hom
 
 4. Run profile over manually defined configurations for a models `classification_malaria_v1` and `classification_chestxray_v1` located in `/home/model_repo` using the YAML config file
 
+```
+$ model-analyzer profile -f /path/to/config.yaml
+```
+
 The contents of `config.yaml` are shown below.
 
 ```yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ online mode, the best model configuration will be the one that maximizes
 throughput. If a latency budget is specified to the [profile subcommand](#subcommand-profile) via
 `--latency-budget`, then the best model configuration will be the one with the highest throughput in the given budget.
 
-In online mode the analyze and report subcommands will generate summaries specific to online inference.
+In online mode the profile and report subcommands will generate summaries specific to online inference.
 See the example [online summary](../examples/online_summary.pdf) and [online detailed report](../examples/online_summary.pdf).
 
 ### Offline Mode
@@ -70,7 +70,7 @@ analyzer, and collect metrics like throughput, latency and memory usage for
 any measurements not present in the checkpoint.
 
 Next, it sorts the models specified in the CLI or
-config YAML, using the objectives specified in the config YAML. Finally, it constructs summary PDFs
+config YAML, using any objectives specified in the config YAML. Finally, it constructs summary PDFs
 using the top model configs for each model, as well as across models, if
 requested (See the [Reports](./report.md) section for more details).
 
@@ -178,10 +178,6 @@ analysis_models:
     constraints:
       perf_latency_p99:
         max: 15
-```
-
-```
-$ model-analyzer profile -f /path/to/config.yaml
 ```
 
 **Note**: The checkpoint directory should be removed between consecutive runs of

--- a/docs/config.md
+++ b/docs/config.md
@@ -81,6 +81,9 @@ profile_models: <comma-delimited-string-list>
 # Allow model analyzer to overwrite contents of the output model repository
 [ override_output_model_repository: <boolean> | default: false ]
 
+# Export path to be used
+[ export_path: <string> | default: '.' ]
+
 # Concurrency values to be used for the analysis
 [ concurrency: <comma-delimited-string|list|range> ]
 
@@ -183,6 +186,36 @@ profile_models: <comma-delimited-string-list>
 # Disables automatic config search
 [ run_config_search_disable: <bool> | default: false ]
 
+# Number of top configs to show in summary plots
+[ num_configs_per_model: <int> | default: 3]
+
+# Number of top model configs to save across ALL models, none saved by default
+[ num_top_model_configs: <int> | default: 0 ]
+
+# File name to be used for the model inference results
+[ filename_model_inference: <string> | default: metrics-model-inference.csv ]
+
+# File name to be used for the GPU metrics results
+[ filename_model_gpu: <string> | default: metrics-model-gpu.csv ]
+
+# File name to be used for storing the server only metrics.
+[ filename_server_only: <string> | default: metrics-server-only.csv ]
+
+# Specifies columns keys for model inference metrics table
+[ inference_output_fields: <comma-delimited-string-list> | default: See [Config Defaults](#config-defaults) section]
+
+# Specifies columns keys for model gpu metrics table
+[ gpu_output_fields: <comma-delimited-string-list> | default: See [Config Defaults](#config-defaults) section]
+
+# Specifies columns keys for server only metrics table
+[ server_output_fields: <comma-delimited-string-list> | default: See [Config Defaults](#config-defaults) section]
+
+# Shorthand that allows a user to specify a max latency constraint in ms
+[ latency_budget: <int>]
+
+# Shorthand that allows a user to specify a min throughput constraint
+[ min_throughput: <int>]
+
 # Specify path to config yaml file
 [ config_file: <string> ]
 ```
@@ -215,6 +248,12 @@ profile_models: <comma-delimited-string-list|list|profile_model>
 # Dict of name=value pairs containing metadata for the tritonserve docker container
 # launched in docker launch mode
 [ triton_docker_labels: <dict> ]
+
+# List of constraints placed on the config search results.
+[ constraints: <constraint> ]
+
+# List of objectives that user wants to sort the results by it.
+[ objectives: <objective|list> ]
 ```
 
 ## Config Options for `analyze`

--- a/docs/config.md
+++ b/docs/config.md
@@ -186,6 +186,9 @@ profile_models: <comma-delimited-string-list>
 # Disables automatic config search
 [ run_config_search_disable: <bool> | default: false ]
 
+# Skips the generation of analysis summary reports and tables
+[ skip_summary_reports: <bool> | default: false]
+
 # Number of top configs to show in summary plots
 [ num_configs_per_model: <int> | default: 3]
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -81,10 +81,10 @@ apt-get update && apt-get install wkhtmltopdf
 
 ---
 
-The [examples/quick-start](../examples/quick-start) directory is an example 
-[Triton Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) that contains a simple libtorch model which calculates 
-the sum and difference of two inputs. 
- 
+The [examples/quick-start](../examples/quick-start) directory is an example
+[Triton Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) that contains a simple libtorch model which calculates
+the sum and difference of two inputs.
+
 Run the Model Analyzer `profile` subcommand inside the container with:
 
 ```
@@ -92,6 +92,7 @@ model-analyzer profile \
     --model-repository <path-to-examples-quick-start> \
     --profile-models add_sub --triton-launch-mode=docker \
     --output-model-repository-path <path-to-output-model-repo>/<output_dir>
+    --export-path analysis_results
 ```
 
 **Important:** You must specify an `<output_dir>` subdirectory. You cannot have `--output-model-repository-path` point directly to `<path-to-output-model-repo>`
@@ -121,20 +122,8 @@ configuration:
 
 With these options, model analyzer will test 5 configs (4 new configs as well as the unmodified default add_sub config), and each config will have 2 experiments run on Perf Analyzer (concurrency=1 and concurrency=2). This significantly reduces the search space, and therefore, model analyzer's runtime.
 
-## `Step 4:` Generate Tables and Summary Reports
-
----
-
-In order to generate tables and summary reports, use the `analyze` subcommand as
-follows.
-
-```
-$ mkdir analysis_results
-$ model-analyzer analyze --analysis-models add_sub -e analysis_results
-```
-
 The measured data and summary report will be placed inside the
-`./analysis_results` directory. The directory should be structured as follows.
+`./analysis_results` directory. The directory will be structured as follows.
 
 ```
 $HOME


### PR DESCRIPTION
Updated CLI, config, and quick start documentation now that profile & analysis are combined.
I have still left the documentation for analysis in, but have indicated that it's usage has been combined with profile and we will be deprecating its usage in the near future.