### PR TITLE
Fix type checking failures in quick search algo

### DIFF
--- a/model_analyzer/config/generate/coordinate.py
+++ b/model_analyzer/config/generate/coordinate.py
@@ -17,7 +17,7 @@ from copy import copy
 
 class Coordinate:
     """
-    Class to define a coordinate in n-dimention space
+    Class to define a coordinate in n-dimension space
     """
 
     def __init__(self, val):
@@ -70,11 +70,10 @@ class Coordinate:
                 return False
         return True
 
-    @staticmethod
-    def round(coordinate: 'Coordinate') -> 'Coordinate':
-        for i, _ in enumerate(coordinate):
-            coordinate[i] = round(coordinate[i])
-        return coordinate
+    def round(self):
+        """ Rounds the coordinate in-place """
+        for i, _ in enumerate(self._values):
+            self._values[i] = round(self._values[i])
 
     def _add_coordinate(self, other):
         ret = Coordinate(self._values)

--- a/model_analyzer/config/generate/coordinate.py
+++ b/model_analyzer/config/generate/coordinate.py
@@ -70,11 +70,11 @@ class Coordinate:
                 return False
         return True
 
-    def __round__(self):
-        ret = Coordinate(self._values)
-        for i, _ in enumerate(ret):
-            ret[i] = round(ret[i])
-        return ret
+    @staticmethod
+    def round(coordinate: 'Coordinate') -> 'Coordinate':
+        for i, _ in enumerate(coordinate):
+            coordinate[i] = round(coordinate[i])
+        return coordinate
 
     def _add_coordinate(self, other):
         ret = Coordinate(self._values)
@@ -111,6 +111,17 @@ class Coordinate:
         for i, v in enumerate(self._values):
             ret[i] = v / other
         return ret
+
+    def __iter__(self):
+        self._idx = 0
+        return self
+
+    def __next__(self):
+        if self._idx < len(self._values):
+            val = self._values[self._idx]
+            self._idx += 1
+            return val
+        raise StopIteration
 
     def __str__(self):
         return str(self._values)

--- a/model_analyzer/config/generate/coordinate_data.py
+++ b/model_analyzer/config/generate/coordinate_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Tuple
 from model_analyzer.config.generate.coordinate import Coordinate
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 
@@ -30,7 +31,7 @@ class CoordinateData:
         """
         Return the measurement data of the given coordinate.
         """
-        key = tuple(coordinate)
+        key: Tuple[Coordinate, ...] = tuple(coordinate)
         return self._measurements.get(key, None)
 
     def set_measurement(self,
@@ -39,7 +40,7 @@ class CoordinateData:
         """
         Set the measurement for the given coordinate.
         """
-        key = tuple(coordinate)
+        key: Tuple[Coordinate, ...] = tuple(coordinate)
         self._measurements[key] = measurement
 
     def reset_measurements(self):
@@ -53,13 +54,13 @@ class CoordinateData:
         Get the visit count for the given coordinate. 
         Returns 0 if the coordinate hasn't been visited yet
         """
-        key = tuple(coordinate)
+        key: Tuple[Coordinate, ...] = tuple(coordinate)
         return self._visit_counts.get(key, 0)
 
     def increment_visit_count(self, coordinate: Coordinate):
         """
         Increase the visit count for the given coordinate by 1
         """
-        key = tuple(coordinate)
+        key: Tuple[Coordinate, ...] = tuple(coordinate)
         new_count = self.get_visit_count(coordinate) + 1
         self._visit_counts[key] = new_count

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -16,7 +16,7 @@ import math
 from itertools import product
 from copy import deepcopy
 
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 
 from model_analyzer.config.generate.coordinate import Coordinate
 from model_analyzer.config.generate.coordinate_data import CoordinateData
@@ -62,7 +62,7 @@ class Neighborhood:
         Return the euclidean distance between two coordinates
         """
 
-        distance = 0
+        distance = 0.0
         for i, _ in enumerate(coordinate1):
             diff = coordinate1[i] - coordinate2[i]
             distance += math.pow(diff, 2)
@@ -98,7 +98,8 @@ class Neighborhood:
         new_coordinate
             The new coordinate computed based on the neighborhood measurements.
         """
-        step_vector = round(self._get_step_vector() * magnitude)
+        step_vector = self._get_step_vector()
+        step_vector = Coordinate.round(step_vector * magnitude)
 
         if enable_clipping:
             step_vector = self._clip_coordinate_values(
@@ -121,7 +122,7 @@ class Neighborhood:
             coordinate[i] = max(-clip_value, min(coordinate[i], clip_value))
         return coordinate
 
-    def pick_coordinate_to_initialize(self) -> Coordinate:
+    def pick_coordinate_to_initialize(self) -> Optional[Coordinate]:
         """
         Based on the initialized coordinate values, pick an unvisited
         coordinate to initialize next.
@@ -141,7 +142,7 @@ class Neighborhood:
 
         return best_coordinate
 
-    def get_nearest_neighbor(self, coordinate_in: Coordinate) -> Coordinate:
+    def get_nearest_neighbor(self, coordinate_in: Coordinate) -> Optional[Coordinate]:
         """
         Find the nearest coordinate to the `coordinate_in` among the
         coordinates within the current neighborhood.
@@ -287,7 +288,7 @@ class Neighborhood:
         """
         visited_coordinates = self._get_visited_coordinates()
 
-        covered_values_per_dimension = [
+        covered_values_per_dimension: List[Dict[Coordinate, bool]] = [
             {} for _ in range(self._config.get_num_dimensions())
         ]
 

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -30,8 +30,7 @@ class Neighborhood:
     a 'home' coordinate
     """
 
-    def __init__(self,
-                 neighborhood_config: NeighborhoodConfig,
+    def __init__(self, neighborhood_config: NeighborhoodConfig,
                  home_coordinate: Coordinate):
         """
         Parameters
@@ -55,8 +54,7 @@ class Neighborhood:
         return self._coordinate_data
 
     @classmethod
-    def calc_distance(cls,
-                      coordinate1: Coordinate,
+    def calc_distance(cls, coordinate1: Coordinate,
                       coordinate2: Coordinate) -> float:
         """ 
         Return the euclidean distance between two coordinates
@@ -98,19 +96,18 @@ class Neighborhood:
         new_coordinate
             The new coordinate computed based on the neighborhood measurements.
         """
-        step_vector = self._get_step_vector()
-        step_vector = Coordinate.round(step_vector * magnitude)
+        step_vector = self._get_step_vector() * magnitude
+        step_vector.round()
 
         if enable_clipping:
-            step_vector = self._clip_coordinate_values(
-                coordinate=step_vector, clip_value=clip_value)
+            step_vector = self._clip_coordinate_values(coordinate=step_vector,
+                                                       clip_value=clip_value)
 
         tmp_new_coordinate = self._home_coordinate + step_vector
         new_coordinate = self._clamp_coordinate_to_bounds(tmp_new_coordinate)
         return new_coordinate
 
-    def _clip_coordinate_values(self,
-                                coordinate: Coordinate,
+    def _clip_coordinate_values(self, coordinate: Coordinate,
                                 clip_value: int) -> Coordinate:
         """
         Clip the coordinate values to be within the interval range of
@@ -142,7 +139,8 @@ class Neighborhood:
 
         return best_coordinate
 
-    def get_nearest_neighbor(self, coordinate_in: Coordinate) -> Optional[Coordinate]:
+    def get_nearest_neighbor(self,
+                             coordinate_in: Coordinate) -> Optional[Coordinate]:
         """
         Find the nearest coordinate to the `coordinate_in` among the
         coordinates within the current neighborhood.
@@ -173,15 +171,13 @@ class Neighborhood:
 
         return neighborhood
 
-    def _get_potential_neighborhood(self,
-                                    coordinate: Coordinate,
+    def _get_potential_neighborhood(self, coordinate: Coordinate,
                                     radius: int) -> List[Coordinate]:
         bounds = self._get_bounds(coordinate, radius)
         potential_values = self._enumerate_all_values_in_bounds(bounds)
         return [Coordinate(x) for x in potential_values]
 
-    def _get_bounds(self,
-                    coordinate: Coordinate,
+    def _get_bounds(self, coordinate: Coordinate,
                     radius: int) -> List[List[int]]:
         bounds = []
         for i in range(self._config.get_num_dimensions()):
@@ -193,8 +189,8 @@ class Neighborhood:
             bounds.append([lower_bound, upper_bound])
         return bounds
 
-    def _enumerate_all_values_in_bounds(self,
-                                        bounds: List[List[int]]) -> List[List[int]]:
+    def _enumerate_all_values_in_bounds(
+            self, bounds: List[List[int]]) -> List[List[int]]:
         possible_index_values = []
         for bound in bounds:
             possible_index_values.append(list(range(bound[0], bound[1])))
@@ -242,8 +238,8 @@ class Neighborhood:
         step_vector /= len(vectors)
         return step_vector
 
-    def _compile_neighborhood_measurements(self) -> Tuple[List[Coordinate],
-                                                          List[RunConfigMeasurement]]:
+    def _compile_neighborhood_measurements(
+            self) -> Tuple[List[Coordinate], List[RunConfigMeasurement]]:
         """
         Gather all the vectors (directions from the home coordinate)
         and their corresponding measurements.
@@ -298,10 +294,9 @@ class Neighborhood:
 
         return covered_values_per_dimension
 
-    def _get_num_uncovered_values(self,
-                                  coordinate: Coordinate,
-                                  covered_values_per_dimension: List[Dict[Coordinate, bool]]
-                                  ) -> int:
+    def _get_num_uncovered_values(
+            self, coordinate: Coordinate,
+            covered_values_per_dimension: List[Dict[Coordinate, bool]]) -> int:
         """
         Determine how many of the coordinate dimensions in the input coordinate have values
         that are not covered in covered_values_per_dimension

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Dict, List, Union, Optional, Generator
 
 from .config_generator_interface import ConfigGeneratorInterface
 
@@ -90,7 +90,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         # Track the best coordinate seen so far that can be used during
         # the back-off stage.
         self._best_coordinate = self._home_coordinate
-        self._best_measurement = None
+        self._best_measurement: Optional[RunConfigMeasurement] = None
 
         self._magnitude_scaler = 1.0
 
@@ -103,7 +103,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
     def _is_done(self) -> bool:
         return self._done
 
-    def get_configs(self) -> RunConfig:
+    def get_configs(self) -> Generator[RunConfig, None, None]:
         """
         Returns
         -------
@@ -135,7 +135,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             logger.info("No coordinate to measure. Exiting")
             self._done = True
 
-    def set_last_results(self, measurements: List[RunConfigMeasurement]):
+    def set_last_results(self, measurements: List[Union[RunConfigMeasurement,
+                                                        None]]):
         """
         Given the results from the last RunConfig, make decisions
         about future configurations to generate
@@ -155,7 +156,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         self._update_best_measurement(measurements)
 
-    def _update_best_measurement(self, measurements: List[RunConfigMeasurement]):
+    def _update_best_measurement(self, measurements: List[Union[RunConfigMeasurement,
+                                                                None]]):
         """Keep track of the best coordinate/measurement seen so far."""
         measurement = measurements[0]
 
@@ -223,7 +225,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
     def _get_coordinate_values(self,
                                coordinate: Coordinate,
-                               key: int) -> int:
+                               key: int) -> Dict[str, Union[int, float]]:
         dims = self._search_config.get_dimensions()
         values = dims.get_values_for_coordinate(coordinate)
         return values[key]
@@ -301,7 +303,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self._models[model_num].perf_analyzer_flags())
         return perf_analyzer_config
 
-    def _print_debug_logs(self, measurements: List[RunConfigMeasurement]):
+    def _print_debug_logs(self, measurements: List[Union[RunConfigMeasurement,
+                                                         None]]):
         if measurements is not None and measurements[0] is not None:
             assert len(measurements) == 1
 

--- a/tests/test_coordinate.py
+++ b/tests/test_coordinate.py
@@ -92,8 +92,8 @@ class TestCoordinate(trc.TestResultCollector):
 
     def test_round(self):
         c1 = Coordinate([0.1, 4.6, 3.9])
-        c2 = Coordinate.round(c1)
-        self.assertEqual(c2, Coordinate([0, 5, 4]))
+        c1.round()
+        self.assertEqual(c1, Coordinate([0, 5, 4]))
 
     def test_iterator(self):
         c1 = Coordinate([2, 4, 1, 7])

--- a/tests/test_coordinate.py
+++ b/tests/test_coordinate.py
@@ -92,7 +92,7 @@ class TestCoordinate(trc.TestResultCollector):
 
     def test_round(self):
         c1 = Coordinate([0.1, 4.6, 3.9])
-        c2 = round(c1)
+        c2 = Coordinate.round(c1)
         self.assertEqual(c2, Coordinate([0, 5, 4]))
 
     def test_iterator(self):


### PR DESCRIPTION
* Fix or add missing type hints
* Make Coordinate class to be iterable for compatibility with tuple type hints
* Avoid `round` operator overloading in Coordinate class since Python expects round operator to return integer
* Fix test case