### PR TITLE
Remove wkhtmltopdf requirement from docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -57,15 +57,7 @@ This ensures the Triton SDK container has access to the model
 config variants that Model Analyzer creates.<br><br>
 **Important:** You must ensure the `<path-to-output-model-repo>` is identical on both sides of the mount<br><br>
 
-**4. Add PDF support to the container**  
-Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
-`wkhtmltopdf`:
-
-```
-apt-get update && apt-get install wkhtmltopdf
-```
-
-**5. Run Model Analyzer with Docker Launch Mode**  
+**4. Run Model Analyzer with Docker Launch Mode**  
 Be sure to use `--triton-launch-mode=docker`, when running Model Analyzer.<br><br>
 
 # Alternative Installation Methods

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -69,14 +69,6 @@ This ensures the Triton SDK container has access to the model
 config variants that Model Analyzer creates.<br><br>
 **Important:** You must ensure the absolutes paths are identical on both sides of the mounts<br><br>
 
-**3. Add PDF support to the container**  
-Model Analyzer uses `pdfkit` for report generation. Once inside the Triton SDK container, you will need to install
-`wkhtmltopdf`:
-
-```
-apt-get update && apt-get install wkhtmltopdf
-```
-
 ## `Step 3:` Profile the `add_sub` model
 
 ---


### PR DESCRIPTION
wkhtmltopdf is available in sdk container and will be installed with a wheel or pip install. There is no need to mention it in any docs