### PR TITLE
Explicitly pull the container in docker mode

### DIFF
--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -68,6 +68,9 @@ class TritonServerDocker(TritonServer):
         assert self._server_config['model-repository'], \
             "Triton Server requires --model-repository argument to be set."
 
+        logger.info(f"Pulling docker image {self._tritonserver_image}")
+        self._docker_client.images.pull(self._tritonserver_image)
+
     def start(self, env=None):
         """
         Starts the tritonserver docker container using docker-py


### PR DESCRIPTION
**Old code** would look like it was hanging while it was pulling the container the first time:

First time running when container image hasn't been pulled yet:
```
15:16:30 [Model Analyzer] Profiling server only metrics...
15:18:26 [Model Analyzer] DEBUG: Triton Server started.
```

Second time:
```
15:24:29 [Model Analyzer] Profiling server only metrics...
15:24:30 [Model Analyzer] DEBUG: Triton Server started.
```

**New code** will call out the pull, so it is clear why there is a delay

First time running when container image hasn't been pulled yet:
```
15:47:14 [Model Analyzer] Starting a Triton Server using docker
15:47:14 [Model Analyzer] Pulling docker image nvcr.io/nvidia/tritonserver:22.07-py3
15:49:02 [Model Analyzer] No checkpoint file found, starting a fresh run.
15:49:02 [Model Analyzer] Profiling server only metrics...
15:49:05 [Model Analyzer] DEBUG: Triton Server started.
```

Second time:
```
15:53:54 [Model Analyzer] Starting a Triton Server using docker
15:53:54 [Model Analyzer] Pulling docker image nvcr.io/nvidia/tritonserver:22.07-py3
15:53:55 [Model Analyzer] No checkpoint file found, starting a fresh run.
15:53:55 [Model Analyzer] Profiling server only metrics...
15:53:56 [Model Analyzer] DEBUG: Triton Server started.
```