### PR TITLE
Enable constraints-aided search in quick algo

### DIFF
--- a/experiments/evaluate_config_generator.py
+++ b/experiments/evaluate_config_generator.py
@@ -62,4 +62,8 @@ class EvaluateConfigGenerator:
             self._profile_data.add_run_config_measurement(
                 run_config, run_config_measurement)
 
+            if run_config_measurement:
+                run_config_measurement.set_model_config_constraints(
+                    model_config_constraints=[self._config_command.constraints])
+
             cg.set_last_results([run_config_measurement])

--- a/model_analyzer/config/generate/coordinate_data.py
+++ b/model_analyzer/config/generate/coordinate_data.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from typing import Tuple, Optional
 from model_analyzer.config.generate.coordinate import Coordinate
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 
@@ -27,16 +27,16 @@ class CoordinateData:
         self._measurements = {}
         self._visit_counts = {}
 
-    def get_measurement(self, coordinate: Coordinate) -> RunConfigMeasurement:
+    def get_measurement(
+            self, coordinate: Coordinate) -> Optional[RunConfigMeasurement]:
         """
         Return the measurement data of the given coordinate.
         """
         key: Tuple[Coordinate, ...] = tuple(coordinate)
         return self._measurements.get(key, None)
 
-    def set_measurement(self,
-                        coordinate: Coordinate,
-                        measurement: RunConfigMeasurement):
+    def set_measurement(self, coordinate: Coordinate,
+                        measurement: Optional[RunConfigMeasurement]):
         """
         Set the measurement for the given coordinate.
         """

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -97,11 +97,11 @@ class Neighborhood:
             The new coordinate computed based on the neighborhood measurements.
         """
         step_vector = self._get_step_vector() * magnitude
-        step_vector.round()
 
         if enable_clipping:
             step_vector = self._clip_vector_values(vector=step_vector,
                                                    clip_value=clip_value)
+        step_vector.round()
 
         tmp_new_coordinate = self._home_coordinate + step_vector
         new_coordinate = self._clamp_coordinate_to_bounds(tmp_new_coordinate)
@@ -134,7 +134,7 @@ class Neighborhood:
 
         if max_value > clip_value and max_value != 0:
             for i in range(len(vector)):
-                vector[i] = round(clip_value * vector[i]/max_value)
+                vector[i] = clip_value * vector[i]/max_value
         return vector
 
     def pick_coordinate_to_initialize(self) -> Optional[Coordinate]:

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -111,10 +111,9 @@ class Neighborhood:
                             clip_value: int) -> Coordinate:
         """
         Clip the values of the vector to be within the range of
-        [-clip_value, clip_value]. The clipping **approximately** preserves
-        the direction of the vector (e.g. if the clip_value is 2, then
-        [10, 5] will be clipped to [2, 1] instead of [2, 2]). It may not
-        be exact due to the rounding of the values at the end.
+        [-clip_value, clip_value]. The clipping preserves the direction
+        of the vector (e.g. if the clip_value is 2, then [10, 5] will be
+        clipped to [2, 1] instead of [2, 2]).
 
         Parameters
         ----------

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -303,8 +303,10 @@ class Neighborhood:
                                           ) -> Coordinate:
         """
         Calculate a step vector that steps toward the coordinates that
-        pass the constraints. If no vectors are provided, continue with
-        measurements that are not passing constraints (but is still better).
+        pass the constraints (set default weights to 1.0). When no vectors
+        are provided (meaning there are no neighbors passing constraints),
+        continue with the neighbors that are not passing constraints by
+        comparing how much they are close to passing constraints.
 
         Parameters
         ----------
@@ -328,7 +330,12 @@ class Neighborhood:
                 vectors=vectors, measurements=measurements)
 
         for vector, measurement in zip(vectors, measurements):
-            weight = self._home_measurement.compare_constraints(measurement)
+            if measurement.is_passing_constraints():
+                weight = 1.0  # when home fails & neighbor passes
+            else:
+                weight = self._home_measurement.compare_constraints(
+                    other=measurement)
+
             step_vector += vector * weight
 
         step_vector /= len(vectors)
@@ -337,7 +344,7 @@ class Neighborhood:
     def _get_all_visited_measurements(
             self) -> Tuple[List[Coordinate], List[RunConfigMeasurement]]:
         """
-        Gather all the vectors (directions from the home coordinate)
+        Gather all the visited vectors (directions from the home coordinate)
         and their corresponding measurements.
 
         Returns

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -23,10 +23,6 @@ from model_analyzer.config.generate.coordinate_data import CoordinateData
 from model_analyzer.config.generate.search_config import NeighborhoodConfig
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 
-from model_analyzer.constants import LOGGER_NAME
-import logging
-logger = logging.getLogger(LOGGER_NAME)
-
 
 class Neighborhood:
     """
@@ -39,9 +35,9 @@ class Neighborhood:
         """
         Parameters
         ----------
-        neighborhood_config:
+        neighborhood_config: 
             NeighborhoodConfig object
-        home_coordinate:
+        home_coordinate: 
             Coordinate object to center the neighborhood around
         """
         assert type(neighborhood_config) == NeighborhoodConfig
@@ -60,7 +56,7 @@ class Neighborhood:
     @classmethod
     def calc_distance(cls, coordinate1: Coordinate,
                       coordinate2: Coordinate) -> float:
-        """
+        """ 
         Return the euclidean distance between two coordinates
         """
 
@@ -102,12 +98,10 @@ class Neighborhood:
         """
         step_vector = self._get_step_vector() * magnitude
         step_vector.round()
-        logger.debug(f"(Measurement) Step vector: {step_vector}")
 
         if enable_clipping:
             step_vector = self._clip_vector_values(vector=step_vector,
                                                    clip_value=clip_value)
-            logger.debug(f"(Measurement) Clipped Step vector: {step_vector}")
 
         tmp_new_coordinate = self._home_coordinate + step_vector
         new_coordinate = self._clamp_coordinate_to_bounds(tmp_new_coordinate)
@@ -264,13 +258,11 @@ class Neighborhood:
         assert home_measurement is not None, "Home measurement cannot be NoneType."
 
         if home_measurement.is_passing_constraints():
-            logger.debug(f"(Measurement) Home Coordinate passed constraints.")
             step_vector = self._optimize_for_better_objectives(
                 home_measurement=home_measurement,
                 vectors=vectors,
                 measurements=measurements)
         else:
-            logger.debug(f"(Measurement) Home Coordinate falied constraints.")
             step_vector = self._optimize_for_passing_constraints(
                 home_measurement=home_measurement,
                 vectors=vectors,
@@ -303,19 +295,13 @@ class Neighborhood:
         step_vector = Coordinate([0] * self._config.get_num_dimensions())
 
         if not vectors:
-            logger.debug(f"(Measurement) No neighbors passing constraints. ")
-            logger.debug(f"(Measurement) Returning zero step vector.")
             return step_vector
 
-        logger.debug(f"(Measurement) Neigbors with passing constraints exists.")
-        logger.debug(f"(Measurement) Optimizing for objective...")
         for vector, measurement in zip(vectors, measurements):
             weight = home_measurement.compare_measurements(measurement)
             step_vector += vector * weight
-            logger.debug(f"(Measurement)\t vector: {vector}, weight: {weight}")
 
         step_vector /= len(vectors)
-        logger.debug(f"(Measurement)\t Initial step vector: {step_vector}")
         return step_vector
 
     def _optimize_for_passing_constraints(self,
@@ -347,23 +333,18 @@ class Neighborhood:
         step_vector = Coordinate([0] * self._config.get_num_dimensions())
 
         if not vectors:
-            logger.debug(f"(Measurement) No neighbors passing constraints. ")
-            logger.debug(f"(Measurement) Compare failing constraints.")
             vectors, measurements = self._get_all_visited_measurements()
             return self._optimize_for_passing_constraints(
                 home_measurement, vectors=vectors, measurements=measurements)
 
-        logger.debug(f"(Measurement) Optimizing for constraints...")
         for vector, measurement in zip(vectors, measurements):
             weight = home_measurement.compare_constraints(measurement)
             if measurement.is_passing_constraints():
                 weight = 1.0  # when home fails & neighbor passes
 
             step_vector += vector * weight
-            logger.debug(f"(Measurement)\t vector: {vector}, weight: {weight}")
 
         step_vector /= len(vectors)
-        logger.debug(f"(Measurement)\t Initial step vector: {step_vector}")
         return step_vector
 
     def _get_all_visited_measurements(

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -81,7 +81,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         # This is an initial center that the neighborhood is built around.
         # It is updated every new creation of the neighborhood.
-        self._home_coordinate  = self._get_starting_coordinate()
+        self._home_coordinate = self._get_starting_coordinate()
 
         # This is the coordinate that we want to measure next. It is
         # updated every step of this generator
@@ -163,22 +163,28 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self._best_coordinate = self._coordinate_to_measure
             self._best_measurement = measurement
 
-        elif not self._best_measurement.is_passing_constraints() \
-            and measurement.is_passing_constraints():
+        elif not self._best_measurement.is_passing_constraints(
+        ) and measurement.is_passing_constraints():
             self._best_coordinate = self._coordinate_to_measure
             self._best_measurement = measurement
 
-        elif not self._best_measurement.is_passing_constraints() \
-            and not measurement.is_passing_constraints() \
-            and self._best_measurement.compare_constraints(measurement) > 0:
-            self._best_coordinate = self._coordinate_to_measure
-            self._best_measurement = measurement
+        elif not self._best_measurement.is_passing_constraints(
+        ) and not measurement.is_passing_constraints():
+            comparison = self._best_measurement.compare_constraints(
+                other=measurement)
 
-        elif self._best_measurement.is_passing_constraints() \
-            and measurement.is_passing_constraints() \
-            and self._best_measurement.compare_measurements(measurement) > 0:
-            self._best_coordinate = self._coordinate_to_measure
-            self._best_measurement = measurement
+            if comparison and comparison > 0:
+                self._best_coordinate = self._coordinate_to_measure
+                self._best_measurement = measurement
+
+        elif self._best_measurement.is_passing_constraints(
+        ) and measurement.is_passing_constraints():
+            comparison = self._best_measurement.compare_measurements(
+                other=measurement)
+
+            if comparison and comparison > 0:
+                self._best_coordinate = self._coordinate_to_measure
+                self._best_measurement = measurement
 
     def _get_last_results(self) -> RunConfigMeasurement:
         return self._neighborhood.coordinate_data.get_measurement(
@@ -326,10 +332,14 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             latency = measurements[0].get_non_gpu_metric_value(
                 "perf_latency_p99")
 
-            best_throughput = self._best_measurement.get_non_gpu_metric_value(
-                "perf_throughput")
-            best_latency = self._best_measurement.get_non_gpu_metric_value(
-                "perf_latency_p99")
+            if self._best_measurement:
+                best_throughput = self._best_measurement.get_non_gpu_metric_value(
+                    "perf_throughput")
+                best_latency = self._best_measurement.get_non_gpu_metric_value(
+                    "perf_latency_p99")
+            else:
+                best_throughput = None
+                best_latency = None
 
             logger.debug(
                 f"Measurement for {self._coordinate_to_measure}: "

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -310,12 +310,12 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
             throughput = measurements[0].get_non_gpu_metric_value(
                 "perf_throughput")
-            avg_latency = measurements[0].get_non_gpu_metric_value(
-                "perf_latency_avg")
+            latency = measurements[0].get_non_gpu_metric_value(
+                "perf_latency_p99")
 
             logger.debug(
                 f"Measurement for {self._coordinate_to_measure}: "
-                f"throughput = {throughput}, avg_latency = {avg_latency}"
+                f"throughput = {throughput}, latency = {latency}"
             )
         else:
             logger.debug(

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -99,6 +99,11 @@ class ModelManager:
             else:
                 logger.info("Skipping illegal run configuration")
                 measurement = None
+
+            if measurement:
+                measurement.set_model_config_constraints(
+                    model_config_constraints=[self._config.constraints])
+
             rcg.set_last_results([measurement])
 
         self._metrics_manager.finalize()

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -33,7 +33,7 @@ class TestNeighborhood(trc.TestResultCollector):
         # yapf: disable
         non_gpu_metric_values = [{
             "perf_throughput": throughput,
-            "perf_latency_avg": latency
+            "perf_latency_p99": latency
         }]
         # yapf: enable
 
@@ -107,42 +107,56 @@ class TestNeighborhood(trc.TestResultCollector):
 
         # Start with 0 initialized
         self.assertEqual(0, len(n._get_visited_coordinates()))
+        self.assertEqual(0, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Home coordinate is ignored. No change to num initialized/visited.
         n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
         self.assertEqual(0, len(n._get_visited_coordinates()))
+        self.assertEqual(0, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Incremented to 1 initialized
         n.coordinate_data.set_measurement(Coordinate([0, 0, 0]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([0, 0, 0]))
         self.assertEqual(1, len(n._get_visited_coordinates()))
+        self.assertEqual(1, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set same point. No change to num initialized
         n.coordinate_data.set_measurement(Coordinate([0, 0, 0]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([0, 0, 0]))
         self.assertEqual(1, len(n._get_visited_coordinates()))
+        self.assertEqual(1, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set a point outside of neighborhood
         n.coordinate_data.set_measurement(Coordinate([0, 0, 4]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([0, 0, 4]))
         self.assertEqual(1, len(n._get_visited_coordinates()))
+        self.assertEqual(1, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set a third point inside of neighborhood
         n.coordinate_data.set_measurement(Coordinate([1, 0, 0]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([1, 0, 0]))
         self.assertEqual(2, len(n._get_visited_coordinates()))
+        self.assertEqual(2, len(n._get_initialized_coordinates()))
+        self.assertFalse(n.enough_coordinates_initialized())
+
+        # Set the none measurement. No changed to num initialized.
+        n.coordinate_data.set_measurement(Coordinate([0, 1, 1]), None)
+        n.coordinate_data.increment_visit_count(Coordinate([0, 1, 1]))
+        self.assertEqual(3, len(n._get_visited_coordinates()))
+        self.assertEqual(2, len(n._get_initialized_coordinates()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set the last point inside of neighborhood
         n.coordinate_data.set_measurement(Coordinate([1, 1, 0]), rcm)
         n.coordinate_data.increment_visit_count(Coordinate([1, 1, 0]))
-        self.assertEqual(3, len(n._get_visited_coordinates()))
+        self.assertEqual(4, len(n._get_visited_coordinates()))
+        self.assertEqual(3, len(n._get_initialized_coordinates()))
         self.assertTrue(n.enough_coordinates_initialized())
 
     def test_clip_vector_values(self):
@@ -183,7 +197,113 @@ class TestNeighborhood(trc.TestResultCollector):
         c = n._clip_vector_values(Coordinate([0, 0]), clip_value=2)
         self.assertEqual(c, Coordinate([0, 0]))
 
-    def test_step_vector(self):
+    def test_get_all_visited_measurements(self):
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        rcm0 = self._construct_rcm(throughput=100, latency=50)
+        rcm1 = self._construct_rcm(throughput=700, latency=350)
+        rcm2 = self._construct_rcm(throughput=300, latency=130)
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), None)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+
+        expected_vectors = [
+            Coordinate([1, 2, 1]) - Coordinate([1, 1, 1]),
+            Coordinate([2, 1, 1]) - Coordinate([1, 1, 1])
+        ]
+        expected_measurements = [rcm2, rcm1]
+
+        vectors, measurements = n._get_all_visited_measurements()
+        for ev, em in zip(expected_vectors, expected_measurements):
+            self.assertTrue(ev in vectors)
+            self.assertTrue(em in measurements)
+
+
+    def test_get_constraints_passing_measurements(self):
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        # Constraints:
+        #   - Minimum throughput of 100 infer/sec
+        #   - Maximum latency of 300 ms
+        constraints = {
+            "perf_throughput" : {
+                "min": 100
+            },
+            "perf_latency_p99" : {
+                "max": 300
+            }
+        }
+
+        rcm0 = self._construct_rcm(throughput=100, latency=50)  # pass
+        rcm0.set_model_config_constraints([constraints])
+
+        rcm1 = self._construct_rcm(throughput=700, latency=350)  # fail
+        rcm1.set_model_config_constraints([constraints])
+
+        rcm2 = self._construct_rcm(throughput=300, latency=130)  # pass
+        rcm2.set_model_config_constraints([constraints])
+
+        rcm3 = self._construct_rcm(throughput=400, latency=290)  # pass
+        rcm3.set_model_config_constraints([constraints])
+
+        rcm4 = self._construct_rcm(throughput=850, latency=400)  # fail
+        rcm4.set_model_config_constraints([constraints])
+
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 2]), rcm3)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 2]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), rcm4)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+
+        expected_vectors = [
+            Coordinate([1, 1, 2]) - Coordinate([1, 1, 1]),
+            Coordinate([1, 2, 1]) - Coordinate([1, 1, 1])
+        ]
+        expected_measurements = [rcm3, rcm2]
+
+        vectors, measurements = n._get_constraints_passing_measurements()
+        for ev, em in zip(expected_vectors, expected_measurements):
+            self.assertTrue(ev in vectors)
+            self.assertTrue(em in measurements)
+
+    def test_step_vector_no_constraints(self):
         """
         Test _get_step_vector method that determines the direction to step
         towards from the home coordinate using the collected coordinates
@@ -227,6 +347,287 @@ class TestNeighborhood(trc.TestResultCollector):
 
         step_vector = n._get_step_vector()
         expected_step_vector = Coordinate([3/4, 1/2, 0])
+        self.assertEqual(step_vector, expected_step_vector)
+
+    def test_step_vector_both_home_and_neighbors_passing_constraints(self):
+        """
+        Test _get_step_vector method with constraints specified. Tests if
+        the method properly handles the following case:
+            - the home coordinate passes the constraints
+            - some neighbor coordinates pass the constraints
+
+          1. Get vectors and measurements tuples that are passing constraints.
+                [1, 2, 1] - [1, 1, 1] = [0, 1, 0] (throughput=300, latency=130)
+                [1, 1, 2] - [1, 1, 1] = [0, 0, 1] (throughput=400, latency=290)
+
+          2. Multiply each vectors by its weights (**objective comparison**):
+                [0, 1, 0] * 1.0 = [0, 1, 0]
+                [0, 0, 1] * 1.2 = [0, 0, 1.2]
+
+          2. Compute the average of the vectors:
+                ([0, 1, 0] + [0, 0, 1.2]) / 2 = [0, 1/2, 3/5]
+        """
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        # Constraints:
+        #   - Minimum throughput of 100 infer/sec
+        #   - Maximum latency of 300 ms
+        constraints = {
+            "perf_throughput" : {
+                "min": 100
+            },
+            "perf_latency_p99" : {
+                "max": 300
+            }
+        }
+
+        rcm0 = self._construct_rcm(throughput=100, latency=50)  # pass
+        rcm0.set_model_config_constraints([constraints])
+
+        rcm1 = self._construct_rcm(throughput=700, latency=350)  # fail
+        rcm1.set_model_config_constraints([constraints])
+
+        rcm2 = self._construct_rcm(throughput=300, latency=130)  # pass
+        rcm2.set_model_config_constraints([constraints])
+
+        rcm3 = self._construct_rcm(throughput=400, latency=290)  # pass
+        rcm3.set_model_config_constraints([constraints])
+
+        rcm4 = self._construct_rcm(throughput=850, latency=400)  # fail
+        rcm4.set_model_config_constraints([constraints])
+
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 2]), rcm3)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 2]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), rcm4)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+
+        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        self.assertTrue(hm.is_passing_constraints())
+
+        step_vector = n._get_step_vector()
+        expected_step_vector = Coordinate([0, 1/2, 3/5])
+        self.assertEqual(step_vector, expected_step_vector)
+
+    def test_step_vector_only_home_passing_constraints(self):
+        """
+        Test _get_step_vector method with constraints specified. Tests if
+        the method properly handles the following case:
+            - the home coordinate passes the constraints
+            - neighbor coordinates all fail the constraints
+        """
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        # Constraints:
+        #   - Minimum throughput of 100 infer/sec
+        #   - Maximum latency of 300 ms
+        constraints = {
+            "perf_throughput" : {
+                "min": 100
+            },
+            "perf_latency_p99" : {
+                "max": 300
+            }
+        }
+
+        rcm0 = self._construct_rcm(throughput=100, latency=50)  # pass
+        rcm0.set_model_config_constraints([constraints])
+
+        rcm1 = self._construct_rcm(throughput=700, latency=350)  # fail
+        rcm1.set_model_config_constraints([constraints])
+
+        rcm2 = self._construct_rcm(throughput=850, latency=400)  # fail
+        rcm2.set_model_config_constraints([constraints])
+
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+
+        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        self.assertTrue(hm.is_passing_constraints())
+
+        step_vector = n._get_step_vector()
+        expected_step_vector = Coordinate([0, 0, 0])
+        self.assertEqual(step_vector, expected_step_vector)
+
+    def test_step_vector_only_home_failing_constraints(self):
+        """
+        Test _get_step_vector method with constraints specified. Tests if
+        the method properly handles the following case:
+            - the home coordinate fails the constraints
+            - some neighbor coordinates pass the constraints
+
+          1. Get vectors and measurements tuples that are passing constraints.
+                [1, 2, 1] - [1, 1, 1] = [0, 1, 0] (throughput=300, latency=130)
+                [1, 1, 2] - [1, 1, 1] = [0, 0, 1] (throughput=400, latency=290)
+
+          2. Multiply each vectors by its weights (set default to 1.0):
+                [0, 1, 0] * 1.0 = [0, 1, 0]
+                [0, 0, 1] * 1.0 = [0, 0, 1]
+
+          2. Compute the average of the vectors:
+                ([0, 1, 0] + [0, 0, 1]) / 2 = [0, 1/2, 1/2]
+        """
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        # Constraints:
+        #   - Minimum throughput of 100 infer/sec
+        #   - Maximum latency of 300 ms
+        constraints = {
+            "perf_throughput" : {
+                "min": 100
+            },
+            "perf_latency_p99" : {
+                "max": 300
+            }
+        }
+
+        rcm0 = self._construct_rcm(throughput=80, latency=50)  # fail
+        rcm0.set_model_config_constraints([constraints])
+
+        rcm1 = self._construct_rcm(throughput=700, latency=350)  # fail
+        rcm1.set_model_config_constraints([constraints])
+
+        rcm2 = self._construct_rcm(throughput=300, latency=130)  # pass
+        rcm2.set_model_config_constraints([constraints])
+
+        rcm3 = self._construct_rcm(throughput=400, latency=290)  # pass
+        rcm3.set_model_config_constraints([constraints])
+
+        rcm4 = self._construct_rcm(throughput=850, latency=400)  # fail
+        rcm4.set_model_config_constraints([constraints])
+
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 2]), rcm3)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 2]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), rcm4)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+
+        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        self.assertFalse(hm.is_passing_constraints())
+
+        step_vector = n._get_step_vector()
+        expected_step_vector = Coordinate([0, 1/2, 1/2])
+        self.assertEqual(step_vector, expected_step_vector)
+
+    def test_step_vector_both_home_and_neighbors_failing_constraints(self):
+        """
+        Test _get_step_vector method with constraints specified. Tests if
+        the method properly handles the following case:
+            - the home coordinate fails the constraints
+            - neighbor coordinates all fails the constraints
+
+          1. Get vectors and measurements tuples that are failing constraints.
+                [2, 1, 1] - [1, 1, 1] = [1, 0, 0] (throughput=700, latency=360)
+                [1, 2, 1] - [1, 1, 1] = [0, 1, 0] (throughput=850, latency=540)
+
+          2. Multiply each vectors by its weights (**constraint comparison**):
+                [1, 0, 0] *  0.3 = [0.3,    0, 0]
+                [0, 1, 0] * -0.3 = [  0, -0.3, 0]
+
+          2. Compute the average of the vectors:
+                ([0.3, 0, 0] + [0, -0.3, 0]) / 2 = [0.15, -0.15, 0]
+        """
+        dims = SearchDimensions()
+        dims.add_dimensions(0, [
+            SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("foobar",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+        ])
+
+        nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
+        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+
+        # Constraints:
+        #   - Minimum throughput of 100 infer/sec
+        #   - Maximum latency of 300 ms
+        constraints = {
+            "perf_throughput" : {
+                "min": 100
+            },
+            "perf_latency_p99" : {
+                "max": 300
+            }
+        }
+
+        rcm0 = self._construct_rcm(throughput=500, latency=450)  # fail
+        rcm0.set_model_config_constraints([constraints])
+
+        rcm1 = self._construct_rcm(throughput=700, latency=360)  # fail
+        rcm1.set_model_config_constraints([constraints])
+
+        rcm2 = self._construct_rcm(throughput=850, latency=540)  # fail
+        rcm2.set_model_config_constraints([constraints])
+
+
+        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+
+        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+
+        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        self.assertFalse(hm.is_passing_constraints())
+
+        step_vector = n._get_step_vector()
+        expected_step_vector = Coordinate([0.15, -0.15, 0])
         self.assertEqual(step_vector, expected_step_vector)
 
     def test_calculate_new_coordinate_one_dimension(self):

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -177,7 +177,7 @@ class TestNeighborhood(trc.TestResultCollector):
         c = n._clip_vector_values(Coordinate([10, 5]), clip_value=2)
         self.assertEqual(c, Coordinate([2, 1]))
         c = n._clip_vector_values(Coordinate([100, 5]), clip_value=2)
-        self.assertEqual(c, Coordinate([2, 0]))
+        self.assertEqual(c, Coordinate([2, 0.1]))
 
         # Test if it clips large, negative values
         c = n._clip_vector_values(Coordinate([-10, 5]), clip_value=2)
@@ -185,7 +185,7 @@ class TestNeighborhood(trc.TestResultCollector):
         c = n._clip_vector_values(Coordinate([-10, -5]), clip_value=2)
         self.assertEqual(c, Coordinate([-2, -1]))
         c = n._clip_vector_values(Coordinate([-100, 5]), clip_value=2)
-        self.assertEqual(c, Coordinate([-2, 0]))
+        self.assertEqual(c, Coordinate([-2, 0.1]))
 
         # Test if it skips clipping if values are within range
         c = n._clip_vector_values(Coordinate([1, 0]), clip_value=2)
@@ -298,7 +298,7 @@ class TestNeighborhood(trc.TestResultCollector):
         ]
         expected_measurements = [rcm3, rcm2]
 
-        vectors, measurements = n._get_constraints_passing_measurements()
+        vectors, measurements = n._get_measurements_passing_constraints()
         for ev, em in zip(expected_vectors, expected_measurements):
             self.assertTrue(ev in vectors)
             self.assertTrue(em in measurements)


### PR DESCRIPTION
* Allow quick algo to adjust search based on constraints provided
* Compare constraints when both home and neighbors are all failing the constraints ([#489](https://github.com/triton-inference-server/model_analyzer/pull/489))
* Add test cases