### PR TITLE
Updating printing of GPU names and max memory

### DIFF
--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
 
-from model_analyzer.result.run_config_measurement import RunConfigMeasurement
+if TYPE_CHECKING:
+    from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 from model_analyzer.constants import LOGGER_NAME, TOP_MODELS_REPORT_KEY
 from model_analyzer.result.constraint_manager import ConstraintManager
 from model_analyzer.record.metrics_manager import MetricsManager
@@ -873,7 +874,8 @@ class ReportManager:
         return len(self._gpu_info)
 
     def _get_gpu_stats(
-            self, measurements: List[RunConfigMeasurement]) -> Tuple[str, str]:
+            self,
+            measurements: List["RunConfigMeasurement"]) -> Tuple[str, str]:
         """
         Gets names and max total memory of GPUs used in measurements
 
@@ -881,8 +883,8 @@ class ReportManager:
         """
 
         gpu_dict = {}
-        for measurement in measurements:
-            for gpu_uuid, gpu_info in self._gpu_info.items():
+        for gpu_uuid, gpu_info in self._gpu_info.items():
+            for measurement in measurements:
                 if gpu_uuid in measurement.gpus_used():
                     gpu_name = gpu_info['name']
                     max_memory = round(gpu_info['total_memory'] / (2**30), 1)
@@ -890,6 +892,7 @@ class ReportManager:
                         gpu_dict[gpu_name] = {"memory": max_memory, "count": 1}
                     else:
                         gpu_dict[gpu_name]["count"] += 1
+                    break
 
         gpu_names = ""
         max_memory = 0

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Tuple
+
+from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 from model_analyzer.constants import LOGGER_NAME, TOP_MODELS_REPORT_KEY
 from model_analyzer.result.constraint_manager import ConstraintManager
 from model_analyzer.record.metrics_manager import MetricsManager
@@ -301,11 +304,8 @@ class ReportManager:
         run_config = self._summary_data[report_key][0][0]
         cpu_only = run_config.cpu_only()
 
-        gpu_dict = self._get_gpu_stats(
+        (gpu_names, max_memories) = self._get_gpu_stats(
             measurements=[v for _, v in self._summary_data[report_key]])
-
-        gpu_names = ','.join(list(gpu_dict.keys()))
-        max_memories = ','.join([str(x) + ' GB' for x in gpu_dict.values()])
 
         # Get constraints
         constraint_strs = self._build_constraint_strings()
@@ -857,10 +857,9 @@ class ReportManager:
         gpu_cpu_string = "CPU"
 
         if not run_config.cpu_only():
-            gpu_dict = self._get_gpu_stats(measurements=measurements)
-            gpu_names = ','.join(list(gpu_dict.keys()))
-            max_memories = ','.join([str(x) + ' GB' for x in gpu_dict.values()])
-            gpu_cpu_string = f"GPU(s) {gpu_names} with memory limit(s) {max_memories}"
+            (gpu_names,
+             max_memories) = self._get_gpu_stats(measurements=measurements)
+            gpu_cpu_string = f"GPU(s) {gpu_names} with total memory {max_memories}"
         sentence = (
             f"The model config \"{model_config_name}\" uses {instance_group_string} "
             f"with {max_batch_size_string} and has {dynamic_batching_string}. "
@@ -873,9 +872,12 @@ class ReportManager:
     def _get_gpu_count(self):
         return len(self._gpu_info)
 
-    def _get_gpu_stats(self, measurements):
+    def _get_gpu_stats(
+            self, measurements: List[RunConfigMeasurement]) -> Tuple[str, str]:
         """
-        Gets names and memory infos of GPUs used in measurements
+        Gets names and max total memory of GPUs used in measurements
+
+        Returns Tuple(Names(string), MaxMemory(string))
         """
 
         gpu_dict = {}
@@ -885,8 +887,22 @@ class ReportManager:
                     gpu_name = gpu_info['name']
                     max_memory = round(gpu_info['total_memory'] / (2**30), 1)
                     if gpu_name not in gpu_dict:
-                        gpu_dict[gpu_name] = max_memory
-        return gpu_dict
+                        gpu_dict[gpu_name] = {"memory": max_memory, "count": 1}
+                    else:
+                        gpu_dict[gpu_name]["count"] += 1
+
+        gpu_names = ""
+        max_memory = 0
+        for name in gpu_dict.keys():
+            count = gpu_dict[name]["count"]
+            memory = gpu_dict[name]["memory"]
+            if gpu_names != "":
+                gpu_names += ", "
+            gpu_names += f"{count} x {name}"
+            max_memory += memory * count
+
+        max_mem_str = f"{max_memory} GB"
+        return (gpu_names, max_mem_str)
 
     def _build_constraint_strings(self):
         """

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -858,8 +858,7 @@ class ReportManager:
         gpu_cpu_string = "CPU"
 
         if not run_config.cpu_only():
-            (gpu_names,
-             max_memories) = self._get_gpu_stats(measurements=measurements)
+            gpu_names, max_memories = self._get_gpu_stats(measurements)
             gpu_cpu_string = f"GPU(s) {gpu_names} with total memory {max_memories}"
         sentence = (
             f"The model config \"{model_config_name}\" uses {instance_group_string} "
@@ -877,9 +876,13 @@ class ReportManager:
             self,
             measurements: List["RunConfigMeasurement"]) -> Tuple[str, str]:
         """
-        Gets names and max total memory of GPUs used in measurements
+        Gets names and max total memory of GPUs used in measurements as a 
+        tuple of strings
 
-        Returns Tuple(Names(string), MaxMemory(string))
+        Returns
+        -------
+        (gpu_names_str, max_memory_str):
+            The GPU names as a string, and the total combined memory as a string
         """
 
         gpu_dict = {}

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -483,10 +483,9 @@ class TestReportManagerMethods(trc.TestResultCollector):
             model_config_weights=MagicMock())
 
         measurements = [measurement, measurement]
-        (names,
-         max_gpu) = report_manager._get_gpu_stats(measurements=measurements)
+        names, max_mem = report_manager._get_gpu_stats(measurements)
         self.assertEqual(names, "2 x fake_gpu_name, 1 x fake_gpu_name_3")
-        self.assertEqual(max_gpu, "12.0 GB")
+        self.assertEqual(max_mem, "12.0 GB")
 
     def tearDown(self):
         self.matplotlib_mock.stop()

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -482,7 +482,7 @@ class TestReportManagerMethods(trc.TestResultCollector):
             metric_objectives=MagicMock(),
             model_config_weights=MagicMock())
 
-        measurements = [measurement]
+        measurements = [measurement, measurement]
         (names,
          max_gpu) = report_manager._get_gpu_stats(measurements=measurements)
         self.assertEqual(names, "2 x fake_gpu_name, 1 x fake_gpu_name_3")


### PR DESCRIPTION
Old code did not specify number of GPUs, so it looked like only one GPU was running in the reports.
![image](https://user-images.githubusercontent.com/50968584/184940114-d034e98b-ecf0-4024-92fa-d6f68ae894c9.png)

![image](https://user-images.githubusercontent.com/50968584/184940132-013065b7-f093-4349-977e-0a2ac0e4a338.png)


New code cleans that up:
![image](https://user-images.githubusercontent.com/50968584/184940206-97381651-2deb-40b2-8659-d5d91330ad60.png)

![image](https://user-images.githubusercontent.com/50968584/184940168-087c5477-32d9-4d66-bd04-83595d95ef52.png)

