### PR TITLE
Sweep experiments script

### DIFF
--- a/experiments/checkpoint_experiment_data.py
+++ b/experiments/checkpoint_experiment_data.py
@@ -15,6 +15,7 @@
 from experiments.experiment_data import ExperimentData
 from model_analyzer.state.analyzer_state_manager import AnalyzerStateManager
 from unittest.mock import MagicMock
+from copy import deepcopy
 
 
 class CheckpointExperimentData(ExperimentData):
@@ -24,17 +25,30 @@ class CheckpointExperimentData(ExperimentData):
 
     def __init__(self, config):
         super().__init__()
+        self._default_run_config = None
         self._load_checkpoint(config)
+
+    def get_default_config_dict(self):
+        ret = self._default_run_config.model_run_configs()[0].model_config(
+        ).to_dict()
+        ret = deepcopy(ret)
+        del ret["cpu_only"]
+        return ret
 
     def _load_checkpoint(self, config):
         state_manager = AnalyzerStateManager(config, MagicMock())
         state_manager.load_checkpoint(checkpoint_required=True)
 
         results = state_manager.get_state_variable('ResultManager.results')
+
         model_name = ",".join([x.model_name() for x in config.profile_models])
         model_measurements = results.get_model_measurements_dict(model_name)
         for (run_config,
              run_config_measurements) in model_measurements.values():
+
+            if run_config.model_variants_name(
+            ) == model_name + "_config_default":
+                self._default_run_config = run_config
 
             # Due to the way that data is stored in the AnalyzerStateManager, the
             # run_config only represents the model configuration used. The
@@ -46,6 +60,46 @@ class CheckpointExperimentData(ExperimentData):
             for (perf_analyzer_string,
                  run_config_measurement) in run_config_measurements.items():
 
+                run_config_measurement.set_model_config_constraints(
+                    model_config_constraints=[config.constraints])
+                run_config_measurement.set_metric_weightings(
+                    metric_objectives=[config.objectives])
                 pa_key = self._make_pa_key_from_cli_string(perf_analyzer_string)
-                self._add_run_config_measurement_from_keys(
-                    ma_key, pa_key, run_config, run_config_measurement)
+
+                existing_measurement = self._get_run_config_measurement_from_keys(
+                    ma_key, pa_key, skip_warn=True)
+                if not existing_measurement or run_config_measurement > existing_measurement:
+                    self._add_run_config_measurement_from_keys(
+                        ma_key, pa_key, run_config, run_config_measurement)
+
+        if self._default_run_config is None:
+            print(f"No default config for {model_name}")
+            exit(1)
+
+        self._print_map()
+
+    def _print_map(self):
+        for i in range(0, 10):
+            row_str = ""
+            for j in range(0, 10):
+                instance_count = j + 1
+                max_batch_size = 2**i
+
+                ma_key = f"instance_count={instance_count},max_batch_size={max_batch_size}"
+
+                clamped_int = self._clamp_to_power_of_two(2 * instance_count *
+                                                          max_batch_size)
+
+                pa_key = str(clamped_int)
+
+                measurement = self._get_run_config_measurement_from_keys(
+                    ma_key, pa_key, skip_warn=True)
+                tput = 0
+                lat = 0
+                if measurement:
+                    tput = measurement.get_non_gpu_metric_value(
+                        'perf_throughput')
+                    lat = measurement.get_non_gpu_metric_value(
+                        'perf_latency_p99')
+                row_str += f"\t{tput:4.1f}:{lat:4.1f}"
+            print(row_str)

--- a/experiments/config_command_experiment.py
+++ b/experiments/config_command_experiment.py
@@ -25,6 +25,16 @@ class ConfigCommandExperiment(ConfigCommandProfile):
     def _fill_config(self):
         super()._fill_config()
         self._add_config(
+            ConfigField(
+                'exponential_inst_count',
+                field_type=ConfigPrimitive(bool),
+                flags=['--exponential-inst-count'],
+                parser_args={'action': 'store_true'},
+                default_value=False,
+                description=
+                'Whether or not the inst count dimension should be linear or exponential'
+            ))
+        self._add_config(
             ConfigField('radius',
                         field_type=ConfigPrimitive(int),
                         flags=['--radius'],

--- a/experiments/experiment_data.py
+++ b/experiments/experiment_data.py
@@ -87,23 +87,27 @@ class ExperimentData:
         curr_dict[ma_key][pa_key] = run_config_measurement
 
     def _update_best_trackers(self, run_config, run_config_measurement):
-        if not self._best_run_config_measurement or run_config_measurement.get_non_gpu_metric_value(
-                'perf_throughput'
-        ) > self._best_run_config_measurement.get_non_gpu_metric_value(
-                'perf_throughput'):
+        if run_config_measurement.is_passing_constraints() and \
+            (not self._best_run_config_measurement or (run_config_measurement > self._best_run_config_measurement)):
+
             self._best_run_config_measurement = run_config_measurement
             self._best_run_config = run_config
 
-    def _get_run_config_measurement_from_keys(self, ma_key, pa_key):
+    def _get_run_config_measurement_from_keys(self,
+                                              ma_key,
+                                              pa_key,
+                                              skip_warn=False):
         if ma_key not in self._data:
-            print(f"WARNING: Model config {ma_key} not in results")
-            self._missing_measurement_count += 1
+            if not skip_warn:
+                print(f"WARNING: Model config {ma_key} not in results")
+                self._missing_measurement_count += 1
             return None
         if pa_key not in self._data[ma_key]:
-            print(
-                f"WARNING: Model config {ma_key}, concurrency={pa_key} not in results"
-            )
-            self._missing_measurement_count += 1
+            if not skip_warn:
+                print(
+                    f"WARNING: Model config {ma_key}, concurrency={pa_key} not in results"
+                )
+                self._missing_measurement_count += 1
             return None
 
         return self._data[ma_key][pa_key]

--- a/experiments/experiment_evaluator.py
+++ b/experiments/experiment_evaluator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from experiment_data import ExperimentData
+
 
 class ExperimentEvaluator:
     """ 
@@ -19,7 +21,7 @@ class ExperimentEvaluator:
     a checkpoint of raw data
     """
 
-    def __init__(self, raw_data, profile_data):
+    def __init__(self, raw_data: ExperimentData, profile_data: ExperimentData):
         self._raw_data = raw_data
         self._profile_data = profile_data
 
@@ -43,6 +45,9 @@ class ExperimentEvaluator:
         print(
             f"Overall best throughput: {overall_best_measurement.get_non_gpu_metric_value('perf_throughput')}"
         )
+        print(
+            f"Overall best latency: {overall_best_measurement.get_non_gpu_metric_value('perf_latency_p99')}"
+        )
         print()
         print(
             f"Generator num measurements: {self._profile_data.get_run_config_measurement_count()}"
@@ -56,14 +61,29 @@ class ExperimentEvaluator:
         print(
             f"Generator best config: {self._run_config_to_string(generator_best_run_config)}"
         )
-        print(
-            f"Generator best throughput: {generator_best_measurement.get_non_gpu_metric_value('perf_throughput')}"
-        )
+
+        if generator_best_measurement:
+            best_throughput = generator_best_measurement.get_non_gpu_metric_value(
+                'perf_throughput')
+            best_latency = generator_best_measurement.get_non_gpu_metric_value(
+                'perf_latency_p99')
+            overall_best_throughput = overall_best_measurement.get_non_gpu_metric_value(
+                'perf_throughput')
+            percentile = round(best_throughput / overall_best_throughput, 2)
+        else:
+            best_throughput = None
+            best_latency = None
+            percentile = None
+
+        print(f"Generator best throughput: {best_throughput}")
+        print(f"Generator best latency: {best_latency}")
+        print(f"Percentile: {percentile}")
         print()
 
     def _run_config_to_string(self, run_config):
-        str = "\n".join([
-            f"{x.model_config().get_config()}"
-            for x in run_config.model_run_configs()
-        ])
-        return str
+        if run_config:
+            str = "\n".join([
+                f"{x.model_config().get_config()}"
+                for x in run_config.model_run_configs()
+            ])
+            return str

--- a/experiments/generator_experiment_factory.py
+++ b/experiments/generator_experiment_factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from model_analyzer.config.generate.brute_run_config_generator import BruteRunConfigGenerator
+from model_analyzer.config.generate.model_variant_name_manager import ModelVariantNameManager
 from model_analyzer.config.generate.quick_run_config_generator import QuickRunConfigGenerator
 from model_analyzer.config.generate.search_config import SearchConfig
 from model_analyzer.config.generate.search_dimension import SearchDimension
@@ -53,10 +54,17 @@ class GeneratorExperimentFactory:
 
             #yapf: disable
             for i, _ in enumerate(config_command.profile_models):
-                dimensions.add_dimensions(i, [
-                    SearchDimension(f"max_batch_size", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
-                    SearchDimension(f"instance_count", SearchDimension.DIMENSION_TYPE_LINEAR)
-                ])
+                if config_command.exponential_inst_count:
+                    dimensions.add_dimensions(i, [
+                        SearchDimension(f"max_batch_size", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+                        SearchDimension(f"instance_count", SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
+                    ])
+                else:
+                    dimensions.add_dimensions(i, [
+                        SearchDimension(f"max_batch_size", SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+                        SearchDimension(f"instance_count", SearchDimension.DIMENSION_TYPE_LINEAR)
+                    ])
+
             #yapf: enable
 
             search_config = SearchConfig(
@@ -65,10 +73,11 @@ class GeneratorExperimentFactory:
                 step_magnitude=config_command.magnitude,
                 min_initialized=config_command.min_initialized)
 
+            mvn = ModelVariantNameManager()
             generator = QuickRunConfigGenerator(search_config, config_command,
                                                 MagicMock(),
                                                 config_command.profile_models,
-                                                MagicMock())
+                                                MagicMock(), mvn)
             return generator
         else:
             raise Exception(f"Unknown generator {generator_name}")

--- a/experiments/scripts/sweep_checkpoints.py
+++ b/experiments/scripts/sweep_checkpoints.py
@@ -137,8 +137,10 @@ def run_all_models():
                 continue
 
             percentile = float(result_data['Percentile'])
-            num_measurement = int(result_data['Generator num configs'])
 
+            num_measurement = int(result_data['Generator num measurements'])
+            num_measurement += int(
+                result_data['Generator missing num measurements'])
             print(
                 f"  {model}: Percentile = {percentile}, measurements = {num_measurement}"
             )

--- a/experiments/scripts/sweep_checkpoints.py
+++ b/experiments/scripts/sweep_checkpoints.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import subprocess
+import re
+from statistics import mean, median, mode
+
+PATH = "/mnt/nvdl/datasets/inferenceserver/mnaas-checkpoints"
+
+
+def find_all_checkpoints(path):
+    """
+    Return a list of all checkpoints at any depth below input path
+    """
+    all_checkpoints = []
+    for dirpath, _, filenames in os.walk(path):
+        for filename in filenames:
+            if filename.endswith(".ckpt"):
+                all_checkpoints.append(f"{dirpath}/{filename}")
+    return all_checkpoints
+
+
+def get_models_in_checkpoint(ckpt):
+    """
+    Given a path to a checkpoint file, return a list of all model names
+    inside of that checkpoint
+    """
+    if not os.path.exists(ckpt):
+        print(f"File {ckpt} not found")
+        exit(1)
+
+    with open(ckpt, 'r') as f:
+        contents = json.load(f)
+        models = list(contents["ResultManager.results"]["_results"].keys())
+    return models
+
+
+def cleanup_checkpoints(path):
+    """ 
+    Given a path, recursively search all folders for all folders
+    with one or more checkpoints in it. In each of those folders,
+    rename the highest numbered checkpoint to be 0.ckpt and delete
+    all others
+    """
+    for dirpath, _, filenames in os.walk(path):
+        cleanup = False
+        for filename in filenames:
+            if filename.endswith(".ckpt"):
+                cleanup = True
+                break
+        if cleanup:
+            filenames.sort()
+            os.rename(f"{dirpath}/{filenames[-1]}", f"{dirpath}/zzz")
+            for filename in filenames[:-1]:
+                os.remove(f"{dirpath}/{filename}")
+            os.rename(f"{dirpath}/zzz", f"{dirpath}/0.ckpt")
+
+
+def parse_experiment_output(output):
+    """
+    Returns a dict of key values from an experiment output
+    """
+    ret = {}
+
+    output_str = output.decode('utf-8')
+    lines = output_str.split("\n")
+    for line in lines:
+        if re.search(':', line):
+            pair = line.split(":", 1)
+            if pair[0] != "WARNING":
+                ret[pair[0]] = pair[1].lstrip()
+
+    return ret
+
+
+def run_all_models():
+    percentiles = []
+    below_cutoff = []
+    num_measurements = []
+    too_many_measurements = []
+    too_few_measurements = []
+
+    PERCENTILE_CUTOFF = 0.70
+    NUM_MEASUREMENTS_MAX = 15
+    NUM_MEASUREMENTS_MIN = 5
+    ckpts = find_all_checkpoints(PATH)
+    total_models = 0
+
+    # FIXME
+    #ckpts = ckpts[80:82]
+    for i, ckpt in enumerate(ckpts):
+
+        # FIXME -- infinite loop
+        if re.search("bert-base-cased-pyt", ckpt):
+            continue
+
+        # FIXME -- they don't use max_batch
+        if re.search("ncf", ckpt):
+            continue
+
+        print(f"{i+1} out of {len(ckpts)} checkpoints")
+        print(ckpt)
+
+        is_linear_inst = False
+        with open(ckpt) as f:
+            contents = f.read()
+            if re.search('instanceGroup": \[{"count": 3,', contents):
+                is_linear_inst = True
+        for model in get_models_in_checkpoint(ckpt):
+            total_models += 1
+            cmd = f"python3 /home/tgerdes/Code/model_analyzer/experiments/main.py --model-name {model} --generator QuickRunConfigGenerator --data-path {ckpt}"
+
+            if not is_linear_inst:
+                cmd = f"{cmd} --exponential-inst-count"
+            cmd_list = cmd.split(' ')
+            result = subprocess.run(cmd_list, stdout=subprocess.PIPE)
+            result_data = parse_experiment_output(result.stdout)
+
+            if 'Percentile' not in result_data:
+                print(f"{model} failed! Skipping")
+                continue
+            if 'Generator num configs' not in result_data:
+                print(f"{model} failed! Skipping")
+                continue
+
+            percentile = float(result_data['Percentile'])
+            num_measurement = int(result_data['Generator num configs'])
+
+            print(
+                f"  {model}: Percentile = {percentile}, measurements = {num_measurement}"
+            )
+            percentiles.append(percentile)
+            num_measurements.append(num_measurement)
+
+            cmd = cmd.replace("main.py", "main.py -v")
+            if percentile < PERCENTILE_CUTOFF:
+                below_cutoff.append(f"{percentile}: {cmd}")
+            if num_measurement > NUM_MEASUREMENTS_MAX:
+                too_many_measurements.append(f"{num_measurement}: {cmd}")
+            if num_measurement < NUM_MEASUREMENTS_MIN:
+                too_few_measurements.append(f"{num_measurement}: {cmd}")
+
+    avg_percentile = mean(percentiles)
+    median_percentile = median(percentiles)
+    mode_percentile = mode(percentiles)
+
+    print()
+    print(f"Average percentile = {avg_percentile:0.2f}")
+    print(f"Median percentile = {median_percentile:0.2f}")
+    print(f"Mode percentile = {mode_percentile:0.2f}")
+
+    avg_measurements = mean(num_measurements)
+    median_measurements = median(num_measurements)
+    mode_measurements = mode(num_measurements)
+
+    print()
+    print(f"Average measurements = {avg_measurements:0.2f}")
+    print(f"Median measurements = {median_measurements:0.2f}")
+    print(f"Mode measurements = {mode_measurements:0.2f}")
+
+    print(
+        f"{len(below_cutoff)} out of {total_models} are below the cutoff of {100*PERCENTILE_CUTOFF}%:"
+    )
+    for x in sorted(below_cutoff):
+        print(f"  {x}")
+
+    print()
+    print()
+    print(
+        f"{len(too_many_measurements)} out of {total_models} are taking more than {NUM_MEASUREMENTS_MAX} measurements:"
+    )
+    for x in sorted(too_many_measurements, reverse=True):
+        print(f"  {x}")
+
+    print()
+    print()
+    print(
+        f"{len(too_few_measurements)} out of {total_models} are taking less than {NUM_MEASUREMENTS_MIN} measurements:"
+    )
+    for x in sorted(too_few_measurements):
+        print(f"  {x}")
+
+
+run_all_models()


### PR DESCRIPTION
New script to run the experiment script on all models in all checkpoints in a directory (recursively) 

Also, make the following updates to the experiment script:
- support for running experiment without default config (it can get it from the checkpoint)
- support for custom constraints and objectives
- support for exponential instance count
- debug print throughput/latency map

