### PR TITLE
Update step calculation. Add translation of vector instead of magnitude

### DIFF
--- a/experiments/config_command_experiment.py
+++ b/experiments/config_command_experiment.py
@@ -41,12 +41,6 @@ class ConfigCommandExperiment(ConfigCommandProfile):
                         default_value=3,
                         description='The size of the neighborhood radius'))
         self._add_config(
-            ConfigField('magnitude',
-                        field_type=ConfigPrimitive(int),
-                        flags=['--magnitude'],
-                        default_value=20,
-                        description='The size of each step'))
-        self._add_config(
             ConfigField('min_mbs_index',
                         field_type=ConfigPrimitive(int),
                         flags=['--min-mbs-index'],

--- a/experiments/evaluate_config_generator.py
+++ b/experiments/evaluate_config_generator.py
@@ -66,8 +66,7 @@ class EvaluateConfigGenerator:
         file_writer = ExperimentFileWriter(
             self._output_path, file_name=f"output_{self._model_name}.csv")
         file_writer.write(self._checkpoint_data, self._profile_data,
-                          configs["radius"], configs["magnitude"],
-                          configs["min_initialized"])
+                          configs["radius"], configs["min_initialized"])
 
     def _run_generator(self, cg):
         for run_config in cg.get_configs():

--- a/experiments/experiment_file_writer.py
+++ b/experiments/experiment_file_writer.py
@@ -25,7 +25,7 @@ class ExperimentFileWriter:
     field_names = [
         "overall_num_measurements", "overall_best_throughput",
         "quick_num_measurements", "missing_num_measurements",
-        "quick_throughput", "radius", "magnitude", "min_initialized"
+        "quick_throughput", "radius", "min_initialized"
     ]
 
     def __init__(self, output_path, file_name="output_vgg19_libtorch.csv"):
@@ -38,8 +38,7 @@ class ExperimentFileWriter:
                 writer = csv.DictWriter(csv_file, fieldnames=self.field_names)
                 writer.writeheader()
 
-    def write(self, checkpoint_data, profile_data, radius, magnitude,
-              min_initialized):
+    def write(self, checkpoint_data, profile_data, radius, min_initialized):
         try:
             with open(self._filename, mode="a") as csv_file:
                 writer = csv.DictWriter(csv_file, fieldnames=self.field_names)
@@ -62,7 +61,6 @@ class ExperimentFileWriter:
                     "quick_throughput":
                         quick_best_measurement.get_non_gpu_metric_value("perf_throughput"),
                     "radius": radius,
-                    "magnitude": magnitude,
                     "min_initialized": min_initialized
                 })
                 # yapf: enable

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -17,6 +17,7 @@
 # Example usage:
 #
 # python3 main.py --model-name resnet50_libtorch --run-config-search-mode=brute --run-config-search-max-model-batch-size 2
+# python3 main.py --model-name resnet50_libtorch --run-config-search-mode=quick --radius 5
 #####################
 
 from evaluate_config_generator import EvaluateConfigGenerator

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -16,8 +16,7 @@
 #
 # Example usage:
 #
-# python3 main.py --model-name resnet50_libtorch --generator BruteRunConfigGenerator --run-config-search-max-model-batch-size 2
-# python3 main.py --model-name resnet50_libtorch --generator QuickRunConfigGenerator --magnitude 5
+# python3 main.py --model-name resnet50_libtorch --run-config-search-mode=brute --run-config-search-max-model-batch-size 2
 #####################
 
 from evaluate_config_generator import EvaluateConfigGenerator

--- a/experiments/start_profiles.sh
+++ b/experiments/start_profiles.sh
@@ -17,18 +17,15 @@ CHECKPOINT_DIR="/mnt/nvdl/datasets/inferenceserver/model_analyzer_profile_result
 
 for model in inception_v1_graphdef resnet50_libtorch vgg19_libtorch; do
   for radius in {2..8}; do
-    for magnitude in {1..8}; do
-      for min_initialized in {2..8}; do
-        echo "Profiling $model (radius = $radius, magnitude = $magnitude, min-initialized = $min_initialized)"
-        python3 main.py --save \
-            --model-name $model \
-            --generator QuickRunConfigGenerator \
-            --data-path $CHECKPOINT_DIR \
-            --output-path output \
-            --radius $radius \
-            --magnitude $magnitude \
-            --min-initialized $min_initialized
-      done
+    for min_initialized in {2..8}; do
+      echo "Profiling $model (radius = $radius, min-initialized = $min_initialized)"
+      python3 main.py --save \
+          --model-name $model \
+          --generator QuickRunConfigGenerator \
+          --data-path $CHECKPOINT_DIR \
+          --output-path output \
+          --radius $radius \
+          --min-initialized $min_initialized
     done
   done
 done

--- a/experiments/start_profiles.sh
+++ b/experiments/start_profiles.sh
@@ -21,7 +21,7 @@ for model in inception_v1_graphdef resnet50_libtorch vgg19_libtorch; do
       echo "Profiling $model (radius = $radius, min-initialized = $min_initialized)"
       python3 main.py --save \
           --model-name $model \
-          --generator QuickRunConfigGenerator \
+          --run-config-search-mode quick \
           --data-path $CHECKPOINT_DIR \
           --output-path output \
           --radius $radius \

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -15,7 +15,6 @@
 import math
 from itertools import product
 from copy import deepcopy
-from re import M
 
 from typing import List, Tuple, Dict, Optional
 

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -30,7 +30,15 @@ class Neighborhood:
     a 'home' coordinate
     """
 
-    # FIXME where to put this?
+    # This defines the bounds of how the vector calculated from
+    # measurements is converted to a step vector.
+    #
+    # The translation will return the lowest index that has a value greater
+    # than the input value.
+    #
+    # For example, if the input is greater than the value in index 1 but less than
+    # the value in index 2, the resulting step will be 1
+    #
     TRANSLATION_LIST = [0.09, 0.3, 1.0]
 
     def __init__(self, neighborhood_config: NeighborhoodConfig,

--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -12,35 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, Optional, Generator
+from typing import List, Optional, Generator
 
 from .config_generator_interface import ConfigGeneratorInterface
 
-from model_analyzer.config.generate.base_model_config_generator import BaseModelConfigGenerator
 from model_analyzer.config.generate.search_config import SearchConfig
-from model_analyzer.config.generate.coordinate import Coordinate
-from model_analyzer.config.generate.coordinate_data import CoordinateData
-from model_analyzer.config.generate.neighborhood import Neighborhood
 from model_analyzer.config.generate.brute_run_config_generator import BruteRunConfigGenerator
 from model_analyzer.config.generate.quick_run_config_generator import QuickRunConfigGenerator
 from model_analyzer.config.generate.model_variant_name_manager import ModelVariantNameManager
-from model_analyzer.config.run.model_run_config import ModelRunConfig
 from model_analyzer.config.run.run_config import RunConfig
-from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
-from model_analyzer.triton.model.model_config import ModelConfig
 from model_analyzer.triton.client.client import TritonClient
 from model_analyzer.device.gpu_device import GPUDevice
 from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
 from model_analyzer.config.input.objects.config_model_profile_spec import ConfigModelProfileSpec
 from model_analyzer.result.result_manager import ResultManager
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
-from model_analyzer.record.metrics_manager import MetricsManager
-from model_analyzer.result.results import Results
 from model_analyzer.result.run_config_result import RunConfigResult
 
-from model_analyzer.constants import LOGGER_NAME, MAGNITUDE_DECAY_RATE
-from model_analyzer.config.input.config_defaults import DEFAULT_NUM_CONFIGS_PER_MODEL, \
-    DEFAULT_RUN_CONFIG_MIN_CONCURRENCY, DEFAULT_RUN_CONFIG_MAX_CONCURRENCY
+from model_analyzer.constants import LOGGER_NAME
+from model_analyzer.config.input.config_defaults import DEFAULT_RUN_CONFIG_MIN_CONCURRENCY, DEFAULT_RUN_CONFIG_MAX_CONCURRENCY
 
 from copy import deepcopy
 

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -195,9 +195,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             coordinate=self._coordinate_to_measure)
 
     def _take_step(self):
-        magnitude = self._get_magnitude()
-
-        new_coordinate = self._neighborhood.calculate_new_coordinate(magnitude)
+        new_coordinate = self._neighborhood.determine_new_home()
         self._determine_if_done(new_coordinate)
 
         logger.debug(f"Stepping {self._home_coordinate}->{new_coordinate}")

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -32,9 +32,8 @@ from model_analyzer.device.gpu_device import GPUDevice
 from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
 from model_analyzer.config.input.objects.config_model_profile_spec import ConfigModelProfileSpec
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
-from model_analyzer.record.metrics_manager import MetricsManager
 
-from model_analyzer.constants import LOGGER_NAME, MAGNITUDE_DECAY_RATE
+from model_analyzer.constants import LOGGER_NAME
 
 import logging
 
@@ -88,8 +87,6 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         # the back-off stage.
         self._best_coordinate = self._home_coordinate
         self._best_measurement: Optional[RunConfigMeasurement] = None
-
-        self._magnitude_scaler = 1.0
 
         self._neighborhood = Neighborhood(
             self._search_config.get_neighborhood_config(),
@@ -217,8 +214,6 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         self._coordinate_to_measure = new_coordinate
         self._recreate_neighborhood(force_slow_mode=True)
 
-        self._magnitude_scaler *= MAGNITUDE_DECAY_RATE
-
     def _should_step_back(self):
         """
         Step back if take any of the following steps:
@@ -268,10 +263,6 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         dims = self._search_config.get_dimensions()
         values = dims.get_values_for_coordinate(coordinate)
         return values[key]
-
-    def _get_magnitude(self) -> float:
-        magnitude = self._search_config.get_step_magnitude()
-        return self._magnitude_scaler * magnitude
 
     def _get_next_run_config(self) -> RunConfig:
         run_config = RunConfig(self._triton_env)

--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -20,7 +20,7 @@ from .search_dimensions import SearchDimensions
 from .search_dimension import SearchDimension
 from .search_config import SearchConfig
 from typing import List
-from model_analyzer.constants import RADIUS, MAGNITUDE, MIN_INITIALIZED
+from model_analyzer.constants import RADIUS, MIN_INITIALIZED
 
 
 class RunConfigGeneratorFactory:
@@ -108,7 +108,6 @@ class RunConfigGeneratorFactory:
 
         search_config = SearchConfig(dimensions=dimensions,
                                      radius=RADIUS,
-                                     step_magnitude=MAGNITUDE,
                                      min_initialized=MIN_INITIALIZED)
 
         return search_config

--- a/model_analyzer/config/generate/search_config.py
+++ b/model_analyzer/config/generate/search_config.py
@@ -75,7 +75,7 @@ class SearchConfig(NeighborhoodConfig):
     Defines all dimensions to search
     """
 
-    def __init__(self, dimensions, radius, step_magnitude, min_initialized):
+    def __init__(self, dimensions, radius, min_initialized):
         """
         Parameters
         ----------
@@ -83,8 +83,6 @@ class SearchConfig(NeighborhoodConfig):
         radius: int
             All points within distance=radius from a location will be in
             each neighborhood
-        step_magnitude: int
-            When a step is taken, this is the distance it will step
         min_initialized: int
             Minimum number of initialized values in a neighborhood
             before a step can be taken
@@ -92,11 +90,6 @@ class SearchConfig(NeighborhoodConfig):
         super().__init__(dimensions=dimensions,
                          radius=radius,
                          min_initialized=min_initialized)
-        self._step_magnitude = step_magnitude
-
-    def get_step_magnitude(self):
-        """ Returns the base magnitude of a step """
-        return self._step_magnitude
 
     def get_neighborhood_config(self, radius=None):
         """

--- a/model_analyzer/constants.py
+++ b/model_analyzer/constants.py
@@ -35,9 +35,7 @@ THROUGHPUT_MINIMUM_CONSECUTIVE_BATCH_SIZE_TRIES = 4
 
 # Quick search algorithm constants
 RADIUS = 3
-MAGNITUDE = 5
 MIN_INITIALIZED = 3
-MAGNITUDE_DECAY_RATE = 0.5
 
 # Reports
 TOP_MODELS_REPORT_KEY = "Best Configs Across All Models"

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -646,11 +646,10 @@ class TestNeighborhood(trc.TestResultCollector):
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 2]))
 
-    def test_determine_new_home_larger_magnitude(self):
+    def test_determine_new_home(self):
         """
         Test determine_new_home for a case where both of the
-        dimensions increases the measurement equally, and magnitude is
-        larger.
+        dimensions increases the measurement equally
         """
         dims = SearchDimensions()
         dims.add_dimensions(0, [

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -40,10 +40,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
                             SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
 
-        sc = SearchConfig(dimensions=dims,
-                          radius=5,
-                          step_magnitude=7,
-                          min_initialized=2)
+        sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
         self._qrcg = QuickRunConfigGenerator(sc, MagicMock(), MagicMock(),
                                              mock_models, MagicMock(),
                                              ModelVariantNameManager())
@@ -57,7 +54,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
                 SearchDimension("y", SearchDimension.DIMENSION_TYPE_LINEAR, min=1),
                 SearchDimension("z", SearchDimension.DIMENSION_TYPE_EXPONENTIAL, min=3)
         ])
-        sc = SearchConfig(dimensions=dims,radius=2, step_magnitude=2, min_initialized=2)
+        sc = SearchConfig(dimensions=dims,radius=2, min_initialized=2)
         #yapf: enable
         qrcg = QuickRunConfigGenerator(sc, MagicMock(), MagicMock(),
                                        MagicMock(), MagicMock(),
@@ -159,10 +156,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
                             SearchDimension.DIMENSION_TYPE_LINEAR)
         ])
 
-        sc = SearchConfig(dimensions=dims,
-                          radius=5,
-                          step_magnitude=7,
-                          min_initialized=2)
+        sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
         qrcg = QuickRunConfigGenerator(sc, MagicMock(), MagicMock(),
                                        mock_models, MagicMock(),
                                        ModelVariantNameManager())
@@ -242,19 +236,6 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(pc2['concurrency-range'], 192)
         self.assertEqual(pc2['batch-size'], 1)
         self.assertEqual(pc2['model-version'], 3)
-
-    def test_magnitude(self):
-        """
-        Test that _get_magnitude works correctly.
-        """
-        qrcg = self._qrcg
-        self.assertEqual(qrcg._get_magnitude(), 7)  # initial value
-
-        qrcg._magnitude_scaler = 0.5
-        self.assertEqual(qrcg._get_magnitude(), 3.5)
-
-        qrcg._magnitude_scaler = 0.1
-        self.assertAlmostEqual(qrcg._get_magnitude(), 0.7)
 
     def tearDown(self):
         patch.stopall()

--- a/tests/test_search_config.py
+++ b/tests/test_search_config.py
@@ -21,7 +21,7 @@ from .common import test_result_collector as trc
 class TestSearchConfig(trc.TestResultCollector):
 
     def test_basic(self):
-        sc = SearchConfig(SearchDimensions(), 0, 0, 0)
+        sc = SearchConfig(SearchDimensions(), 0, 0)
         self.assertEqual(0, sc.get_num_dimensions())
 
     def test_config(self):
@@ -50,7 +50,7 @@ class TestSearchConfig(trc.TestResultCollector):
                             10),
             SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
-        sc = SearchConfig(dims, 0, 0, 0)
+        sc = SearchConfig(dims, 0, 0)
 
         self.assertEqual([1, 0], sc.get_min_indexes())
 

--- a/tests/test_search_config.py
+++ b/tests/test_search_config.py
@@ -31,14 +31,10 @@ class TestSearchConfig(trc.TestResultCollector):
             SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
 
-        sc = SearchConfig(dimensions=dims,
-                          radius=4,
-                          step_magnitude=6,
-                          min_initialized=2)
+        sc = SearchConfig(dimensions=dims, radius=4, min_initialized=2)
 
         self.assertEqual(2, sc.get_num_dimensions())
         self.assertEqual(4, sc.get_radius())
-        self.assertEqual(6, sc.get_step_magnitude())
         self.assertEqual(2, sc.get_min_initialized())
 
         self.assertEqual("foo", sc.get_dimension(0).get_name())
@@ -68,10 +64,7 @@ class TestSearchConfig(trc.TestResultCollector):
             SearchDimension("bar", SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
 
-        sc = SearchConfig(dimensions=dims,
-                          radius=4,
-                          step_magnitude=6,
-                          min_initialized=2)
+        sc = SearchConfig(dimensions=dims, radius=4, min_initialized=2)
 
         nc = sc.get_neighborhood_config(radius=5)
         self.assertEqual(2, nc.get_num_dimensions())


### PR DESCRIPTION
- Updated the way that measurements and vectors are used to calculate the step vector
- Added a translation function to convert resulting step vector into actual step vector (instead of relying on magnitude, clipping, and clamping)
- Removed the concept of magnitude

Almost no change in the results, but gives us more control over tweaking step direction and size

**Old (current main with slow mode support):**
normal Average/Median/Mode percentiles = 0.95 / 0.99 / 1.00
normal Average/Median/Mode measurements = 13.23 / 12.00 / 7.00
normal: 7 out of 128 are below the cutoff of 70.0%:

latency_budget Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
latency_budget Average/Median/Mode measurements = 11.74 / 10.00 / 10.00
latency_budget: 2 out of 127 are below the cutoff of 70.0%:

min_throughput Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
min_throughput Average/Median/Mode measurements = 6.55 / 5.00 / 4.00
min_throughput: 3 out of 125 are below the cutoff of 70.0%:

**New (with these changes):**
normal Average/Median/Mode percentiles = 0.94 / 0.98 / 1.00
normal Average/Median/Mode measurements = 12.55 / 10.00 / 4.00
normal: 6 out of 128 are below the cutoff of 70.0%:

latency_budget Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
latency_budget Average/Median/Mode measurements = 11.63 / 10.00 / 3.00
latency_budget: 2 out of 126 are below the cutoff of 70.0%:

min_throughput Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
min_throughput Average/Median/Mode measurements = 6.31 / 5.00 / 4.00
min_throughput: 5 out of 124 are below the cutoff of 70.0%:

