### PR TITLE
only use one coordinate data

### DIFF
--- a/model_analyzer/config/generate/coordinate_data.py
+++ b/model_analyzer/config/generate/coordinate_data.py
@@ -26,6 +26,7 @@ class CoordinateData:
     def __init__(self):
         self._measurements = {}
         self._visit_counts = {}
+        self._is_measured = {}
 
     def get_measurement(
             self, coordinate: Coordinate) -> Optional[RunConfigMeasurement]:
@@ -42,6 +43,20 @@ class CoordinateData:
         """
         key: Tuple[Coordinate, ...] = tuple(coordinate)
         self._measurements[key] = measurement
+        self._is_measured[key] = True
+
+    def is_measured(self, coordinate: Coordinate) -> bool:
+        """
+        Returns true if a measurement has been set for the given Coordinate
+        """
+        key: Tuple[Coordinate, ...] = tuple(coordinate)
+        return self._is_measured.get(key, False)
+
+    def has_valid_measurement(self, coordinate: Coordinate) -> bool:
+        """
+        Returns true if there is a valid measurement for the given Coordinate
+        """
+        return self.get_measurement(coordinate) is not None
 
     def reset_measurements(self):
         """

--- a/model_analyzer/config/generate/neighborhood.py
+++ b/model_analyzer/config/generate/neighborhood.py
@@ -175,7 +175,7 @@ class Neighborhood:
 
     def _pick_slow_mode_coordinate_to_initialize(self):
         for neighbor in self._get_all_adjacent_neighbors():
-            if not self._coordinate_data.is_measured(neighbor):
+            if not self._is_coordinate_measured(neighbor):
                 return neighbor
 
         raise Exception("Picking slow mode coordinate, but none are unvisited")
@@ -186,7 +186,7 @@ class Neighborhood:
         max_num_uncovered = -1
         best_coordinate = None
         for coordinate in self._neighborhood:
-            if not self._coordinate_data.is_measured(coordinate):
+            if not self._is_coordinate_measured(coordinate):
                 num_uncovered = self._get_num_uncovered_values(
                     coordinate, covered_values_per_dimension)
 

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -90,7 +90,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         self._neighborhood = Neighborhood(
             self._search_config.get_neighborhood_config(),
-            self._home_coordinate)
+            self._home_coordinate, self._coordinate_data)
 
         # Sticky bit. Once true, we should never stay at a home that is failing or None
         self._home_has_passed = False
@@ -142,11 +142,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         ----------
         measurements: List of Measurements from the last run(s)
         """
-        self._coordinate_data.increment_visit_count(self._coordinate_to_measure)
-        self._neighborhood.coordinate_data.increment_visit_count(
-            coordinate=self._coordinate_to_measure)
-
-        self._neighborhood.coordinate_data.set_measurement(
+        self._coordinate_data.set_measurement(
             coordinate=self._coordinate_to_measure, measurement=measurements[0])
 
         if measurements[0] is not None:
@@ -187,8 +183,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
                 self._best_coordinate = self._coordinate_to_measure
                 self._best_measurement = measurement
 
-    def _get_last_results(self) -> RunConfigMeasurement:
-        return self._neighborhood.coordinate_data.get_measurement(
+    def _get_last_results(self) -> Optional[RunConfigMeasurement]:
+        return self._coordinate_data.get_measurement(
             coordinate=self._coordinate_to_measure)
 
     def _take_step(self):
@@ -245,7 +241,11 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         neighborhood_config = self._search_config.get_neighborhood_config()
 
         self._neighborhood = Neighborhood(neighborhood_config,
-                                          self._home_coordinate)
+                                          self._home_coordinate,
+                                          self._coordinate_data)
+
+        self._coordinate_data.increment_visit_count(self._home_coordinate)
+
         if force_slow_mode:
             self._neighborhood.force_slow_mode()
 

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cmath import exp
 from unittest.mock import MagicMock, patch
 
 from model_analyzer.config.generate.neighborhood import Neighborhood
@@ -358,16 +357,9 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=300, latency=130)
 
         cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([1, 1, 1]))
-
         cd.set_measurement(Coordinate([2, 1, 1]), rcm1)
-        cd.increment_visit_count(Coordinate([2, 1, 1]))
-
         cd.set_measurement(Coordinate([1, 2, 1]), rcm2)
-        cd.increment_visit_count(Coordinate([1, 2, 1]))
-
         cd.set_measurement(Coordinate([1, 2, 2]), None)
-        cd.increment_visit_count(Coordinate([1, 2, 2]))
 
         expected_vectors = [
             Coordinate([1, 2, 1]) - Coordinate([1, 1, 1]),
@@ -423,19 +415,10 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm4.set_model_config_constraints([constraints])
 
         cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([1, 1, 1]))
-
         cd.set_measurement(Coordinate([2, 1, 1]), rcm1)
-        cd.increment_visit_count(Coordinate([2, 1, 1]))
-
         cd.set_measurement(Coordinate([1, 2, 1]), rcm2)
-        cd.increment_visit_count(Coordinate([1, 2, 1]))
-
         cd.set_measurement(Coordinate([1, 1, 2]), rcm3)
-        cd.increment_visit_count(Coordinate([1, 1, 2]))
-
         cd.set_measurement(Coordinate([1, 2, 2]), rcm4)
-        cd.increment_visit_count(Coordinate([1, 2, 2]))
 
         expected_vectors = [
             Coordinate([1, 1, 2]) - Coordinate([1, 1, 1]),
@@ -501,15 +484,9 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=400, latency=290)  # pass
         rcm2.set_model_config_constraints([constraints])
 
-        cd.set_measurement(Coordinate([1, 1, 1]),
-                                          rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([1, 1, 1]))
-
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
         cd.set_measurement(Coordinate([2, 3, 1]), rcm1)
-        cd.increment_visit_count(Coordinate([2, 3, 1]))
-
         cd.set_measurement(Coordinate([1, 1, 2]), rcm2)
-        cd.increment_visit_count(Coordinate([1, 1, 2]))
 
         hm = cd.get_measurement(Coordinate([1, 1, 1]))
         self.assertTrue(hm.is_passing_constraints())
@@ -576,13 +553,8 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2.set_model_config_constraints([constraints])
 
         cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([1, 1, 1]))
-
-        cd.set_measurement(Coordinate([3, 1, 1]), rcm1)
-        cd.increment_visit_count(Coordinate([3, 1, 1]))
-
+        cd.set_measurement(Coordinate([3, 2, 1]), rcm1)
         cd.set_measurement(Coordinate([1, 2, 0]), rcm2)
-        cd.increment_visit_count(Coordinate([1, 2, 0]))
 
         hm = cd.get_measurement(Coordinate([1, 1, 1]))
         self.assertFalse(hm.is_passing_constraints())
@@ -613,13 +585,8 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=1, latency=5)
 
         cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([0, 0]))
-
         cd.set_measurement(Coordinate([1, 0]), rcm1)
-        cd.increment_visit_count(Coordinate([1, 0]))
-
         cd.set_measurement(Coordinate([0, 1]), rcm2)
-        cd.increment_visit_count(Coordinate([0, 1]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 0]))
@@ -646,13 +613,8 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=3, latency=5)
 
         cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([0, 0]))
-
         cd.set_measurement(Coordinate([1, 0]), rcm1)
-        cd.increment_visit_count(Coordinate([1, 0]))
-
         cd.set_measurement(Coordinate([0, 1]), rcm2)
-        cd.increment_visit_count(Coordinate([0, 1]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 2]))
@@ -679,13 +641,8 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=7, latency=5)
 
         cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([0, 0]))
-
         cd.set_measurement(Coordinate([1, 0]), rcm1)
-        cd.increment_visit_count(Coordinate([1, 0]))
-
         cd.set_measurement(Coordinate([0, 1]), rcm2)
-        cd.increment_visit_count(Coordinate([0, 1]))
 
         # 7x increase in throughputs will result in the maximum step of [3,3]
         new_coord = n.determine_new_home()
@@ -721,10 +678,7 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm1 = self._construct_rcm(throughput=7, latency=5)
 
         cd.set_measurement(Coordinate([3, 6]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([3, 6]))
-
         cd.set_measurement(Coordinate([2, 7]), rcm1)
-        cd.increment_visit_count(Coordinate([2, 7]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 7]))
@@ -755,16 +709,9 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm3 = self._construct_rcm(throughput=10, latency=5)
 
         cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
-        cd.increment_visit_count(Coordinate([1, 1, 1]))
-
         cd.set_measurement(Coordinate([1, 0, 0]), rcm1)
-        cd.increment_visit_count(Coordinate([1, 0, 0]))
-
         cd.set_measurement(Coordinate([0, 1, 0]), rcm2)
-        cd.increment_visit_count(Coordinate([0, 1, 0]))
-
         cd.set_measurement(Coordinate([0, 0, 1]), rcm3)
-        cd.increment_visit_count(Coordinate([0, 0, 1]))
 
         step_vector = n._get_step_vector()
         self.assertEqual(step_vector, Coordinate([0, 0, 0]))
@@ -830,7 +777,9 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
         cd = CoordinateData()
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0, 0]),coordinate_data=cd)
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 0, 0]),
+                         coordinate_data=cd)
 
         vectors = [[0, 0, 1], [1, -3, 2], [-4, 2, 0], [3, 2, 6]]
         weights = [0.5, -3.0, -1, 0]

--- a/tests/test_neighborhood.py
+++ b/tests/test_neighborhood.py
@@ -77,7 +77,9 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=CoordinateData())
 
         # These are all values within radius of 2 from [1,1,1]
         # but within the bounds (no negative values)
@@ -104,62 +106,50 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         rcm = self._construct_rcm(throughput=100, latency=80)
 
         # Start with 0 initialized
-        self.assertEqual(0, len(n._get_visited_coordinates()))
-        self.assertEqual(0, len(n._get_initialized_coordinates()))
+        self.assertEqual(0, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Home coordinate is ignored. No change to num initialized/visited.
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
-        self.assertEqual(0, len(n._get_visited_coordinates()))
-        self.assertEqual(0, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm)
+        self.assertEqual(0, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Incremented to 1 initialized
-        n.coordinate_data.set_measurement(Coordinate([0, 0, 0]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 0]))
-        self.assertEqual(1, len(n._get_visited_coordinates()))
-        self.assertEqual(1, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([0, 0, 0]), rcm)
+        self.assertEqual(1, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set same point. No change to num initialized
-        n.coordinate_data.set_measurement(Coordinate([0, 0, 0]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 0]))
-        self.assertEqual(1, len(n._get_visited_coordinates()))
-        self.assertEqual(1, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([0, 0, 0]), rcm)
+        self.assertEqual(1, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set a point outside of neighborhood
-        n.coordinate_data.set_measurement(Coordinate([0, 0, 4]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 4]))
-        self.assertEqual(1, len(n._get_visited_coordinates()))
-        self.assertEqual(1, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([0, 0, 4]), rcm)
+        self.assertEqual(1, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set a third point inside of neighborhood
-        n.coordinate_data.set_measurement(Coordinate([1, 0, 0]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0, 0]))
-        self.assertEqual(2, len(n._get_visited_coordinates()))
-        self.assertEqual(2, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([1, 0, 0]), rcm)
+        self.assertEqual(2, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set the none measurement. No changed to num initialized.
-        n.coordinate_data.set_measurement(Coordinate([0, 1, 1]), None)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1, 1]))
-        self.assertEqual(3, len(n._get_visited_coordinates()))
-        self.assertEqual(2, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([0, 1, 1]), None)
+        self.assertEqual(2, len(n._get_coordinates_with_valid_measurements()))
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Set the last point inside of neighborhood
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 0]), rcm)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 0]))
-        self.assertEqual(4, len(n._get_visited_coordinates()))
-        self.assertEqual(3, len(n._get_initialized_coordinates()))
+        cd.set_measurement(Coordinate([1, 1, 0]), rcm)
+        self.assertEqual(3, len(n._get_coordinates_with_valid_measurements()))
         self.assertTrue(n.enough_coordinates_initialized())
 
     def test_get_all_adjacent_neighbors(self):
@@ -183,7 +173,9 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 1, 4]))
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 1, 4]),
+                         coordinate_data=CoordinateData())
 
         adjacent_neighbors = n._get_all_adjacent_neighbors()
         expected_list = [
@@ -215,26 +207,29 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 0, 1]),
+                         coordinate_data=cd)
         n.force_slow_mode()
 
         # Start with None initialized
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Home coordinate is ignored
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 1]))
+        cd.set_measurement(Coordinate([0, 0, 1]), MagicMock())
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Add 3 of the 4 neighbors
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0, 1]))
+        cd.set_measurement(Coordinate([1, 0, 1]), MagicMock())
         self.assertFalse(n.enough_coordinates_initialized())
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1, 1]))
+        cd.set_measurement(Coordinate([0, 1, 1]), MagicMock())
         self.assertFalse(n.enough_coordinates_initialized())
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 0]))
+        cd.set_measurement(Coordinate([0, 0, 0]), MagicMock())
         self.assertFalse(n.enough_coordinates_initialized())
 
         # Add the final neighbor
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 2]))
+        cd.set_measurement(Coordinate([0, 0, 2]), MagicMock())
         self.assertTrue(n.enough_coordinates_initialized())
 
     def test_is_slow_mode(self):
@@ -315,7 +310,7 @@ class TestNeighborhood(trc.TestResultCollector):
             patch.object(Neighborhood, "_get_measurements_passing_constraints",
                          MagicMock(return_value=passing_ret_val)))
         patches.append(
-            patch.object(Neighborhood, "_get_all_visited_measurements",
+            patch.object(Neighborhood, "_get_all_measurements",
                          MagicMock(return_value=all_ret_val)))
         patches.append(
             patch.object(Neighborhood, "_is_home_passing_constraints",
@@ -328,7 +323,9 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1]))
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1]),
+                         coordinate_data=CoordinateData())
 
         for p in patches:
             p.start()
@@ -341,7 +338,7 @@ class TestNeighborhood(trc.TestResultCollector):
         for p in patches:
             p.stop()
 
-    def test_get_all_visited_measurements(self):
+    def test_get_all_measurements(self):
         dims = SearchDimensions()
         dims.add_dimensions(0, [
             SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR),
@@ -351,24 +348,26 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=100, latency=50)
         rcm1 = self._construct_rcm(throughput=700, latency=350)
         rcm2 = self._construct_rcm(throughput=300, latency=130)
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([1, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+        cd.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        cd.increment_visit_count(Coordinate([2, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+        cd.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        cd.increment_visit_count(Coordinate([1, 2, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), None)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+        cd.set_measurement(Coordinate([1, 2, 2]), None)
+        cd.increment_visit_count(Coordinate([1, 2, 2]))
 
         expected_vectors = [
             Coordinate([1, 2, 1]) - Coordinate([1, 1, 1]),
@@ -376,7 +375,7 @@ class TestNeighborhood(trc.TestResultCollector):
         ]
         expected_measurements = [rcm2, rcm1]
 
-        vectors, measurements = n._get_all_visited_measurements()
+        vectors, measurements = n._get_all_measurements()
         for ev, em in zip(expected_vectors, expected_measurements):
             self.assertTrue(ev in vectors)
             self.assertTrue(em in measurements)
@@ -391,7 +390,10 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         # Constraints:
         #   - Minimum throughput of 100 infer/sec
@@ -420,21 +422,20 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm4 = self._construct_rcm(throughput=850, latency=400)  # fail
         rcm4.set_model_config_constraints([constraints])
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([1, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([2, 1, 1]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([2, 1, 1]))
+        cd.set_measurement(Coordinate([2, 1, 1]), rcm1)
+        cd.increment_visit_count(Coordinate([2, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 2, 1]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 1]))
+        cd.set_measurement(Coordinate([1, 2, 1]), rcm2)
+        cd.increment_visit_count(Coordinate([1, 2, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 2]), rcm3)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 2]))
+        cd.set_measurement(Coordinate([1, 1, 2]), rcm3)
+        cd.increment_visit_count(Coordinate([1, 1, 2]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 2, 2]), rcm4)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 2]))
+        cd.set_measurement(Coordinate([1, 2, 2]), rcm4)
+        cd.increment_visit_count(Coordinate([1, 2, 2]))
 
         expected_vectors = [
             Coordinate([1, 1, 2]) - Coordinate([1, 1, 1]),
@@ -474,7 +475,10 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=3, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         # Constraints:
         #   - Minimum throughput of 100 infer/sec
@@ -497,21 +501,22 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=400, latency=290)  # pass
         rcm2.set_model_config_constraints([constraints])
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]),
+        cd.set_measurement(Coordinate([1, 1, 1]),
                                           rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+        cd.increment_visit_count(Coordinate([1, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([2, 3, 1]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([2, 3, 1]))
+        cd.set_measurement(Coordinate([2, 3, 1]), rcm1)
+        cd.increment_visit_count(Coordinate([2, 3, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 2]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 2]))
+        cd.set_measurement(Coordinate([1, 1, 2]), rcm2)
+        cd.increment_visit_count(Coordinate([1, 1, 2]))
 
-        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        hm = cd.get_measurement(Coordinate([1, 1, 1]))
         self.assertTrue(hm.is_passing_constraints())
 
         step_vector = n._get_step_vector()
         expected_step_vector = Coordinate([1.0, 0.5, 1.2])
+
         self.assertEqual(step_vector, expected_step_vector)
 
     def test_step_vector_both_home_and_neighbors_failing_constraints(self):
@@ -544,7 +549,10 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=3, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         # Constraints:
         #   - Minimum throughput of 100 infer/sec
@@ -567,17 +575,16 @@ class TestNeighborhood(trc.TestResultCollector):
         rcm2 = self._construct_rcm(throughput=850, latency=540)  # fail
         rcm2.set_model_config_constraints([constraints])
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([1, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([3, 2, 1]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([3, 2, 1]))
+        cd.set_measurement(Coordinate([3, 1, 1]), rcm1)
+        cd.increment_visit_count(Coordinate([3, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 2, 0]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 2, 0]))
+        cd.set_measurement(Coordinate([1, 2, 0]), rcm2)
+        cd.increment_visit_count(Coordinate([1, 2, 0]))
 
-        hm = n.coordinate_data.get_measurement(Coordinate([1, 1, 1]))
+        hm = cd.get_measurement(Coordinate([1, 1, 1]))
         self.assertFalse(hm.is_passing_constraints())
 
         step_vector = n._get_step_vector()
@@ -596,21 +603,23 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 0]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=1, latency=5)
         rcm1 = self._construct_rcm(throughput=3, latency=5)
         rcm2 = self._construct_rcm(throughput=1, latency=5)
 
-        n.coordinate_data.set_measurement(Coordinate([0, 0]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0]))
+        cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([0, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 0]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0]))
+        cd.set_measurement(Coordinate([1, 0]), rcm1)
+        cd.increment_visit_count(Coordinate([1, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([0, 1]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1]))
+        cd.set_measurement(Coordinate([0, 1]), rcm2)
+        cd.increment_visit_count(Coordinate([0, 1]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 0]))
@@ -627,21 +636,23 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 0]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=1, latency=5)
         rcm1 = self._construct_rcm(throughput=3, latency=5)
         rcm2 = self._construct_rcm(throughput=3, latency=5)
 
-        n.coordinate_data.set_measurement(Coordinate([0, 0]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0]))
+        cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([0, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 0]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0]))
+        cd.set_measurement(Coordinate([1, 0]), rcm1)
+        cd.increment_visit_count(Coordinate([1, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([0, 1]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1]))
+        cd.set_measurement(Coordinate([0, 1]), rcm2)
+        cd.increment_visit_count(Coordinate([0, 1]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 2]))
@@ -658,21 +669,23 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0, 0]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=1, latency=5)
         rcm1 = self._construct_rcm(throughput=7, latency=5)
         rcm2 = self._construct_rcm(throughput=7, latency=5)
 
-        n.coordinate_data.set_measurement(Coordinate([0, 0]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0]))
+        cd.set_measurement(Coordinate([0, 0]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([0, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 0]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0]))
+        cd.set_measurement(Coordinate([1, 0]), rcm1)
+        cd.increment_visit_count(Coordinate([1, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([0, 1]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1]))
+        cd.set_measurement(Coordinate([0, 1]), rcm2)
+        cd.increment_visit_count(Coordinate([0, 1]))
 
         # 7x increase in throughputs will result in the maximum step of [3,3]
         new_coord = n.determine_new_home()
@@ -699,17 +712,19 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=8, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([3, 6]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([3, 6]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=1, latency=5)
         rcm1 = self._construct_rcm(throughput=7, latency=5)
 
-        n.coordinate_data.set_measurement(Coordinate([3, 6]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([3, 6]))
+        cd.set_measurement(Coordinate([3, 6]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([3, 6]))
 
-        n.coordinate_data.set_measurement(Coordinate([2, 7]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([2, 7]))
+        cd.set_measurement(Coordinate([2, 7]), rcm1)
+        cd.increment_visit_count(Coordinate([2, 7]))
 
         new_coord = n.determine_new_home()
         self.assertEqual(new_coord, Coordinate([2, 7]))
@@ -729,25 +744,27 @@ class TestNeighborhood(trc.TestResultCollector):
         ])
 
         nc = NeighborhoodConfig(dims, radius=3, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([1, 1, 1]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([1, 1, 1]),
+                         coordinate_data=cd)
 
         rcm0 = self._construct_rcm(throughput=10, latency=5)
         rcm1 = self._construct_rcm(throughput=10, latency=5)
         rcm2 = self._construct_rcm(throughput=10, latency=5)
         rcm3 = self._construct_rcm(throughput=10, latency=5)
 
-        n.coordinate_data.set_measurement(Coordinate([1, 1, 1]),
-                                          rcm0)  # home coordinate
-        n.coordinate_data.increment_visit_count(Coordinate([1, 1, 1]))
+        cd.set_measurement(Coordinate([1, 1, 1]), rcm0)  # home coordinate
+        cd.increment_visit_count(Coordinate([1, 1, 1]))
 
-        n.coordinate_data.set_measurement(Coordinate([1, 0, 0]), rcm1)
-        n.coordinate_data.increment_visit_count(Coordinate([1, 0, 0]))
+        cd.set_measurement(Coordinate([1, 0, 0]), rcm1)
+        cd.increment_visit_count(Coordinate([1, 0, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([0, 1, 0]), rcm2)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 1, 0]))
+        cd.set_measurement(Coordinate([0, 1, 0]), rcm2)
+        cd.increment_visit_count(Coordinate([0, 1, 0]))
 
-        n.coordinate_data.set_measurement(Coordinate([0, 0, 1]), rcm3)
-        n.coordinate_data.increment_visit_count(Coordinate([0, 0, 1]))
+        cd.set_measurement(Coordinate([0, 0, 1]), rcm3)
+        cd.increment_visit_count(Coordinate([0, 0, 1]))
 
         step_vector = n._get_step_vector()
         self.assertEqual(step_vector, Coordinate([0, 0, 0]))
@@ -789,7 +806,10 @@ class TestNeighborhood(trc.TestResultCollector):
         dims.add_dimensions(
             0, [SearchDimension("foo", SearchDimension.DIMENSION_TYPE_LINEAR)])
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0]))
+        cd = CoordinateData()
+        n = Neighborhood(nc,
+                         home_coordinate=Coordinate([0]),
+                         coordinate_data=cd)
 
         input_coord = Coordinate(input_vector)
         expected_coord = Coordinate(expected_vector)
@@ -809,7 +829,8 @@ class TestNeighborhood(trc.TestResultCollector):
                             SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
         nc = NeighborhoodConfig(dims, radius=2, min_initialized=3)
-        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0, 0]))
+        cd = CoordinateData()
+        n = Neighborhood(nc, home_coordinate=Coordinate([0, 0, 0]),coordinate_data=cd)
 
         vectors = [[0, 0, 1], [1, -3, 2], [-4, 2, 0], [3, 2, 6]]
         weights = [0.5, -3.0, -1, 0]


### PR DESCRIPTION
No longer create a coordinateData inside of neighborhood. Instead, pass it in. Without this change, we were ignoring some measurements and wasting time gathering new different measurements.

Also, update some CoordinateData concepts around visiting/measuring to differentiate between home visits vs random coordinate measurements


Results: Significant drop off in the number of measurements taken, but much of this was probably fake savings (we would re-measure a coordinate, but the ResultData had a cache so it didn't cost us anything to re-measure). However, this still looks really good.

**Old Results (current main with slow mode changes):**
normal Average/Median/Mode percentiles = 0.95 / 0.99 / 1.00
normal Average/Median/Mode measurements = 13.23 / 12.00 / 7.00
normal: 7 out of 128 are below the cutoff of 70.0%:

latency_budget Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
latency_budget Average/Median/Mode measurements = 11.74 / 10.00 / 10.00
latency_budget: 2 out of 127 are below the cutoff of 70.0%:

min_throughput Average/Median/Mode percentiles = 0.97 / 1.00 / 1.00
min_throughput Average/Median/Mode measurements = 6.55 / 5.00 / 4.00
min_throughput: 3 out of 125 are below the cutoff of 70.0%:

**New Results:**
normal Average/Median/Mode percentiles = 0.95 / 1.00 / 1.00
normal Average/Median/Mode measurements = 9.97 / 10.00 / 5.00
normal: 6 out of 128 are below the cutoff of 70.0%:

latency_budget Average/Median/Mode percentiles = 0.98 / 1.00 / 1.00
latency_budget Average/Median/Mode measurements = 10.54 / 10.00 / 3.00
latency_budget: 1 out of 127 are below the cutoff of 70.0%:

min_throughput Average/Median/Mode percentiles = 0.98 / 1.00 / 1.00
min_throughput Average/Median/Mode measurements = 6.34 / 5.00 / 4.00
min_throughput: 2 out of 123 are below the cutoff of 70.0%:
