### PR TITLE
Rebuilding heaps after profile completes

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -113,6 +113,7 @@ class Analyzer:
         logger.info("")
 
         if not self._config.skip_summary_reports:
+            self._result_manager.add_results_to_heaps()
             self._create_summary_tables(verbose)
             self._create_summary_reports(mode)
             logger.info(self._get_report_command_help_string())

--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -106,7 +106,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
 
     def _sweep_concurrency_over_top_results(self):
         top_results = self._result_manager.top_n_results(
-            n=self._config.num_top_model_configs)
+            n=self._config.num_configs_per_model)
 
         for count, result in enumerate(top_results):
             new_config = self._create_new_config_command_profile(result)

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -233,6 +233,16 @@ class ResultManager:
 
         return result_stats
 
+    # TODO: This is the big hammer to fix the issues that arise because we
+    # can create new measurements inside existing RCR's after the heaps have been
+    # created either when re-profiling or running quick + brute w/ concurrency sweep
+    def add_results_to_heaps(self):
+        # Delete the current heaps
+        self._per_model_sorted_results = defaultdict(ResultHeap)
+        self._across_model_sorted_results = ResultHeap()
+
+        self._add_results_to_heaps()
+
     def _init_state(self):
         """
         Sets ResultManager object managed

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -233,7 +233,7 @@ class ResultManager:
 
         return result_stats
 
-    # TODO: This is the big hammer to fix the issues that arise because we
+    # TODO: TMA-898 This is the big hammer to fix the issues that arise because we
     # can create new measurements inside existing RCR's after the heaps have been
     # created either when re-profiling or running quick + brute w/ concurrency sweep
     def add_results_to_heaps(self):


### PR DESCRIPTION
Destroying and rebuilding the result heaps after profile completes
Also changed to use the correct number of configs per model when sweeping concurrency.

I've verified this works with fresh runs for quick searches of add_sub and resnet, as well as a sequential run of resnet+add_sub