### PR TITLE
Fix broken doc links. Add test to protect doc links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN python3 -m pip install mypy
 RUN python3 -m pip install types-PyYAML
 RUN python3 -m pip install types-requests
 RUN python3 -m pip install types-protobuf
+RUN python3 -m pip install mkdocs
+RUN python3 -m pip install mkdocs-htmlproofer-plugin
 
 RUN apt-get install -y wkhtmltopdf
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Triton Inference Server.
 
 * [Brute and Quick search](docs/config_search.md): Model Analyzer can
 help you automatically find the optimal settings for
-[Max Batch Size](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#maximum-batch-size),
-[Dynamic Batching](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#dynamic-batcher), and
-[Instance Group](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#instance-groups)
+[Max Batch Size](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#maximum-batch-size),
+[Dynamic Batching](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher), and
+[Instance Group](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#instance-groups)
 parameters of your model configuration. Model Analyzer utilizes 
-[Performance Analyzer](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md) 
+[Performance Analyzer](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/perf_analyzer.md) 
 to test the model with different concurrency and batch sizes of requests. Using
 [Manual Config Search](docs/config_search.md#manual-brute-search), you can create manual sweeps for every parameter that can be specified in the model configuration.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,7 +87,7 @@ $ model-analyzer profile -h
 Depending on the command line or YAML config options provided, the `profile`
 subcommand will either perform a
 [manual](./config_search.md#manual-brute-search), [automatic](./config_search.md#automatic-brute-search), or
-[quick](./config_search.md#quick-configuration-search) search over perf analyzer
+[quick](./config_search.md#quick-search-mode) search over perf analyzer
 and model config file parameters. For each combination of [model config
 parameters](./config.md#model-config-parameters) (e.g. _max batch size_, _dynamic batching_, and _instance count_), it will run tritonserver and perf analyzer instances with
 all the specified run parameters (client request concurrency and static batch

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,7 +66,7 @@ converting the `snake_case` options to `--kebab-case`. For example,
 `profile_models` in the YAML would be `--profile-models` in the CLI.
 
 ```yaml
-# Path to the Triton Model Repository (https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md)
+# Path to the Triton Model Repository (https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md)
 model_repository: <string>
 
 # List of the model names to be profiled
@@ -575,7 +575,7 @@ This will result in 27 individual test runs of the model.
 
 This field represents the values that can be changed or swept through using
 Model Analyzer. All the values supported in the [Triton
-Config](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md)
+Config](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md)
 can be specified or swept through here. `<model-config-parameters>` should be
 specified on a per model basis and cannot be specified globally (like
 `<parameter>`).
@@ -585,9 +585,9 @@ sweeping:
 
 |                                                              Option                                                              |                                                                                                                                                               Description                                                                                                                                                               |
 | :------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| [`dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#dynamic-batcher)  |                                                                                              Dynamic batching is a feature of Triton that allows inference requests to be combined by the server, so that a batch is created dynamically.                                                                                               |
-| [`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#maximum-batch-size) |                                       The max_batch_size property indicates the maximum batch size that the model supports for the [types of batching](https://github.com/triton-inference-server/server/blob/master/docs/architecture.md#models-and-schedulers) that can be exploited by Triton.                                       |
-|  [`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#instance-groups)   | Triton can provide multiple instances of a model so that multiple inference requests for that model can be handled simultaneously. The model configuration ModelInstanceGroup property is used to specify the number of execution instances that should be made available and what compute resource should be used for those instances. |
+| [`dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher)  |                                                                                              Dynamic batching is a feature of Triton that allows inference requests to be combined by the server, so that a batch is created dynamically.                                                                                               |
+| [`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size) |                                       The max_batch_size property indicates the maximum batch size that the model supports for the [types of batching](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/architecture.md#models-and-schedulers) that can be exploited by Triton.                                       |
+|  [`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups)   | Triton can provide multiple instances of a model so that multiple inference requests for that model can be handled simultaneously. The model configuration ModelInstanceGroup property is used to specify the number of execution instances that should be made available and what compute resource should be used for those instances. |
 
 An example `<model-config-parameters>` look like below:
 
@@ -676,25 +676,15 @@ but profile `model_2` using GPU.
 
 ### `<perf-analyzer-flags>`
 
-This field allows fine-grained control over the behavior of the `perf_analyzer`
-instances launched by Model Analyzer. `perf_analyzer` options and their values
-can be specified here, and will be passed to `perf_analyzer`. Refer to [the
+This field allows the user to pass `perf_analyzer` any CLI options it needs to
+execute properly. Refer to [the
 `perf_analyzer`
-docs](https://github.com/triton-inference-server/server/blob/master/docs/perf_analyzer.md)
+docs](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/perf_analyzer.md)
 for more information on these options.
 
-#### Example
+#### Global options to apply to all instances of Perf Analyzer
 
-```yaml
-model_repository: /path/to/model/repository/
-profile_models:
-  model_1:
-    perf_analyzer_flags:
-      percentile: 95
-      latency-report-file: /path/to/latency/report/file
-```
-
-The `perf_analyzer_flags` section can also be specified globally to affect
+The `perf_analyzer_flags` section can be specified globally to affect
 perf_analyzer instances across all models in the following way:
 
 ```yaml
@@ -707,6 +697,22 @@ perf_analyzer_flags:
   percentile: 95
   latency-report-file: /path/to/latency/report/file
 ```
+
+#### Model-specific options for Perf Analyzer
+
+In order to set flags only for a specific model, you can specify 
+the flags in the following way:
+
+```yaml
+model_repository: /path/to/model/repository/
+profile_models:
+  model_1:
+    perf_analyzer_flags:
+      percentile: 95
+      latency-report-file: /path/to/latency/report/file
+```
+
+#### Shape, Input-Data, and Streaming
 
 The `input-data`, `shape`, and `streaming` perf_analyzer options are additive and can take either
 a single string (non-list) or a list of strings. Below is an example for `shape` argument:
@@ -723,12 +729,15 @@ perf_analyzer_flags:
     - INPUT1:1024,1024
 ```
 
+#### Variable-sized dimensions
+
 If a model configuration has variable-sized dimensions in the inputs section,
 then the `shape` option of the `perf_analyzer_flags` option must be specified.
 More information about this can be found in the
-[Perf Analyzer documentation](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md#input-data).
+[Perf Analyzer documentation](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/perf_analyzer.md#input-data).
 
-**Note**:
+
+#### SSL Support:
 Perf Analyzer now supports SSL via GRPC and HTTP. It can be enabled via Model Analyzer configuration file updates.
 
 GRPC example:
@@ -754,9 +763,9 @@ profile_models:
 ```
 
 More information about this can be found in the
-[Perf Analyzer documentation](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md#ssltls-support).
+[Perf Analyzer documentation](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/perf_analyzer.md#ssltls-support).
 
-**Important Notes**:
+#### Important Notes:
 
 - Only a subset of flags can be specified on the command line. Use `model-analyzer profile --help` to see the list of flags that can be specified on the command line. If a flag isn't listed there, it can be specified via the yaml file.
 - When providing arguments under `perf_analyzer_flags`, you must use `-` instead
@@ -842,7 +851,7 @@ triton_server_flags:
 ```
 
 More information about this can be found in the
-[Triton Server documentation](https://github.com/triton-inference-server/server/blob/main/docs/inference_protocols.md#ssltls).
+[Triton Server documentation](https://github.com/triton-inference-server/server/blob/main/docs/customization_guide/inference_protocols.md#ssltls).
 
 **Important Notes**:
 
@@ -856,7 +865,7 @@ More information about this can be found in the
 This section enables setting environment variables for the tritonserver
 instances launched by Model Analyzer. For example, when a custom operation is
 required by a model, Triton requires the LD_PRELOAD and LD_LIBRARY_PATH
-environment variables to be set. See [this link](https://github.com/triton-inference-server/server/blob/main/docs/custom_operations.md)
+environment variables to be set. See [this link](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/custom_operations.md)
 for details. The value for this section is a dictionary where the
 keys are the environment variable names and their values are the values to be
 set.

--- a/docs/config.md
+++ b/docs/config.md
@@ -738,7 +738,7 @@ More information about this can be found in the
 
 
 #### SSL Support:
-Perf Analyzer now supports SSL via GRPC and HTTP. It can be enabled via Model Analyzer configuration file updates.
+Perf Analyzer supports SSL via GRPC and HTTP. It can be enabled via Model Analyzer configuration file updates.
 
 GRPC example:
 
@@ -827,7 +827,7 @@ profile_models:
 ```
 
 **Note**:
-Triton Server now supports SSL via GRPC. It can be enabled via Model Analyzer configuration file updates.
+Triton Server supports SSL via GRPC. It can be enabled via Model Analyzer configuration file updates.
 
 GRPC example:
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -30,10 +30,10 @@ let it [Automatically](config_search.md#automatic-brute-search) sweep through co
 Automatic configuration search is the default behavior when running Model
 Analyzer without manually specifying what values to search. The parameters
 that are automatically searched are
-[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#maximum-batch-size)
+[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size)
 and
-[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#instance-groups).
-Additionally, [`dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#dynamic-batcher) will be enabled if it is legal to do so.
+[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups).
+Additionally, [`dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher) will be enabled if it is legal to do so.
 
 An example model analyzer config that performs automatic config search looks
 like below:
@@ -47,15 +47,15 @@ profile_models:
 ```
 
 In the default mode, automatic config search will try values 1 through 5 for
-[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#instance-groups).
+[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups).
 The maximum value can be changed using the `run_config_search_max_instance_count` key in the Model Analyzer Config.
 For each `instance_group`, Model Analyzer will sweep values 1 through 128 increasing exponentially (i.e. 1, 2, 4, 8, ...) for
-[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#maximum-batch-size). The start and end values can be changed using `run_config_search_min_model_batch_size` and `run_config_search_max_model_batch_size`.
-[`Dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md#dynamic-batcher)
+[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size). The start and end values can be changed using `run_config_search_min_model_batch_size` and `run_config_search_max_model_batch_size`.
+[`Dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher)
 will be enabled for all model configs generated using automatic search.
 
 For each model config that is generated in automatic search, Model Analyzer will gather data for
-[`concurrency`](https://github.com/triton-inference-server/server/blob/master/docs/perf_analyzer.md#request-concurrency)
+[`concurrency`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/perf_analyzer.md#request-concurrency)
 values 1 through 1024 increased exponentially (i.e. 1, 2, 4, 8, ...). The maximum value can be configured
 using the `run_config_search_max_concurrency` key in the Model Analyzer Config.
 
@@ -145,7 +145,7 @@ profile_models:
 In this mode, Model Analyzer can sweep through every Triton model configuration
 parameter available. For a complete list of parameters allowed under
 `model_config_parameters`, refer to the [Triton Model
-Configuration](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md).
+Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md).
 It is your responsibility to make sure that the sweep configuration specified
 works with your model. For example, in the above config, if we change `[6, 8]`
 as the range for the `max_batch_size` to `[1]`, it will no longer be a valid
@@ -161,9 +161,9 @@ sweep on every parameter that can be specified in Triton model configuration. In
 this section, we describe some of the parameters that might be of interest for
 manual sweep:
 
-- [Rate limiter](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#rate-limiter-config) setting
+- [Rate limiter](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#rate-limiter-config) setting
 - If the model is using [ONNX](https://github.com/triton-inference-server/onnxruntime_backend) or [Tensorflow backend](https://github.com/triton-inference-server/tensorflow_backend), the "execution_accelerators" parameters. More information about this parameter is
-  available in the [Triton Optimization Guide](https://github.com/triton-inference-server/server/blob/main/docs/optimization.md#framework-specific-optimization)
+  available in the [Triton Optimization Guide](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/optimization.md#framework-specific-optimization)
 
 ## Quick Search Mode
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,7 +125,7 @@ default, as all the dependencies will be available.<br><br>
 
 **1. Build Triton SDK Container from Main**  
 Follow the instructions found at
-[Build SDK Image](https://github.com/triton-inference-server/server/blob/main/docs/test.md#build-sdk-image)<br><br>
+[Build SDK Image](https://github.com/triton-inference-server/server/blob/main/docs/customization_guide/test.md#build-sdk-image)<br><br>
 
 **2. Build Model Analyzer's Main Docker Image**
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,7 +24,7 @@ tags, which are used in various places to configure Model Analyzer.
 
 These metrics come from the perf analyzer and are parsed and processed by the
 model analyzer. See the [perf analyzer
-docs](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md)
+docs](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/perf_analyzer.md)
 for more info on these 
 
 * `perf_throughput`: The number of inferences per second measured by the perf

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -74,7 +74,7 @@ config variants that Model Analyzer creates.<br><br>
 ---
 
 The [examples/quick-start](../examples/quick-start) directory is an example
-[Triton Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) that contains a simple libtorch model which calculates
+[Triton Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md) that contains a simple libtorch model which calculates
 the sum and difference of two inputs.
 
 Run the Model Analyzer `profile` subcommand inside the container with:

--- a/qa/L0_doc_links/mkdocs.yml
+++ b/qa/L0_doc_links/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: CI Test
+use_directory_urls: False
+docs_dir: "../../docs"
+plugins:
+        - htmlproofer
+        - search

--- a/qa/L0_doc_links/mkdocs.yml
+++ b/qa/L0_doc_links/mkdocs.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 site_name: CI Test
 use_directory_urls: False
 docs_dir: "../../docs"

--- a/qa/L0_doc_links/test.sh
+++ b/qa/L0_doc_links/test.sh
@@ -16,7 +16,7 @@ LOG="`pwd`/log.txt"
 CONFIG="`pwd`/mkdocs.yml"
 RET=0
 
-rm $LOG
+#rm $LOG
 
 exec mkdocs serve -f $CONFIG > $LOG &
 PID=$!

--- a/qa/L0_doc_links/test.sh
+++ b/qa/L0_doc_links/test.sh
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOG="`pwd`/log.txt"
+CONFIG="`pwd`/mkdocs.yml"
+RET=0
+
+rm $LOG
+
+exec mkdocs serve -f $CONFIG > $LOG &
+PID=$!
+sleep 20
+
+until [[ (-z `pgrep mkdocs`) ]]; do
+    kill -2 $PID
+    sleep 2
+done
+
+if [[ ! -z `grep "invalid url" $LOG` ]]; then
+    cat $LOG
+    RET=1
+fi
+
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test PASSED\n***"
+else
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+exit $RET


### PR DESCRIPTION
Fixed all broken doc links
Added a test to protect against links ever breaking again
Tweaked the perf_analyzer_flags section (for https://github.com/triton-inference-server/model_analyzer/issues/529)
