### PR TITLE
Error if profile-models is specified on both CLI and in the YAML

### DIFF
--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict, List
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 import yaml
@@ -103,6 +104,8 @@ class ConfigCommand:
         for key, value in self._fields.items():
             self._fields[key].set_name(key)
             if key in args:
+                self._check_for_duplicate_profile_models_option(
+                    yaml_config, key)
                 self._fields[key].set_value(getattr(args, key))
             elif yaml_config is not None and key in yaml_config:
                 self._fields[key].set_value(yaml_config[key])
@@ -115,6 +118,16 @@ class ConfigCommand:
                 )
         self._preprocess_and_verify_arguments()
         self._autofill_values()
+
+    def _check_for_duplicate_profile_models_option(self,
+                                                   yaml_config: Dict[str, List],
+                                                   key: str) -> None:
+        if yaml_config is not None and key in yaml_config and key == 'profile_models':
+            raise TritonModelAnalyzerException(
+                f'\n The profile model option is specified on both '
+                'the CLI (--profile-models) and in the YAML config file.'
+                '\n Please remove the option from one of the locations and try again'
+            )
 
     def _preprocess_and_verify_arguments(self):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,6 +256,23 @@ class TestConfig(trc.TestResultCollector):
         yaml_content = 'model_repository: yaml_repository'
         self._assert_error_on_evaluate_config(args, yaml_content)
 
+    def test_missing_config(self):
+        ''' Test that we fail if the required option profile-models is omitted '''
+
+        args = ['model-analyzer', 'profile', '-f', 'path-to-config-file']
+        yaml_content = 'model_repository: yaml_repository'
+        self._assert_error_on_evaluate_config(args, yaml_content)
+
+    def test_conflicting_configs(self):
+        ''' Test that we fail if an option is specified in both CLI and YAML '''
+
+        args = [
+            'model-analyzer', 'profile', '--model-repository', 'cli_repository',
+            '-f', 'path-to-config-file', '--profile-models', 'vgg11'
+        ]
+        yaml_content = 'profile_models: add_sub'
+        self._assert_error_on_evaluate_config(args, yaml_content)
+
     def test_range_and_list_values(self):
         args = [
             'model-analyzer', 'profile', '--model-repository', 'cli_repository',


### PR DESCRIPTION
If the user specifies `profile-models` on both the CLI and in the YAML we should error and force the user to remove one of these specifications.

Unlike, other options which might have a use case where the user wants to override certain  YAML values on the CLI, there is no use case where the user would want to override `profile-models` on the CLI.

 

This has bitten multiple engineers and wasted countless person-hours debugging why the YAML settings were not being recognized.