### PR TITLE
Multi-model and Quick Search Config Checking

### DIFF
--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -95,14 +95,13 @@ class ConfigCommand:
             this exception
         """
 
-        # Config file has been specified
         yaml_config = self._load_yaml_config(args)
         self._check_for_illegal_config_settings(args, yaml_config)
         self._set_field_values(args, yaml_config)
         self._preprocess_and_verify_arguments()
         self._autofill_values()
 
-    def _load_yaml_config(self, args: Namespace) -> Dict[str, List]:
+    def _load_yaml_config(self, args: Namespace) -> Optional[Dict[str, List]]:
         if 'config_file' in args:
             yaml_config = self._load_config_file(args.config_file)
             YamlConfigValidator.validate(yaml_config)
@@ -112,13 +111,14 @@ class ConfigCommand:
         return yaml_config
 
     def _check_for_illegal_config_settings(
-            self, args: Namespace, yaml_config: Dict[str, List]) -> None:
+            self, args: Namespace, yaml_config: Optional[Dict[str,
+                                                              List]]) -> None:
         self._check_for_duplicate_profile_models_option(args, yaml_config)
         self._check_for_multi_model_incompatability(args, yaml_config)
         self._check_for_quick_search_incompatability(args, yaml_config)
 
     def _set_field_values(self, args: Namespace,
-                          yaml_config: Dict[str, List]) -> None:
+                          yaml_config: Optional[Dict[str, List]]) -> None:
         for key, value in self._fields.items():
             self._fields[key].set_name(key)
             config_value = self._get_config_value(key, args, yaml_config)
@@ -164,10 +164,11 @@ class ConfigCommand:
                 yaml_config):
             return
 
-        self._check_search_mode(args, yaml_config)
+        self._check_multi_model_search_mode_incompatability(args, yaml_config)
 
-    def _check_search_mode(self, args: Namespace,
-                           yaml_config: Optional[Dict[str, List]]) -> None:
+    def _check_multi_model_search_mode_incompatability(
+            self, args: Namespace, yaml_config: Optional[Dict[str,
+                                                              List]]) -> None:
         if self._get_config_value('run_config_search_mode', args,
                                   yaml_config) != 'quick':
             raise TritonModelAnalyzerException(

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Any
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 import yaml
@@ -133,8 +133,7 @@ class ConfigCommand:
 
     def _get_config_value(
             self, key: str, args: Namespace,
-            yaml_config: Optional[Dict[str,
-                                       List]]) -> Optional[Union[int, float]]:
+            yaml_config: Optional[Dict[str, List]]) -> Optional[Any]:
         if key in args:
             return getattr(args, key)
         elif yaml_config is not None and key in yaml_config:

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -236,10 +236,8 @@ class ConfigCommand:
         profile_models = self._get_config_value('profile_models', args,
                                                 yaml_config)
 
-        if type(profile_models) is str:
-            return
-
-        if not profile_models:
+        if not profile_models or type(profile_models) is str or type(
+                profile_models) is list:
             return
 
         for model in profile_models.values():

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-22, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -239,6 +239,9 @@ class ConfigCommand:
         if type(profile_models) is str:
             return
 
+        if not profile_models:
+            return
+
         for model in profile_models.values():
             if not 'parameters' in model:
                 continue

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -183,9 +183,20 @@ class ConfigCommand:
                                   yaml_config) != 'quick':
             return
 
+        self._check_no_search_disable(args, yaml_config)
         self._check_no_search_values(args, yaml_config)
         self._check_no_global_list_values(args, yaml_config)
         self._check_no_per_model_list_values(args, yaml_config)
+
+    def _check_no_search_disable(
+            self, args: Namespace, yaml_config: Optional[Dict[str,
+                                                              List]]) -> None:
+        if self._get_config_value('run_config_search_disable', args,
+                                  yaml_config):
+            raise TritonModelAnalyzerException(
+                f'\nDisabling of run config search is not supported in quick search mode.'
+                '\nPlease use brute search mode or remove --run-config-search-disable.'
+            )
 
     def _check_no_search_values(self, args: Namespace,
                                 yaml_config: Optional[Dict[str, List]]) -> None:

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -251,6 +251,16 @@ class ConfigCommand:
                     '\nPlease use brute search mode or remove concurrency/batch sizes list.'
                 )
 
+        for model in profile_models.values():
+            if not 'model_config_parameters' in model:
+                continue
+
+            if 'max_batch_size' in model['model_config_parameters']:
+                raise TritonModelAnalyzerException(
+                    f'\nProfiling of models in quick search mode is not supported with lists max batch sizes.'
+                    '\nPlease use brute search mode or remov max batch size list.'
+                )
+
     def _preprocess_and_verify_arguments(self):
         """
         Enforces some rules on the config.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -367,6 +367,9 @@ class TestCLI(trc.TestResultCollector):
     @patch(
         'model_analyzer.config.input.config_command_profile.ConfigCommandProfile._load_config_file',
         MagicMock())
+    @patch(
+        'model_analyzer.config.input.config_command.ConfigCommand._check_for_illegal_config_settings',
+        MagicMock())
     def test_all_options(self):
 
         options = get_test_options()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1818,6 +1818,35 @@ profile_models:
         self._test_quick_search_list_value(args, yaml_content, '--batch-sizes')
         self._test_quick_search_list_value(args, yaml_content, '--concurrency')
 
+    def test_quick_search_model_specific(self):
+        """
+        Test for illegal model specific options in the YAML during quick search
+        """
+        args = [
+            'model-analzyer', 'profile', '--model-repository', 'cli-repository',
+            '--run-config-search-mode', 'quick', '-f', 'path-to-config-file'
+        ]
+
+        yaml_content = """
+        profile_models:
+          model_1:
+            parameters:
+              concurrency: 1,2,4,128
+        """
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self._evaluate_config(args, yaml_content, subcommand='profile')
+
+        yaml_content = """
+        profile_models:
+          model_1:
+            parameters:
+              batch size: 1,2,4,128
+        """
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self._evaluate_config(args, yaml_content, subcommand='profile')
+
     def _test_quick_search_rcs_value(self, args: Namespace,
                                      yaml_content: Optional[Dict[str, List]],
                                      rcs_string: str) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1803,20 +1803,31 @@ profile_models:
 
         self._evaluate_config(args, yaml_content)
 
-        self._test_quick_search_rcs_value(
-            args, yaml_content, '--run-config-search-min-concurrency')
-        self._test_quick_search_rcs_value(
-            args, yaml_content, '--run-config-search-max-concurrency')
-        self._test_quick_search_rcs_value(
+        self._test_quick_search_with_rcs(args,
+                                         yaml_content,
+                                         '--run-config-search-disable',
+                                         use_value=False,
+                                         use_list=False)
+        self._test_quick_search_with_rcs(args, yaml_content,
+                                         '--run-config-search-min-concurrency')
+        self._test_quick_search_with_rcs(args, yaml_content,
+                                         '--run-config-search-max-concurrency')
+        self._test_quick_search_with_rcs(
             args, yaml_content, '--run-config-search-min-instance-count')
-        self._test_quick_search_rcs_value(
+        self._test_quick_search_with_rcs(
             args, yaml_content, '--run-config-search-max-instance-count')
-        self._test_quick_search_rcs_value(
+        self._test_quick_search_with_rcs(
             args, yaml_content, '--run-config-search-min-model-batch-size')
-        self._test_quick_search_rcs_value(
+        self._test_quick_search_with_rcs(
             args, yaml_content, '--run-config-search-max-model-batch-size')
-        self._test_quick_search_list_value(args, yaml_content, '--batch-sizes')
-        self._test_quick_search_list_value(args, yaml_content, '--concurrency')
+        self._test_quick_search_with_rcs(args,
+                                         yaml_content,
+                                         '--batch-sizes',
+                                         use_value=False)
+        self._test_quick_search_with_rcs(args,
+                                           yaml_content,
+                                           '--concurrency',
+                                           use_value=False)
 
     def test_quick_search_model_specific(self):
         """
@@ -1857,29 +1868,22 @@ profile_models:
         with self.assertRaises(TritonModelAnalyzerException):
             self._evaluate_config(args, yaml_content, subcommand='profile')
 
-    def _test_quick_search_rcs_value(self, args: Namespace,
-                                     yaml_content: Optional[Dict[str, List]],
-                                     rcs_string: str) -> None:
+    def _test_quick_search_with_rcs(self,
+                                    args: Namespace,
+                                    yaml_content: Optional[Dict[str, List]],
+                                    rcs_string: str,
+                                    use_value: bool = True,
+                                    use_list: bool = True) -> None:
         """
         Tests that run-config-search options raise exceptions 
         in quick search mode
         """
         new_args = deepcopy(args)
         new_args.append(rcs_string)
-        new_args.append('1')
-        with self.assertRaises(TritonModelAnalyzerException):
-            self._evaluate_config(new_args, yaml_content, subcommand='profile')
-
-    def _test_quick_search_list_value(self, args: Namespace,
-                                      yaml_content: Optional[Dict[str, List]],
-                                      rcs_string: str) -> None:
-        """
-        Tests that concurrency/batch lists raise exceptions 
-        in quick search mode
-        """
-        new_args = deepcopy(args)
-        new_args.append(rcs_string)
-        new_args.append(['1', '2', '4'])
+        if use_value:
+            new_args.append('1')
+        elif use_list:
+            new_args.append(['1', '2', '4'])
         with self.assertRaises(TritonModelAnalyzerException):
             self._evaluate_config(new_args, yaml_content, subcommand='profile')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1847,6 +1847,16 @@ profile_models:
         with self.assertRaises(TritonModelAnalyzerException):
             self._evaluate_config(args, yaml_content, subcommand='profile')
 
+        yaml_content = """
+        profile_models:
+          model_1:
+            model_config_parameters:
+              max batch size: 2
+        """
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self._evaluate_config(args, yaml_content, subcommand='profile')
+
     def _test_quick_search_rcs_value(self, args: Namespace,
                                      yaml_content: Optional[Dict[str, List]],
                                      rcs_string: str) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1774,11 +1774,20 @@ profile_models:
         with self.assertRaises(TritonModelAnalyzerException):
             self._evaluate_config(args, yaml_content, subcommand='profile')
 
-        args.append('--run-config-search-mode')
-        args.append('brute')
+        # Brute should fail
+        new_args = deepcopy(args)
+        new_args.append('--run-config-search-mode')
+        new_args.append('brute')
 
         with self.assertRaises(TritonModelAnalyzerException):
-            self._evaluate_config(args, yaml_content, subcommand='profile')
+            self._evaluate_config(new_args, yaml_content, subcommand='profile')
+
+        # Quick should pass
+        new_args = deepcopy(args)
+        new_args.append('--run-config-search-mode')
+        new_args.append('quick')
+
+        self._evaluate_config(new_args, yaml_content, subcommand='profile')
 
     def test_quick_search_mode(self):
         """


### PR DESCRIPTION
Checks that quick search is specified when running multi-model and than no search or list values are used when in quick search.

Added unit testing and refactored the code in config command.