### PR TITLE
Update gevent version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ pdfkit>=0.6.1
 cryptography>=3.3.2
 httplib2>=0.19.0
 tritonclient[all]>=2.4.0
-gevent>=21.12.0
+gevent>=22.08.0


### PR DESCRIPTION
Update gevent version to pick up the following fix:
https://github.com/gevent/gevent/pull/1864

I confirmed this makes the following warnings go away:
```
/usr/local/lib/python3.8/dist-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
setattr(self, word, getattr(machar, word).flat[0])
/usr/local/lib/python3.8/dist-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.
return self._float_to_str(self.smallest_subnormal)
```
