### PR TITLE
Fix PDF warning to include command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -181,6 +181,13 @@ pip3 install --upgrade pip
 
 You can then try installing model analyzer again.
 
+Optionally, if you want Model Analyzer to generate PDF reports instead of HTML, 
+you should also run the following:
+
+```
+sudo apt-get update && sudo apt-get install wkhtmltopdf
+```
+
 <br>
 
 ## From the Source

--- a/model_analyzer/reports/report_factory.py
+++ b/model_analyzer/reports/report_factory.py
@@ -27,14 +27,20 @@ class ReportFactory:
     """
 
     PDF_PACKAGE = "wkhtmltopdf"
+    WARNING_PRINTED = False
 
     @staticmethod
     def create_report():
         if ReportFactory._is_package_installed(f"{ReportFactory.PDF_PACKAGE}"):
             return ReportFactory._create_pdf_report()
         else:
-            logging.warning(f"Warning: {ReportFactory.PDF_PACKAGE} is not installed. "\
-                f"Pdf reports cannot be generated. Html reports will be generated instead."
+            if not ReportFactory.WARNING_PRINTED:
+                ReportFactory.WARNING_PRINTED = True
+                logging.warning(
+                    f'Warning: html reports are being generated instead of pdf because'
+                    f'{ReportFactory.PDF_PACKAGE} is not installed. If you want pdf '
+                    f'reports, run the following command and then rerun Model Analyzer: '
+                    f'"sudo apt-get update && sudo apt-get install wkhtmltopdf"'
                 )
             return ReportFactory._create_html_report()
 


### PR DESCRIPTION
Despite what https://github.com/triton-inference-server/model_analyzer/pull/493 says, wkhtmltopdf is NOT included in the wheel install. Thus, adding back in clearer directions for the case where the user runs without it installed.

Also, making sure the warning only prints once per run.