### PR TITLE
Fixing constraints statement for multi-model

### DIFF
--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -439,7 +439,7 @@ class ReportManager:
 
     def _create_multi_model_constraint_string(self, report_key: str,
                                               constraint_strs: str) -> str:
-        constraint_str = None
+        constraint_str = ""
         for model_name in report_key.split(','):
             if model_name in constraint_strs:
                 if constraint_str:
@@ -447,11 +447,8 @@ class ReportManager:
                     for i in range(len("Constraint targets: ")):
                         constraint_str += "&ensp;"
 
-                    constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
-                        model_name]
-                else:
-                    constraint_str = "<strong>" + model_name + "</strong>: " + constraint_strs[
-                        model_name]
+                constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
+                    model_name]
 
         return constraint_str
 

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -437,8 +437,8 @@ class ReportManager:
 
         return constraint_str
 
-    def _create_multi_model_constraint_string(self, report_key: str,
-                                              constraint_strs: str) -> str:
+    def _create_multi_model_constraint_string(
+            self, report_key: str, constraint_strs: Dict[str, str]) -> str:
         constraint_str = ""
         for model_name in report_key.split(','):
             if model_name in constraint_strs:

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -936,7 +936,7 @@ class ReportManager:
         max_mem_str = f"{max_memory} GB"
         return (gpu_names, max_mem_str)
 
-    def _build_constraint_strings(self):
+    def _build_constraint_strings(self) -> Dict[str, str]:
         """
         Constructs constraint strings to show the constraints under which
         each model is being run.

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -309,13 +309,7 @@ class ReportManager:
             measurements=[v for _, v in self._summary_data[report_key]])
 
         # Get constraints
-        constraint_strs = self._build_constraint_strings()
-        constraint_str = "None"
-        if constraint_strs:
-            if report_key in constraint_strs:
-                constraint_str = constraint_strs[report_key]
-            elif report_key == TOP_MODELS_REPORT_KEY:
-                constraint_str = constraint_strs['default']
+        constraint_str = self._create_constraint_string(report_key)
 
         # Build summary table and info sentence
         if not cpu_only:
@@ -425,6 +419,28 @@ class ReportManager:
         best_run_config_measurement = sorted_measurements[0][1]
 
         return best_run_config, best_run_config_measurement, sorted_measurements
+
+    def _create_constraint_string(self, report_key: str) -> str:
+        constraint_strs = self._build_constraint_strings()
+
+        if constraint_strs:
+            if report_key == TOP_MODELS_REPORT_KEY:
+                constraint_str = constraint_strs['default']
+            elif ',' in report_key:  # indicates multi-model
+                constraint_str = ""
+                for model_name in report_key.split(','):
+                    if model_name in constraint_strs:
+                        constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
+                            model_name] + "<br>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"
+
+                constraint_str = constraint_str[:-64]  # remove trailing <br>...
+            else:  # single-model
+                if report_key in constraint_strs:
+                    constraint_str = constraint_strs[report_key]
+        else:
+            constraint_str = "None"
+
+        return constraint_str
 
     def _create_summary_sentence(self, report_key, num_configurations,
                                  num_measurements, best_run_config,
@@ -925,11 +941,11 @@ class ReportManager:
                     metric_header = MetricsManager.get_metric_types(
                         [metric])[0].header(aggregation_tag='')
                     for constraint_type, constraint_val in constraint.items():
-                        # String looks like 'Max p99 Latency : 99 ms'
+                        # String looks like 'Max p99 Latency: 99 ms'
                         metric_header_name = metric_header.rsplit(' ', 1)[0]
                         metric_unit = metric_header.rsplit(' ', 1)[1][1:-1]
                         strs.append(
-                            f"{constraint_type.capitalize()} {metric_header_name} : {constraint_val} {metric_unit}"
+                            f"{constraint_type.capitalize()} {metric_header_name}: {constraint_val} {metric_unit}"
                         )
                 constraint_strs[model_name] = ', '.join(strs)
         return constraint_strs

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -427,13 +427,19 @@ class ReportManager:
             if report_key == TOP_MODELS_REPORT_KEY:
                 constraint_str = constraint_strs['default']
             elif ',' in report_key:  # indicates multi-model
-                constraint_str = ""
+                constraint_str = None
                 for model_name in report_key.split(','):
                     if model_name in constraint_strs:
-                        constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
-                            model_name] + "<br>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"
+                        if constraint_str:
+                            constraint_str += "<br>"
+                            for i in range(len("Constraint targets: ")):
+                                constraint_str += "&ensp;"
 
-                constraint_str = constraint_str[:-64]  # remove trailing <br>...
+                            constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
+                                model_name]
+                        else:
+                            constraint_str = "<strong>" + model_name + "</strong>: " + constraint_strs[
+                                model_name]
             else:  # single-model
                 if report_key in constraint_strs:
                     constraint_str = constraint_strs[report_key]

--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -427,24 +427,31 @@ class ReportManager:
             if report_key == TOP_MODELS_REPORT_KEY:
                 constraint_str = constraint_strs['default']
             elif ',' in report_key:  # indicates multi-model
-                constraint_str = None
-                for model_name in report_key.split(','):
-                    if model_name in constraint_strs:
-                        if constraint_str:
-                            constraint_str += "<br>"
-                            for i in range(len("Constraint targets: ")):
-                                constraint_str += "&ensp;"
-
-                            constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
-                                model_name]
-                        else:
-                            constraint_str = "<strong>" + model_name + "</strong>: " + constraint_strs[
-                                model_name]
+                constraint_str = self._create_multi_model_constraint_string(
+                    report_key, constraint_strs)
             else:  # single-model
                 if report_key in constraint_strs:
                     constraint_str = constraint_strs[report_key]
         else:
             constraint_str = "None"
+
+        return constraint_str
+
+    def _create_multi_model_constraint_string(self, report_key: str,
+                                              constraint_strs: str) -> str:
+        constraint_str = None
+        for model_name in report_key.split(','):
+            if model_name in constraint_strs:
+                if constraint_str:
+                    constraint_str += "<br>"
+                    for i in range(len("Constraint targets: ")):
+                        constraint_str += "&ensp;"
+
+                    constraint_str += "<strong>" + model_name + "</strong>: " + constraint_strs[
+                        model_name]
+                else:
+                    constraint_str = "<strong>" + model_name + "</strong>: " + constraint_strs[
+                        model_name]
 
         return constraint_str
 

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -538,6 +538,40 @@ class TestReportManagerMethods(trc.TestResultCollector):
         self.assertEqual(names, "2 x fake_gpu_name, 1 x fake_gpu_name_3")
         self.assertEqual(max_mem, "12.0 GB")
 
+    @patch(
+        'model_analyzer.reports.report_manager.ReportManager._build_constraint_strings',
+        return_value={"modelA": "Max p99 latency: 100 ms"})
+    def test_constraint_string_single_model(self, *args):
+        report_manager = ReportManager(mode=MagicMock(),
+                                       config=MagicMock(),
+                                       gpu_info=MagicMock(),
+                                       result_manager=MagicMock())
+        expected_constraint_str = "Max p99 latency: 100 ms"
+        actual_constraint_str = report_manager._create_constraint_string(
+            report_key="modelA")
+
+        self.assertEqual(actual_constraint_str, expected_constraint_str)
+
+    @patch(
+        'model_analyzer.reports.report_manager.ReportManager._build_constraint_strings',
+        return_value={
+            "modelA": "Max p99 latency: 100 ms",
+            "modelB": "Max p99 latency: 200 ms"
+        })
+    def test_constraint_string_multi_model(self, *args):
+        report_manager = ReportManager(mode=MagicMock(),
+                                       config=MagicMock(),
+                                       gpu_info=MagicMock(),
+                                       result_manager=MagicMock())
+        expected_constraint_str = "<strong>modelA</strong>: Max p99 latency: 100 ms"
+        expected_constraint_str += "<br>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"
+        expected_constraint_str += "<strong>modelB</strong>: Max p99 latency: 200 ms"
+
+        actual_constraint_str = report_manager._create_constraint_string(
+            report_key="modelA,modelB")
+
+        self.assertEqual(actual_constraint_str, expected_constraint_str)
+
     def tearDown(self):
         self.matplotlib_mock.stop()
         self.io_mock.stop()

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -564,7 +564,11 @@ class TestReportManagerMethods(trc.TestResultCollector):
                                        gpu_info=MagicMock(),
                                        result_manager=MagicMock())
         expected_constraint_str = "<strong>modelA</strong>: Max p99 latency: 100 ms"
-        expected_constraint_str += "<br>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"
+        expected_constraint_str += "<br>"
+
+        for i in range(len("Constraint targets: ")):
+            expected_constraint_str += "&ensp;"
+
         expected_constraint_str += "<strong>modelB</strong>: Max p99 latency: 200 ms"
 
         actual_constraint_str = report_manager._create_constraint_string(


### PR DESCRIPTION
Noticed a bug in the constraints message in our result summary for multi-model runs:
![image](https://user-images.githubusercontent.com/92820864/202263830-a055756e-078a-4825-90a4-d0a1a43897fd.png)

Root caused an fixed it:
![image](https://user-images.githubusercontent.com/92820864/202264198-d704265e-9b7d-48fa-ac9f-0559db362333.png)

I've also added unit testing to ensure this doesn't break in the future and checked that single model is still printing as intended (just the constraint w/o the test name)