### PR TITLE
Add PA flag support to quick search's default config

### DIFF
--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -349,6 +349,9 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             perf_config_params = {'batch-size': 1, 'concurrency-range': 1}
             default_perf_analyzer_config.update_config(perf_config_params)
 
+            default_perf_analyzer_config.update_config(
+                model.perf_analyzer_flags())
+
             default_model_run_config = ModelRunConfig(
                 model.model_name(), default_model_config,
                 default_perf_analyzer_config)

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -44,7 +44,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 def evaluate_mock_config(
     args: list,
     yaml_str: str,
-    subcommand: str = 'analyze'
+    subcommand: str = 'profile'
 ) -> Union[ConfigCommandProfile, ConfigCommandReport]:
     """
     Return a ConfigCommandReport/Analyze/Profile created from the fake CLI


### PR DESCRIPTION
Fix issue where quick search's default config generation wasn't respecting the PA flags set by the user