### PR TITLE
Ensemble default config generation

### DIFF
--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -210,7 +210,7 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
         model_name = model.model_name()
         model_config_dict = model.get_default_config()
         ensemble_config_dicts = [
-            model.to_dict() for model in ensemble_submodels
+            submodel.to_dict() for submodel in ensemble_submodels
         ]
         ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
             ensemble_config_dicts)
@@ -224,7 +224,8 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
 
         for submodel in ensemble_submodels:
             variant_name = submodel.get_field("name")
-            submodel_name = variant_name[:variant_name.find("_config_")]
+            submodel_name = BaseModelConfigGenerator.extract_model_name_from_variant_name(
+                variant_name)
 
             model_config.set_submodel_variant_name(submodel_name=submodel_name,
                                                    variant_name=variant_name)
@@ -241,6 +242,10 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
                 "No longer increasing max_batch_size because throughput has plateaued"
             )
             self._max_batch_size_warning_printed = True
+
+    @staticmethod
+    def extract_model_name_from_variant_name(variant_name):
+        return variant_name[:variant_name.find("_config_")]
 
     @staticmethod
     def _apply_value_to_dict(key: Any, value: Any, dict_in: Dict) -> None:

--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -162,6 +162,13 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
         """
         Loads the base model config from the model repository, and then applies the
         parameters in the param_combo on top to create and return a new model config
+        
+        Parameters:
+        -----------
+        param_combo: dict
+            dict of key:value pairs to apply to the model config
+        model: ModelProfileSpec
+        model_variant_name_manager: ModelVariantNameManager
         """
         model_name = model.model_name()
 

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -62,19 +62,10 @@ class ModelVariantNameManager:
         If the same input values are provided to this function multiple times, 
         the same value will be returned
         """
-        mcd = self._copy_and_restore_mcd_name(model_name, model_config_dict)
-
-        variant_found, model_variant_name = self._find_existing_variant(mcd)
-
-        if self._is_default_config(param_combo):
-            return (False, model_name + '_config_default')
-
-        if variant_found:
-            return (True, model_variant_name)
-
-        model_variant_name = self._create_new_model_variant(model_name, mcd)
-
-        return (False, model_variant_name)
+        return self._get_variant_name(model_name,
+                                      model_config_dict,
+                                      is_ensemble=False,
+                                      param_combo=param_combo)
 
     def get_ensemble_model_variant_name(
             self, model_name: str, ensemble_dict: Dict) -> Tuple[bool, str]:
@@ -85,12 +76,25 @@ class ModelVariantNameManager:
         If the same input values are provided to this function multiple times,
         the same value will be returned
         """
-        mcd = self._copy_and_restore_mcd_name(model_name, ensemble_dict)
+        return self._get_variant_name(model_name,
+                                      ensemble_dict,
+                                      is_ensemble=True)
+
+    def _get_variant_name(self,
+                          model_name: str,
+                          config_dict: Dict,
+                          is_ensemble: bool,
+                          param_combo: Dict = {}) -> Tuple[bool, str]:
+        mcd = self._copy_and_restore_mcd_name(model_name, config_dict)
 
         variant_found, model_variant_name = self._find_existing_variant(mcd)
 
-        if self._is_ensemble_default_config(ensemble_dict):
-            return (False, model_name + '_config_default')
+        if is_ensemble:
+            if self._is_ensemble_default_config(config_dict):
+                return (False, model_name + '_config_default')
+        else:
+            if self._is_default_config(param_combo):
+                return (False, model_name + '_config_default')
 
         if variant_found:
             return (True, model_variant_name)

--- a/model_analyzer/config/generate/model_variant_name_manager.py
+++ b/model_analyzer/config/generate/model_variant_name_manager.py
@@ -85,9 +85,11 @@ class ModelVariantNameManager:
                           config_dict: Dict,
                           is_ensemble: bool,
                           param_combo: Dict = {}) -> Tuple[bool, str]:
-        mcd = self._copy_and_restore_mcd_name(model_name, config_dict)
+        model_config_dict = self._copy_and_restore_model_config_dict_name(
+            model_name, config_dict)
 
-        variant_found, model_variant_name = self._find_existing_variant(mcd)
+        variant_found, model_variant_name = self._find_existing_variant(
+            model_config_dict)
 
         if is_ensemble:
             if self._is_ensemble_default_config(config_dict):
@@ -99,16 +101,17 @@ class ModelVariantNameManager:
         if variant_found:
             return (True, model_variant_name)
 
-        model_variant_name = self._create_new_model_variant(model_name, mcd)
+        model_variant_name = self._create_new_model_variant(
+            model_name, model_config_dict)
 
         return (False, model_variant_name)
 
-    def _copy_and_restore_mcd_name(self, model_name: str,
-                                   model_config_dict: Dict) -> Dict:
-        mcd = deepcopy(model_config_dict)
-        mcd['name'] = model_name
+    def _copy_and_restore_model_config_dict_name(
+            self, model_name: str, model_config_dict: Dict) -> Dict:
+        model_config_dict_copy = deepcopy(model_config_dict)
+        model_config_dict_copy['name'] = model_name
 
-        return mcd
+        return model_config_dict_copy
 
     def _find_existing_variant(self,
                                model_config_dict: Dict) -> Tuple[bool, str]:

--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Generator
+from typing import List, Optional, Generator, Dict
 
 from .config_generator_interface import ConfigGeneratorInterface
 
@@ -48,8 +48,9 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
 
     def __init__(self, search_config: SearchConfig,
                  config: ConfigCommandProfile, gpus: List[GPUDevice],
-                 models: List[ModelProfileSpec], client: TritonClient,
-                 result_manager: ResultManager,
+                 models: List[ModelProfileSpec],
+                 ensemble_submodels: Dict[str, List[ModelProfileSpec]],
+                 client: TritonClient, result_manager: ResultManager,
                  model_variant_name_manager: ModelVariantNameManager):
         """
         Parameters
@@ -73,6 +74,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
         self._config = config
         self._gpus = gpus
         self._models = models
+        self._ensemble_submodels = ensemble_submodels
         self._client = client
         self._result_manager = result_manager
         self._model_variant_name_manager = model_variant_name_manager
@@ -116,6 +118,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
             config=self._config,
             gpus=self._gpus,
             models=self._models,
+            ensemble_submodels=self._ensemble_submodels,
             client=self._client,
             model_variant_name_manager=self._model_variant_name_manager)
 

--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -60,8 +60,10 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
         config: ConfigCommandProfile
             Profile configuration information
         gpus: List of GPUDevices
-        models: List of ConfigModelProfileSpec
+        models: List of ModelProfileSpec
             List of models to profile
+        ensemble_submodels: Dict of List of ModelProfileSpec
+            Dict indexed by model name of list of submodels to profile
         client: TritonClient
         result_manager: ResultManager
             The object that handles storing and sorting the results from the perf analyzer

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -32,6 +32,7 @@ from model_analyzer.triton.client.client import TritonClient
 from model_analyzer.device.gpu_device import GPUDevice
 from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
+from model_analyzer.config.input.objects.config_model_profile_spec import ConfigModelProfileSpec
 
 from model_analyzer.constants import LOGGER_NAME
 
@@ -47,7 +48,9 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
     def __init__(self, search_config: SearchConfig,
                  config: ConfigCommandProfile, gpus: List[GPUDevice],
-                 models: List[ModelProfileSpec], client: TritonClient,
+                 models: List[ModelProfileSpec],
+                 ensemble_submodels: Dict[str, List[ModelProfileSpec]],
+                 client: TritonClient,
                  model_variant_name_manager: ModelVariantNameManager):
         """
         Parameters
@@ -64,8 +67,11 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         """
         self._search_config = search_config
         self._config = config
-        self._models = models
         self._client = client
+        self._gpus = gpus
+        self._models = models
+        self._ensemble_submodels = ensemble_submodels
+
         self._model_variant_name_manager = model_variant_name_manager
 
         self._triton_env = BruteRunConfigGenerator.determine_triton_server_env(

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -370,8 +370,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             model.model_name(), default_ensemble_model_config,
             default_perf_analyzer_config)
 
-        default_model_run_config = self._add_submodels_to_model_run_config(
-            default_model_run_config, default_submodel_configs)
+        default_model_run_config.add_ensemble_submodel_configs(
+            default_submodel_configs)
 
         return default_model_run_config
 
@@ -387,14 +387,6 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             )
 
         return default_submodel_configs
-
-    def _add_submodels_to_model_run_config(
-            self, model_run_config: ModelRunConfig,
-            submodel_configs: List[ModelConfig]) -> ModelRunConfig:
-        for submodel_config in submodel_configs:
-            model_run_config.add_ensemble_submodel_config(submodel_config)
-
-        return model_run_config
 
     def _create_default_model_run_config(
             self, model: ModelProfileSpec) -> ModelRunConfig:

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -360,7 +360,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         default_ensemble_model_config = BaseModelConfigGenerator.make_ensemble_model_config(
             model=model,
-            ensemble_submodels=default_submodel_configs,
+            ensemble_submodel_configs=default_submodel_configs,
             model_variant_name_manager=self._model_variant_name_manager)
 
         default_perf_analyzer_config = self._create_default_perf_analyzer_config(

--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -198,8 +198,13 @@ class RunConfigGeneratorFactory:
             if model_config.is_ensemble():
                 ensemble_submodel_names = model_config.get_ensemble_submodels()
 
-                submodel_configs = ConfigModelProfileSpec.model_list_to_config_model_profile_spec(
+                submodel_specs = ConfigModelProfileSpec.model_list_to_config_model_profile_spec(
                     ensemble_submodel_names)
+
+                submodel_configs = [
+                    ModelProfileSpec(submodel_spec, config, client, gpus)
+                    for submodel_spec in submodel_specs
+                ]
 
                 submodels[model.model_name()] = submodel_configs
 

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -141,12 +141,13 @@ class ModelRunConfig:
         return self._model_config.get_ensemble_submodels(
         ) if self._model_config.is_ensemble() else None
 
-    def add_ensemble_submodel_config(self,
-                                     submodel_config: ModelConfig) -> None:
+    def add_ensemble_submodel_configs(
+            self, submodel_configs: List[ModelConfig]) -> None:
         """
-        Add an ensemble submodel config
+        Adds a list of ensemble submodel configs
         """
-        self._ensemble_subconfigs.append(submodel_config)
+        for submodel_config in submodel_configs:
+            self._ensemble_subconfigs.append(submodel_config)
 
     @classmethod
     def from_dict(cls, model_run_config_dict):

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -139,7 +139,7 @@ class ModelRunConfig:
         Returns list of Ensemble Subconfig names
         """
         return self._model_config.get_ensemble_submodels(
-        ) if self._model_config.is_ensemble() else None
+        ) if self._model_config.is_ensemble() else []
 
     def add_ensemble_submodel_configs(
             self, submodel_configs: List[ModelConfig]) -> None:

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -131,28 +131,6 @@ class ModelManager:
             'ModelManager.model_variant_name_manager',
             model_variant_name_manager_dict)
 
-    def _create_ensemble_submodels(
-        self, model: ConfigModelProfileSpec
-    ) -> Optional[List[ConfigModelProfileSpec]]:
-        model_config_dict = ModelConfig.create_model_config_dict(
-            config=self._config,
-            client=self._client,
-            gpus=self._gpus,
-            model_repository=self._config.model_repository,
-            model_name=model.model_name())
-
-        model_config = ModelConfig.create_from_dictionary(model_config_dict)
-
-        if not model_config.is_ensemble():
-            return None
-
-        ensemble_submodel_names = model_config.get_ensemble_submodels()
-
-        submodels = ConfigModelProfileSpec.model_list_to_config_model_profile_spec(
-            ensemble_submodel_names)
-
-        return submodels
-
     def _get_triton_server_flags(self, models):
         triton_server_flags = models[0].triton_server_flags()
 

--- a/model_analyzer/result/result_manager.py
+++ b/model_analyzer/result/result_manager.py
@@ -24,6 +24,8 @@ from .run_config_measurement import RunConfigMeasurement
 from .run_config_result import RunConfigResult
 from .results import Results
 
+from model_analyzer.config.generate.base_model_config_generator import BaseModelConfigGenerator
+
 from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
 from model_analyzer.config.input.config_command_report import ConfigCommandReport
 
@@ -152,7 +154,8 @@ class ResultManager:
 
         # Name format is <base_model_name>_config_<number_or_default>
         #
-        model_name = model_variants_name.rsplit('_', 2)[0]
+        model_name = BaseModelConfigGenerator.extract_model_name_from_variant_name(
+            model_variants_name)
 
         # Remote mode has model_name == model_config_name
         #

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -25,6 +25,10 @@ from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 
 from model_analyzer.triton.server.server_factory import TritonServerFactory
+from model_analyzer.config.input.objects.config_model_profile_spec import ConfigModelProfileSpec
+from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
+from model_analyzer.triton.client.client import TritonClient
+from model_analyzer.device.gpu_device import GPUDevice
 
 
 class ModelConfig:
@@ -244,6 +248,26 @@ class ModelConfig:
         model_config_dict = client.get_model_config(model_name, num_retries)
 
         return ModelConfig.create_from_dictionary(model_config_dict)
+
+    @staticmethod
+    def create_from_profile_spec(spec: ConfigModelProfileSpec,
+                                 config: ConfigCommandProfile,
+                                 client: TritonClient,
+                                 gpus: List[GPUDevice]) -> "ModelConfig":
+        """
+        Creates the model config from a ModelProfileSpec, plus assoc. collateral 
+        """
+
+        model_config_dict = ModelConfig.create_model_config_dict(
+            config=config,
+            client=client,
+            gpus=gpus,
+            model_repository=config.model_repository,
+            model_name=spec.model_name())
+
+        model_config = ModelConfig.create_from_dictionary(model_config_dict)
+
+        return model_config
 
     def set_cpu_only(self, cpu_only):
         """

--- a/tests/test_model_variant_name_manager.py
+++ b/tests/test_model_variant_name_manager.py
@@ -120,6 +120,77 @@ class TestModelVariantNameManager(trc.TestResultCollector):
         self.assertEqual(a0, (False, "modelA_config_0"))
         self.assertEqual(a1, (False, "modelA_config_1"))
 
+    def test_ensemble_default(self):
+        """
+        Test that a default ensemble config is returned
+        """
+        sub_configA = {"name": "modelA_config_default"}
+        sub_configB = {"name": "modelB_config_default"}
+
+        ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
+            [sub_configA, sub_configB])
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (False, "ensemble_model_config_default"))
+
+    def test_ensemble_basic(self):
+        """
+        Test that we can increment the ensemble config numbers
+        """
+        sub_configA = {"name": "modelA_config_0"}
+        sub_configB = {"name": "modelB_config_0"}
+
+        ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
+            [sub_configA, sub_configB])
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (False, "ensemble_model_config_0"))
+
+        sub_configB = {"name": "modelB_config_1"}
+
+        ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
+            [sub_configA, sub_configB])
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (False, "ensemble_model_config_1"))
+
+        sub_configA = {"name": "modelA_config_1"}
+
+        ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
+            [sub_configA, sub_configB])
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (False, "ensemble_model_config_2"))
+
+    def test_ensemble_repeat(self):
+        """
+        Calling with the same model name/ensemble key multiple times 
+        should result in the same config name being returned
+        """
+        sub_configA = {"name": "modelA_config_0"}
+        sub_configB = {"name": "modelB_config_0"}
+
+        ensemble_key = ModelVariantNameManager.make_ensemble_submodel_key(
+            [sub_configA, sub_configB])
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (False, "ensemble_model_config_0"))
+
+        name = self._mvnm.get_ensemble_model_variant_name(
+            "ensemble_model", ensemble_key)
+
+        self.assertEqual(name, (True, "ensemble_model_config_0"))
+
     def test_from_dict(self):
         """
         Restoring from a dict should see existing configs

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -385,6 +385,12 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
             SearchDimension("instance_count",
                             SearchDimension.DIMENSION_TYPE_LINEAR),
             SearchDimension("concurrency",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("max_batch_size",
+                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
+            SearchDimension("instance_count",
+                            SearchDimension.DIMENSION_TYPE_LINEAR),
+            SearchDimension("concurrency",
                             SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
         ])
 

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -378,23 +378,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
                                  gpus=MagicMock())
             ]
 
-        dims = SearchDimensions()
-        dims.add_dimensions(0, [
-            SearchDimension("max_batch_size",
-                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
-            SearchDimension("instance_count",
-                            SearchDimension.DIMENSION_TYPE_LINEAR),
-            SearchDimension("concurrency",
-                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
-            SearchDimension("max_batch_size",
-                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL),
-            SearchDimension("instance_count",
-                            SearchDimension.DIMENSION_TYPE_LINEAR),
-            SearchDimension("concurrency",
-                            SearchDimension.DIMENSION_TYPE_EXPONENTIAL)
-        ])
-
-        sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
+        sc = SearchConfig(dimensions=MagicMock(), radius=5, min_initialized=2)
 
         with patch(
                 "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",


### PR DESCRIPTION
Logic to create the default config in the Quick RCG for an ensemble model.
This also includes changes to the Model Variant Name Manager.

I have a new unit test in the QRCG and have run this with an ensemble model and verified that we are generating the default configs correctly.