### PR TITLE
Loading ensemble submodels into Triton

### DIFF
--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -26,6 +26,7 @@ from model_analyzer.perf_analyzer.perf_analyzer import PerfAnalyzer
 from model_analyzer.perf_analyzer.perf_config import PerfAnalyzerConfig
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 from model_analyzer.result.results import Results
+from model_analyzer.config.generate.base_model_config_generator import BaseModelConfigGenerator
 
 from collections import defaultdict
 from prometheus_client.parser import text_string_to_metric_families
@@ -276,6 +277,13 @@ class MetricsManager:
             self._create_model_variant(original_name=mrc.model_name(),
                                        variant_config=mrc.model_config())
 
+            for ensemble_subconfig in mrc.ensemble_subconfigs():
+                variant_name = ensemble_subconfig.get_field("name")
+                original_name = BaseModelConfigGenerator.extract_model_name_from_variant_name(
+                    variant_name)
+
+                self._create_model_variant(original_name, ensemble_subconfig)
+
     def _create_model_variant(self, original_name, variant_config):
         """
         Creates a directory for the model config variant in the output model
@@ -309,6 +317,11 @@ class MetricsManager:
         for mrc in run_config.model_run_configs():
             if not self._load_model_variant(variant_config=mrc.model_config()):
                 return False
+
+            for ensemble_subconfig in mrc.ensemble_subconfigs():
+                if not self._load_model_variant(
+                        variant_config=ensemble_subconfig):
+                    return False
         return True
 
     def _load_model_variant(self, variant_config):


### PR DESCRIPTION
The creates and loads the submodel variants for ensemble models. No unit testing for this, but here's the output log from an ensemble run (preprocess and resnet50_trt are the submodel names):

```
22:13:19 [Model Analyzer] Initializing GPUDevice handles
22:13:20 [Model Analyzer] Using GPU 0 NVIDIA TITAN RTX with UUID GPU-8557549f-9c89-4384-8bd6-1fd823c342e0
22:13:20 [Model Analyzer] WARNING: Overriding the output model repo path "/swdev/profile_outputs/"
22:13:20 [Model Analyzer] Starting a local Triton Server
22:13:20 [Model Analyzer] No checkpoint file found, starting a fresh run.
22:13:20 [Model Analyzer] Profiling server only metrics...
22:13:20 [Model Analyzer] DEBUG: Triton Server started.
22:13:30 [Model Analyzer] DEBUG: Stopped Triton Server.
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] Starting quick mode search to find optimal configs
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] Creating model config: preprocess_config_default
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] Creating model config: resnet50_trt_config_default
22:13:30 [Model Analyzer] 
22:13:30 [Model Analyzer] DEBUG: Triton Server started.
22:13:36 [Model Analyzer] DEBUG: Model ensemble_python_resnet50_config_default loaded
22:13:40 [Model Analyzer] DEBUG: Model preprocess_config_default loaded
22:13:41 [Model Analyzer] DEBUG: Model resnet50_trt_config_default loaded
22:13:41 [Model Analyzer] Profiling ensemble_python_resnet50_config_default: client batch size=1, concurrency=1
22:13:41 [Model Analyzer] DEBUG: Running ['perf_analyzer', '-m', 'ensemble_python_resnet50_config_default', '-b', '1', '-u', 'localhost:8001', '-i', 'grpc', '-f', 'ensemble_python_resnet50_config_default-results.csv', '--verbose-csv', '--concurrency-range', '1', '--input-data', '/swdev/profile_models/test_image', '--shape', 'INPUT:1005970', '--measurement-mode', 'count_windows', '--collect-metrics', '--metrics-url', 'http://localhost:8002/metrics', '--metrics-interval', '1000.0']
22:13:55 [Model Analyzer] DEBUG: Reading PA results from ensemble_python_resnet50_config_default-results.csv
22:13:55 [Model Analyzer] DEBUG: Measurement for [0, 0, 0, 0]: throughput = 14.4134, latency = 88.49 (best throughput: 14.4134, best_latency: 88.49)
```