### PR TITLE
fix bug for discarded records

### DIFF
--- a/model_analyzer/monitor/monitor.py
+++ b/model_analyzer/monitor/monitor.py
@@ -62,6 +62,7 @@ class Monitor(ABC):
             duration = time.time() - begin
             if duration < frequency:
                 time.sleep(frequency - duration)
+        self._monitoring_iteration()
 
     @abstractmethod
     def _monitoring_iteration(self):
@@ -114,6 +115,7 @@ class Monitor(ABC):
                 "called before stop_recording_metrics")
 
         self._thread_active = False
+        self._thread.wait()
         self._thread = None
 
         return self._collect_records()


### PR DESCRIPTION
The main thread set [`self._thread_active`](https://github.com/triton-inference-server/model_analyzer/blob/main/model_analyzer/monitor/monitor.py#L116) to False while the monitor thread is [sleeping](https://github.com/triton-inference-server/model_analyzer/blob/main/model_analyzer/monitor/monitor.py#L64). The monitor thread will directly exit the while loop after its sleeping. But the records collected during the monitor thread sleeping are not obtained by the main thread. 

This PR adds an extra `self._monitoring_iteration()` and `self._thread.wait()` to collect the last bunch of records.