### PR TITLE
Added ensemble support to detailed report PDF

### DIFF
--- a/model_analyzer/reports/report_manager.py
+++ b/model_analyzer/reports/report_manager.py
@@ -286,7 +286,7 @@ class ReportManager:
             "are the requested configurable plots showing the relationship between "
             "various metrics measured by the Model Analyzer. The above table contains "
             "detailed data for each of the measurements taken for this model config in "
-            "decreasing order of throughput.",
+            "decreasing order of concurrency.",
             font_size=18)
         return detailed_report
 
@@ -950,12 +950,22 @@ class ReportManager:
         if not run_config.cpu_only():
             gpu_names, max_memories = self._get_gpu_stats(measurements)
             gpu_cpu_string = f"GPU(s) {gpu_names} with total memory {max_memories}"
-        sentence = (
-            f"The model config \"{model_config_name}\" uses {instance_group_string} "
-            f"with {max_batch_size_string} and has {dynamic_batching_string}. "
-            f"{len(measurements)} measurement(s) were obtained for the model config on "
-            f"{gpu_cpu_string}. "
-            f"This model uses the platform {platform}.")
+
+        if run_config.is_ensemble_model():
+            sentence = f"This <strong>{model_config_name}</strong> consists of the following sub-model configurations:"
+
+            for ensemble_subconfig in run_config.ensemble_subconfigs():
+                sentence = sentence + '<LI> ' + self._create_summary_config_info(
+                    ensemble_subconfig) + ' </LI>'
+
+            sentence = sentence + f"<br>{len(measurements)} measurement(s) were obtained for the model config on {gpu_cpu_string}."
+        else:
+            sentence = (
+                f"The model config <strong>{model_config_name}</strong> uses {instance_group_string} "
+                f"with {max_batch_size_string} and has {dynamic_batching_string}. "
+                f"{len(measurements)} measurement(s) were obtained for the model config on "
+                f"{gpu_cpu_string}. "
+                f"This model uses the platform {platform}.")
 
         return sentence
 

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -316,13 +316,13 @@ class TestReportManagerMethods(trc.TestResultCollector):
 
         if cpu_only:
             expected_sentence = (
-                f"The model config \"test_model_config_10\" uses 1 GPU instance with "
+                f"The model config <strong>test_model_config_10</strong> uses 1 GPU instance with "
                 f"a max batch size of 8 and has dynamic batching enabled. 1 measurement(s) "
                 f"were obtained for the model config on CPU. "
                 f"This model uses the platform tensorflow_graphdef.")
         else:
             expected_sentence = (
-                f"The model config \"test_model_config_10\" uses 1 GPU instance with "
+                f"The model config <strong>test_model_config_10</strong> uses 1 GPU instance with "
                 f"a max batch size of 8 and has dynamic batching enabled. 1 measurement(s) "
                 f"were obtained for the model config on GPU(s) 1 x fake_gpu_name with total memory 1.0 GB. "
                 f"This model uses the platform tensorflow_graphdef.")


### PR DESCRIPTION
Updated the sentence below the table to include details about the submodels that make up the ensemble.

![image](https://user-images.githubusercontent.com/92820864/212182100-243916b8-2d19-47f8-9896-e7ff72c1325c.png)

(table is unchanged just shown for reference)