### PR TITLE
Allow min/max setting in quick search

### DIFF
--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -181,12 +181,17 @@ this will find greater than 95% of the maximum objective value (that could be fo
 
 After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the default concurrency range before generation of the summary reports.
 
+### Limiting Batch Size, Instance Count, and Client Concurrency
+
+Using the `--run-config-search-<min/max>...` CLI options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's concurrency.
+
+Note: That by default quick search runs unbounded and ignores any default values for these settings
+
 ## Multi-Model Search Mode
 
 _This mode is in EARLY ACCESS and has the following limitations:_
 
 - Can only be run in `quick` search mode
-- Cannot set limitations on min/max batch size, concurrency or instance count
 - Does not support individual model constraints, only global constraints
 - Does not support detailed reporting, only summary reports
 

--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -34,6 +34,7 @@ from model_analyzer.constants import LOGGER_NAME
 from model_analyzer.config.input.config_defaults import DEFAULT_RUN_CONFIG_MIN_CONCURRENCY, DEFAULT_RUN_CONFIG_MAX_CONCURRENCY
 
 from copy import deepcopy
+from math import log2
 
 import logging
 
@@ -135,8 +136,12 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
             for count, result in enumerate(top_results):
                 run_config = deepcopy(result.run_config())
 
+                max_concurrency_index = int(
+                    log2(self._config.run_config_search_max_concurrency))
+
                 run_config_measurements = []
-                for concurrency in (2**i for i in range(0, 10)):
+                for concurrency in (
+                        2**i for i in range(0, max_concurrency_index + 1)):
                     run_config = self._set_concurrency(run_config, concurrency)
                     yield run_config
 

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -374,7 +374,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         kind = "KIND_CPU" if model.cpu_only() else "KIND_GPU"
         instance_count = self._calculate_instance_count(
-            dimension_values['instance_count'])
+            int(dimension_values['instance_count']))
 
         param_combo: dict = {
             'instance_group': [{
@@ -385,7 +385,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         if 'max_batch_size' in dimension_values:
             param_combo['max_batch_size'] = self._calculate_model_batch_size(
-                dimension_values['max_batch_size'])
+                int(dimension_values['max_batch_size']))
 
         if model.supports_dynamic_batching():
             param_combo['dynamic_batching'] = {}
@@ -407,8 +407,9 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         perf_analyzer_config.update_config_from_profile_config(
             model_variant_name, self._config)
 
-        dimension_batch_size = dimension_values.get("max_batch_size", 1)
-        dimension_instance_count = dimension_values.get("instance_count", 1)
+        dimension_batch_size = int(dimension_values.get("max_batch_size", 1))
+        dimension_instance_count = int(dimension_values.get(
+            "instance_count", 1))
 
         model_batch_size = self._calculate_model_batch_size(
             dimension_batch_size)

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -418,16 +418,16 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self, dimension_values: Dict[str, Union[int, float]]) -> int:
         batch_size = int(dimension_values.get("max_batch_size", 1))
 
-        min_batch_size_set = self._config.get_config(
-        )['run_config_search_min_model_batch_size'].set_by_config()
+        min_batch_size_is_set_by_config = self._config.get_config(
+        )['run_config_search_min_model_batch_size'].is_set_by_config()
 
-        max_batch_size_set = self._config.get_config(
-        )['run_config_search_max_model_batch_size'].set_by_config()
+        max_batch_size_is_set_by_config = self._config.get_config(
+        )['run_config_search_max_model_batch_size'].is_set_by_config()
 
-        if min_batch_size_set and batch_size < self._config.run_config_search_min_model_batch_size:
+        if min_batch_size_is_set_by_config and batch_size < self._config.run_config_search_min_model_batch_size:
             return self._config.run_config_search_min_model_batch_size
 
-        if max_batch_size_set and batch_size > self._config.run_config_search_max_model_batch_size:
+        if max_batch_size_is_set_by_config and batch_size > self._config.run_config_search_max_model_batch_size:
             return self._config.run_config_search_max_model_batch_size
 
         return batch_size
@@ -436,16 +436,16 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self, dimension_values: Dict[str, Union[int, float]]) -> int:
         instance_count = int(dimension_values.get("instance_count", 1))
 
-        min_instance_count_set = self._config.get_config(
-        )['run_config_search_min_instance_count'].set_by_config()
+        min_instance_count_is_set_by_config = self._config.get_config(
+        )['run_config_search_min_instance_count'].is_set_by_config()
 
-        max_instance_count_set = self._config.get_config(
-        )['run_config_search_max_instance_count'].set_by_config()
+        max_instance_count_is_set_by_config = self._config.get_config(
+        )['run_config_search_max_instance_count'].is_set_by_config()
 
-        if min_instance_count_set and instance_count < self._config.run_config_search_min_instance_count:
+        if min_instance_count_is_set_by_config and instance_count < self._config.run_config_search_min_instance_count:
             return self._config.run_config_search_min_instance_count
 
-        if max_instance_count_set and instance_count > self._config.run_config_search_max_instance_count:
+        if max_instance_count_is_set_by_config and instance_count > self._config.run_config_search_max_instance_count:
             return self._config.run_config_search_max_instance_count
 
         return instance_count
@@ -456,16 +456,16 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         instance_count = self._calculate_instance_count(dimension_values)
         concurrency = 2 * model_batch_size * instance_count
 
-        min_concurrency_set = self._config.get_config(
-        )['run_config_search_min_concurrency'].set_by_config()
+        min_concurrency_is_set_by_config = self._config.get_config(
+        )['run_config_search_min_concurrency'].is_set_by_config()
 
-        max_concurrency_set = self._config.get_config(
-        )['run_config_search_max_concurrency'].set_by_config()
+        max_concurrency_is_set_by_config = self._config.get_config(
+        )['run_config_search_max_concurrency'].is_set_by_config()
 
-        if min_concurrency_set and concurrency < self._config.run_config_search_min_concurrency:
+        if min_concurrency_is_set_by_config and concurrency < self._config.run_config_search_min_concurrency:
             return self._config.run_config_search_min_concurrency
 
-        if max_concurrency_set and concurrency > self._config.run_config_search_max_concurrency:
+        if max_concurrency_is_set_by_config and concurrency > self._config.run_config_search_max_concurrency:
             return self._config.run_config_search_max_concurrency
 
         return concurrency

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -373,16 +373,19 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self._coordinate_to_measure, dimension_index)
 
         kind = "KIND_CPU" if model.cpu_only() else "KIND_GPU"
+        instance_count = self._calculate_instance_count(
+            dimension_values['instance_count'])
 
         param_combo: dict = {
             'instance_group': [{
-                'count': dimension_values['instance_count'],
+                'count': instance_count,
                 'kind': kind,
             }]
         }
 
         if 'max_batch_size' in dimension_values:
-            param_combo['max_batch_size'] = dimension_values['max_batch_size']
+            param_combo['max_batch_size'] = self._calculate_model_batch_size(
+                dimension_values['max_batch_size'])
 
         if model.supports_dynamic_batching():
             param_combo['dynamic_batching'] = {}
@@ -421,20 +424,20 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
         perf_analyzer_config.update_config(model.perf_analyzer_flags())
         return perf_analyzer_config
 
-    def _calculate_model_batch_size(self, dimension_batch_size: int) -> int:
+    def _calculate_model_batch_size(self, batch_size: int) -> int:
         min_batch_size_set = self._config.get_config(
         )['run_config_search_min_model_batch_size'].set_by_config()
 
         max_batch_size_set = self._config.get_config(
         )['run_config_search_max_model_batch_size'].set_by_config()
 
-        if min_batch_size_set and dimension_batch_size < self._config.run_config_search_min_model_batch_size:
+        if min_batch_size_set and batch_size < self._config.run_config_search_min_model_batch_size:
             return self._config.run_config_search_min_model_batch_size
 
-        if max_batch_size_set and dimension_batch_size > self._config.run_config_search_max_model_batch_size:
+        if max_batch_size_set and batch_size > self._config.run_config_search_max_model_batch_size:
             return self._config.run_config_search_max_model_batch_size
 
-        return dimension_batch_size
+        return batch_size
 
     def _calculate_instance_count(self, instance_count: int) -> int:
         min_instance_count_set = self._config.get_config(

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -124,9 +124,10 @@ class ConfigCommand:
             config_value = self._get_config_value(key, args, yaml_config)
 
             if config_value:
-                self._fields[key].set_value(config_value)
+                self._fields[key].set_value(config_value, set_by_config=True)
             elif value.default_value() is not None:
-                self._fields[key].set_value(value.default_value())
+                self._fields[key].set_value(value.default_value(),
+                                            set_by_config=False)
             elif value.required():
                 flags = ', '.join(value.flags())
                 raise TritonModelAnalyzerException(
@@ -184,7 +185,7 @@ class ConfigCommand:
             return
 
         self._check_no_search_disable(args, yaml_config)
-        self._check_no_search_values(args, yaml_config)
+        # self._check_no_search_values(args, yaml_config)
         self._check_no_global_list_values(args, yaml_config)
         self._check_no_per_model_list_values(args, yaml_config)
 

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -185,7 +185,6 @@ class ConfigCommand:
             return
 
         self._check_no_search_disable(args, yaml_config)
-        # self._check_no_search_values(args, yaml_config)
         self._check_no_global_list_values(args, yaml_config)
         self._check_no_per_model_list_values(args, yaml_config)
 
@@ -197,37 +196,6 @@ class ConfigCommand:
             raise TritonModelAnalyzerException(
                 f'\nDisabling of run config search is not supported in quick search mode.'
                 '\nPlease use brute search mode or remove --run-config-search-disable.'
-            )
-
-    def _check_no_search_values(self, args: Namespace,
-                                yaml_config: Optional[Dict[str, List]]) -> None:
-        max_concurrency = self._get_config_value(
-            'run_config_search_max_concurrency', args, yaml_config)
-        min_concurrency = self._get_config_value(
-            'run_config_search_min_concurrency', args, yaml_config)
-        max_instance = self._get_config_value(
-            'run_config_search_max_instance_count', args, yaml_config)
-        min_instance = self._get_config_value(
-            'run_config_search_min_instance_count', args, yaml_config)
-        max_batch_size = self._get_config_value(
-            'run_config_search_max_model_batch_size', args, yaml_config)
-        min_batch_size = self._get_config_value(
-            'run_config_search_min_model_batch_size', args, yaml_config)
-
-        if max_concurrency or min_concurrency:
-            raise TritonModelAnalyzerException(
-                f'\nProfiling of models in quick search mode is not supported with min/max concurrency search values.'
-                '\nPlease use brute search mode or remove concurrency search values.'
-            )
-        if max_instance or min_instance:
-            raise TritonModelAnalyzerException(
-                f'\nProfiling of models in quick search mode is not supported with min/max instance search values.'
-                '\nPlease use brute search mode or remove instance search values.'
-            )
-        if max_batch_size or min_batch_size:
-            raise TritonModelAnalyzerException(
-                f'\nProfiling of models in quick search mode is not supported with min/max batch size search values.'
-                '\nPlease use brute search mode or remove batch size search values.'
             )
 
     def _check_no_global_list_values(

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -124,10 +124,10 @@ class ConfigCommand:
             config_value = self._get_config_value(key, args, yaml_config)
 
             if config_value:
-                self._fields[key].set_value(config_value, set_by_config=True)
+                self._fields[key].set_value(config_value, is_set_by_config=True)
             elif value.default_value() is not None:
                 self._fields[key].set_value(value.default_value(),
-                                            set_by_config=False)
+                                            is_set_by_config=False)
             elif value.required():
                 flags = ', '.join(value.flags())
                 raise TritonModelAnalyzerException(
@@ -309,4 +309,4 @@ class ConfigCommand:
         if name == '_fields':
             self.__dict__[name] = value
         else:
-            self._fields[name].set_value(value)
+            self._fields[name].set_value(value, is_set_by_config=True)

--- a/model_analyzer/config/input/config_field.py
+++ b/model_analyzer/config/input/config_field.py
@@ -17,6 +17,8 @@ from model_analyzer.model_analyzer_exceptions import \
 from model_analyzer.constants import \
     CONFIG_PARSER_FAILURE
 
+from typing import Any
+
 
 class ConfigField:
 
@@ -151,7 +153,7 @@ class ConfigField:
 
         return self._flags
 
-    def set_value(self, value, set_by_config: bool = False):
+    def set_value(self, value: Any, set_by_config: bool = False) -> None:
         """
         Set the value for the config field.
         """

--- a/model_analyzer/config/input/config_field.py
+++ b/model_analyzer/config/input/config_field.py
@@ -179,7 +179,7 @@ class ConfigField:
 
         self._default_value = default_value
 
-        self._set_by_user = False
+        self._set_by_config = False
 
     def value(self):
         """

--- a/model_analyzer/config/input/config_field.py
+++ b/model_analyzer/config/input/config_field.py
@@ -59,7 +59,7 @@ class ConfigField:
         self._flags = flags
         self._choices = choices
         self._parser_args = {} if parser_args is None else parser_args
-        self._set_by_config = False
+        self._is_set_by_config = False
 
     def choices(self):
         """
@@ -153,7 +153,7 @@ class ConfigField:
 
         return self._flags
 
-    def set_value(self, value: Any, set_by_config: bool = False) -> None:
+    def set_value(self, value: Any, is_set_by_config: bool = False) -> None:
         """
         Set the value for the config field.
         """
@@ -165,7 +165,7 @@ class ConfigField:
                 f'Failed to set the value for field "{self._name}". Error: {config_status.message()}'
             )
 
-        self._set_by_config = set_by_config
+        self._is_set_by_config = is_set_by_config
 
     def set_default_value(self, default_value):
         """
@@ -179,7 +179,7 @@ class ConfigField:
 
         self._default_value = default_value
 
-        self._set_by_config = False
+        self._is_set_by_config = False
 
     def value(self):
         """
@@ -208,8 +208,8 @@ class ConfigField:
     def set_name(self, name):
         self._field_type.set_name(name)
 
-    def set_by_config(self) -> bool:
+    def is_set_by_config(self) -> bool:
         """
         Returns true if the user set the field
         """
-        return self._set_by_config
+        return self._is_set_by_config

--- a/model_analyzer/config/input/config_field.py
+++ b/model_analyzer/config/input/config_field.py
@@ -57,6 +57,7 @@ class ConfigField:
         self._flags = flags
         self._choices = choices
         self._parser_args = {} if parser_args is None else parser_args
+        self._set_by_config = False
 
     def choices(self):
         """
@@ -150,7 +151,7 @@ class ConfigField:
 
         return self._flags
 
-    def set_value(self, value):
+    def set_value(self, value, set_by_config: bool = False):
         """
         Set the value for the config field.
         """
@@ -161,6 +162,8 @@ class ConfigField:
             raise TritonModelAnalyzerException(
                 f'Failed to set the value for field "{self._name}". Error: {config_status.message()}'
             )
+
+        self._set_by_config = set_by_config
 
     def set_default_value(self, default_value):
         """
@@ -173,6 +176,8 @@ class ConfigField:
         """
 
         self._default_value = default_value
+
+        self._set_by_user = False
 
     def value(self):
         """
@@ -200,3 +205,9 @@ class ConfigField:
 
     def set_name(self, name):
         self._field_type.set_name(name)
+
+    def set_by_config(self) -> bool:
+        """
+        Returns true if the user set the field
+        """
+        return self._set_by_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1369,9 +1369,10 @@ profile_models:
 
             self.assertEqual(
                 config.get_all_config()['profile_models'][0].constraints(),
-                ModelConstraints({constraint_shorthand[2]: {
-                     constraint_shorthand[1]: 40
-                 }}))
+                ModelConstraints(
+                    {constraint_shorthand[2]: {
+                         constraint_shorthand[1]: 40
+                     }}))
 
             # check that model specific constraints are appended to
             args = [
@@ -1395,7 +1396,8 @@ profile_models:
                      constraint_shorthand[1]: 40
                  }})
             self.assertEqual(
-                config.get_all_config()['profile_models'][0].constraints(), ModelConstraints({
+                config.get_all_config()['profile_models'][0].constraints(),
+                ModelConstraints({
                     constraint_shorthand[2]: {
                         constraint_shorthand[1]: 40
                     },
@@ -1417,9 +1419,10 @@ profile_models:
                                            subcommand='profile')
             self.assertEqual(
                 config.get_all_config()['profile_models'][0].constraints(),
-                ModelConstraints({constraint_shorthand[2]: {
-                     constraint_shorthand[1]: 40
-                 }}))
+                ModelConstraints(
+                    {constraint_shorthand[2]: {
+                         constraint_shorthand[1]: 40
+                     }}))
 
             # check that global constraints are appended to
             yaml_content = """
@@ -1809,18 +1812,6 @@ profile_models:
                                          '--run-config-search-disable',
                                          use_value=False,
                                          use_list=False)
-        self._test_quick_search_with_rcs(args, yaml_content,
-                                         '--run-config-search-min-concurrency')
-        self._test_quick_search_with_rcs(args, yaml_content,
-                                         '--run-config-search-max-concurrency')
-        self._test_quick_search_with_rcs(
-            args, yaml_content, '--run-config-search-min-instance-count')
-        self._test_quick_search_with_rcs(
-            args, yaml_content, '--run-config-search-max-instance-count')
-        self._test_quick_search_with_rcs(
-            args, yaml_content, '--run-config-search-min-model-batch-size')
-        self._test_quick_search_with_rcs(
-            args, yaml_content, '--run-config-search-max-model-batch-size')
         self._test_quick_search_with_rcs(args,
                                          yaml_content,
                                          '--batch-sizes',


### PR DESCRIPTION
This change enables the user to specify a min/max concurrency, model batch size or instance count in quick search.

Added unit testing to cover all relevant cases and have tried this out with an ensemble model and confirmed it is working.