### PR TITLE
Checking for illegal inputs from user for an ensemble model

### DIFF
--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -41,7 +41,7 @@ class RunConfigGeneratorFactory:
     @staticmethod
     def create_run_config_generator(
         command_config: ConfigCommandProfile, gpus: List[GPUDevice],
-        models: List[ModelProfileSpec], client: TritonClient,
+        models: List[ConfigModelProfileSpec], client: TritonClient,
         result_manager: ResultManager,
         model_variant_name_manager: ModelVariantNameManager
     ) -> ConfigGeneratorInterface:

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -113,8 +113,9 @@ class ConfigCommand:
     def _check_for_illegal_config_settings(
             self, args: Namespace, yaml_config: Optional[Dict[str,
                                                               List]]) -> None:
-        # Illegal config settings check for ensemble is done in model_manager,
+        # Note: Illegal config settings check for ensemble is done in model_manager,
         # since we don't yet know the type of model being profiled
+
         self._check_for_duplicate_profile_models_option(args, yaml_config)
         self._check_for_multi_model_incompatability(args, yaml_config)
         self._check_for_quick_search_incompatability(args, yaml_config)

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -113,8 +113,8 @@ class ConfigCommand:
     def _check_for_illegal_config_settings(
             self, args: Namespace, yaml_config: Optional[Dict[str,
                                                               List]]) -> None:
-        # Illegal config settings for ensemble is done in model_manager,
-        # since we don't yet know if the model is an ensemble
+        # Illegal config settings check for ensemble is done in model_manager,
+        # since we don't yet know the type of model being profiled
         self._check_for_duplicate_profile_models_option(args, yaml_config)
         self._check_for_multi_model_incompatability(args, yaml_config)
         self._check_for_quick_search_incompatability(args, yaml_config)

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -113,6 +113,8 @@ class ConfigCommand:
     def _check_for_illegal_config_settings(
             self, args: Namespace, yaml_config: Optional[Dict[str,
                                                               List]]) -> None:
+        # Illegal config settings for ensemble is done in model_manager,
+        # since we don't yet know if the model is an ensemble
         self._check_for_duplicate_profile_models_option(args, yaml_config)
         self._check_for_multi_model_incompatability(args, yaml_config)
         self._check_for_quick_search_incompatability(args, yaml_config)

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -129,7 +129,7 @@ class ModelManager:
         self._server.update_config(params=server_config_copy.server_args())
 
         model_variant_name_manager_dict = self._state_manager.default_encode(
-            rcg._model_variant_name_manager)  # type: ignore
+            self._model_variant_name_manager)
 
         self._state_manager.set_state_variable(
             'ModelManager.model_variant_name_manager',
@@ -159,7 +159,8 @@ class ModelManager:
                 if self._config.run_config_search_mode != 'quick':
                     raise TritonModelAnalyzerException(
                         f'\nBrute search mode is not supported for ensemble models'
-                        '\nPlease use quick search mode')
+                        '\nPlease use quick search mode (--run-config-search-mode quick)'
+                    )
 
     def _init_state(self):
         """

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -23,6 +23,8 @@ from model_analyzer.record.metrics_manager import MetricsManager
 from model_analyzer.model_manager import ModelManager
 from model_analyzer.state.analyzer_state_manager import AnalyzerStateManager
 from model_analyzer.triton.model.model_config import ModelConfig
+from model_analyzer.config.input.objects.config_model_profile_spec import ConfigModelProfileSpec
+from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -1017,6 +1019,45 @@ class TestModelManager(trc.TestResultCollector):
             """)
 
         self._test_model_manager(yaml_str, expected_ranges)
+
+    @patch('model_analyzer.triton.model.model_config.ModelConfig.is_ensemble',
+           return_value=True)
+    def test_ensemble_illegal_checks(self, *args):
+        yaml_str = ("""
+                  profile_models: ensemble_model, test_model
+                  """)
+
+        args = self._args.copy()
+        args.append('--run-config-search-mode')
+        args.append('brute')
+
+        self.mock_model_config = MockModelConfig(self._model_config_protobuf)
+        self.mock_model_config.start()
+        config = evaluate_mock_config(args, yaml_str, subcommand="profile")
+
+        state_manager = AnalyzerStateManager(config, MagicMock())
+        metrics_manager = MetricsManagerSubclass(config, MagicMock(),
+                                                 MagicMock(), MagicMock(),
+                                                 MagicMock(), state_manager)
+        model_manager = ModelManager(config, MagicMock(), MagicMock(),
+                                     MagicMock(), metrics_manager, MagicMock(),
+                                     state_manager)
+
+        # Multiple model check
+        models = [
+            ConfigModelProfileSpec('ensemble_model'),
+            ConfigModelProfileSpec('test_model')
+        ]
+        with self.assertRaises(TritonModelAnalyzerException):
+            model_manager._check_for_ensemble_model_incompatability(models)
+
+        # RunConfigSearch check
+        models = [
+            ConfigModelProfileSpec('ensemble_model'),
+        ]
+        with self.assertRaises(TritonModelAnalyzerException):
+            model_manager._check_for_ensemble_model_incompatability(models)
+        self.mock_model_config.stop()
 
     def _test_model_manager(self, yaml_content, expected_ranges, args=None):
         """ 


### PR DESCRIPTION
This checks for the two illegal inputs the user could provide for an ensemble model:

- More than one model being profiled
- Brute force search mode