### PR TITLE
Add is_legal_combination check for ensemble submodels

### DIFF
--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -139,7 +139,7 @@ class RunConfigGeneratorFactory:
             if model.model_name() in ensemble_submodels:
                 for submodel in ensemble_submodels[model.model_name()]:
                     dims = RunConfigGeneratorFactory._get_dimensions_for_model(
-                        model.supports_batching())
+                        submodel.supports_batching())
                     dimensions.add_dimensions(index, dims)
                     index += 1
             else:

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -133,22 +133,29 @@ class ModelRunConfig:
         """
         Returns false if maximum of preferred batch size is greater than model batch size. Else true
         """
-        model_config = self._model_config.get_config()
         legal = True
+        ensemble_subconfigs = [
+            subconfig.get_config() for subconfig in self._ensemble_subconfigs
+        ]
+        model_configs = ensemble_subconfigs if self._ensemble_subconfigs else [
+            self._model_config.get_config()
+        ]
 
-        max_batch_size = model_config[
-            'max_batch_size'] if 'max_batch_size' in model_config else self.DEFAULT_MAX_BATCH_SIZE
+        for model_config in model_configs:
+            max_batch_size = model_config[
+                'max_batch_size'] if 'max_batch_size' in model_config else self.DEFAULT_MAX_BATCH_SIZE
 
-        if 'dynamic_batching' in model_config and 'preferred_batch_size' in model_config[
-                'dynamic_batching']:
-            max_preferred_batch_size = max(
-                model_config['dynamic_batching']['preferred_batch_size'])
-            legal = max_batch_size >= max_preferred_batch_size
+            if 'dynamic_batching' in model_config and 'preferred_batch_size' in model_config[
+                    'dynamic_batching']:
+                max_preferred_batch_size = max(
+                    model_config['dynamic_batching']['preferred_batch_size'])
+                legal = max_batch_size >= max_preferred_batch_size
 
-            if not legal:
-                logger.debug(
-                    f"Illegal model run config because maximum of model preferred batch size {max_preferred_batch_size} is greater than model max batch size {max_batch_size}"
-                )
+                if not legal:
+                    logger.debug(
+                        f"Illegal model run config because maximum of {model_config['name']}'s preferred batch size {max_preferred_batch_size} is greater than model max batch size {max_batch_size}"
+                    )
+                    return legal
 
         return legal
 


### PR DESCRIPTION
Adds in the necessary checks to see if all ensemble submodels are legal w/ unit testing.

Also:

- fixes a bug in RCG that was not properly setting the batch size dimension for ensemble models
- fixes formatting issues from Sai's check-in.