### PR TITLE
Add Ensemble documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Triton Inference Server.
   find the optimal settings when profiling multiple concurrent models, utilizing the Quick Search alogrithm
 
 - [Ensemble Model Search](docs/config_search.md#ensemble-model-search): Model Analyzer can help you find the optimal
-  settings when profiling an ensemble model, utilizing the Quick Search algorithm
+  settings when profiling a non-BLS ensemble model, utilizing the Quick Search algorithm
 
 - [Detailed and summary reports](docs/report.md): Model Analyzer is able to generate
   summarized and detailed reports that can help you better understand the trade-offs

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Triton Inference Server.
   to test the model with different concurrency and batch sizes of requests. Using
   [Manual Config Search](docs/config_search.md#manual-brute-search), you can create manual sweeps for every parameter that can be specified in the model configuration.
 
-- [Multi-Model Search](docs/config_search.md#multi-model-search-mode): Model Analyzer can help you
-  find the optimal settings when profiling multiple concurrent models, utilizing our Quick Search alogrithm
+- [Multi-Model Search](docs/config_search.md#multi-model-search-mode): **EARLY ACCESS** - Model Analyzer can help you
+  find the optimal settings when profiling multiple concurrent models, utilizing the Quick Search alogrithm
 
 - [Ensemble Model Search](docs/config_search.md#ensemble-model-search): Model Analyzer can help you find the optimal
-  settings when profiling an ensemble model, utilizing our Quick Search algorithm
+  settings when profiling an ensemble model, utilizing the Quick Search algorithm
 
 - [Detailed and summary reports](docs/report.md): Model Analyzer is able to generate
   summarized and detailed reports that can help you better understand the trade-offs
@@ -60,7 +60,7 @@ Triton Inference Server.
 
 ## Examples and Tutorials
 
-See our [Quick Start](docs/quick_start.md) for a guide of how to use Model Analyzer to profile, analyze and report on a simple PyTorch model.
+See the [Quick Start](docs/quick_start.md) for a guide of how to use Model Analyzer to profile, analyze and report on a simple PyTorch model.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Triton Inference Server.
   to test the model with different concurrency and batch sizes of requests. Using
   [Manual Config Search](docs/config_search.md#manual-brute-search), you can create manual sweeps for every parameter that can be specified in the model configuration.
 
-- [Multi-Model Search](docs/config_search.md#multi-model-search-mode): **EARLY ACCESS** - Model Analyzer can help you
+- [Multi-Model Search](docs/config_search.md#multi-model-search-mode): Model Analyzer can help you
   find the optimal settings when profiling multiple concurrent models, utilizing our Quick Search alogrithm
+
+- [Ensemble Model Search](docs/config_search.md#ensemble-model-search): Model Analyzer can help you find the optimal
+  settings when profiling an ensemble model, utilizing our Quick Search algorithm
 
 - [Detailed and summary reports](docs/report.md): Model Analyzer is able to generate
   summarized and detailed reports that can help you better understand the trade-offs

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -187,6 +187,16 @@ Using the `--run-config-search-<min/max>...` CLI options you have the ability to
 
 Note: That by default quick search runs unbounded and ignores any default values for these settings
 
+## Ensemble Model Search
+
+_This mode has the following limitations:_
+
+- Can only be run in `quick` search mode
+
+Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under 60 minutes (compared to the days it would take a brute force run to complete) for ensembles with up to 4 submodels.
+
+After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
+
 ## Multi-Model Search Mode
 
 _This mode is in EARLY ACCESS and has the following limitations:_

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ _This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
 
-Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under 60 minutes (compared to the days it would take a brute force run to complete) for ensembles with up to 4 submodels.
+Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
 
 After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -190,7 +190,7 @@ _This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
 
-Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
+Non-BLS Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
 
 After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -20,9 +20,6 @@ Model Analyzer's `profile` subcommand supports multiple modes when searching to 
 
 - [Brute](config_search.md#brute-search-mode) is the default, and will do a brute-force sweep of the cross product of all possible configurations
 - [Quick](config_search.md#quick-search-mode) will use heuristics to try to find the optimal configuration much quicker than brute, and can be enabled via `--run-config-search-mode quick`
-
-_This is mode is in **EARLY ACCESS** and is limited in scope:_
-
 - [Multi-model](config_search.md#multi-model-search-mode) will profile mutliple models to find the optimal configurations for all models while they are running concurrently. This feature is enabled via `--run-config-profile-models-concurrently-enable`
 
 ## Brute Search Mode
@@ -199,7 +196,7 @@ After it has found the best config(s), it will then sweep the top-N configuratio
 
 ## Multi-Model Search Mode
 
-_This mode is in EARLY ACCESS and has the following limitations:_
+_This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
 - Does not support detailed reporting, only summary reports

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -189,8 +189,9 @@ Note: That by default quick search runs unbounded and ignores any default values
 _This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
+- Only supports up to 3 sub-models
 
-Non-BLS Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
+Non-BLS Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to three submodels.
 
 After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 


### PR DESCRIPTION
Adding ensemble model support to our documentation. Will file a separate story to add an example ensemble to our documentation when we find a suitable model. I've also removed the `early access` tag from multi-model. 