### PR TITLE
Rewrite config_search.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -177,10 +177,10 @@ profile_models: <comma-delimited-string-list>
 # Maximum max_batch_size used for the automatic config search.
 [ run_config_search_max_model_batch_size: <int> | default: 128 ]
 
-# Minimum instance count used for the automatic config search.
+# Minimum instance group count used for the automatic config search.
 [ run_config_search_min_instance_count: <int> | default: 1 ]
 
-# Maximum instance count used for the automatic config search.
+# Maximum instance group count used for the automatic config search.
 [ run_config_search_max_instance_count: <int> | default: 5 ]
 
 # Disables automatic config search
@@ -241,7 +241,7 @@ profile_models: <comma-delimited-string-list|list|profile_model>
 # List of objectives that user wants to sort the results by it.
 [ objectives: <objective|list> ]
 
-# Weighting used to bias the model's objectives (agianst the other models) in multi-mode mode
+# Weighting used to bias the model's objectives (against the other models) in multi-mode mode
 [ weighting: <int>]
 
 # Specify flags to pass to the Triton instances launched by model analyzer

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -282,6 +282,8 @@ Ensemble models can be optimized using the Quick Search mode's hill climbing alg
 
 After MA has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 
+---
+
 ## Multi-Model Search Mode
 
 _This mode has the following limitations:_

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -251,7 +251,7 @@ profile_models:
 
 Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's request concurrency.
 
-_Note: That by default quick search runs unbounded and ignores any default values for these settings_
+_Note: By default, quick search runs unbounded and ignores any default values for these settings_
 
 ---
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -14,9 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+# Table of Contents
+
+- [Search Modes](#search-modes)
+- [Default Search Mode](#default-search-mode)
+- [Brute Search Mode](#brute-search-mode)
+  - [Automatic Brute Search](#automatic-brute-search)
+  - [Manual Brute Search](#manual-brute-search)
+- [Quick Search Mode](#quick-search-mode)
+- [Ensemble Model Search](#ensemble-model-search)
+- [Multi-Model Search Mode](#multi-model-search-mode)
+
+<br>
+
 # Model Config Search
 
-Model Analyzer's `profile` subcommand supports multiple modes when searching to find the best model configuration.
+## Search Modes
+
+Model Analyzer's `profile` subcommand supports multiple modes when searching to find the best model configuration:
 
 - [Brute Force Search](config_search.md#brute-search-mode)
   - **Search type:** Brute-force sweep of the cross product of all possible configurations
@@ -30,11 +45,24 @@ Model Analyzer's `profile` subcommand supports multiple modes when searching to 
     - Single ensemble models
     - Multiple models being profiled concurrently
   - **Command:** `--run-config-search-mode quick`
+
+---
+
+## Default Search Mode
+
+Model Analyzer's default search mode depends on the type of model and if you are profiling models concurrently (in the case of multiple models):
+
+- [Sequential (single or multi-model) Search](config_search.md#brute-search-mode)
+  - **Default Search type:** [Brute Force Search](config_search.md#brute-search-mode)
+  - **Command:** N/A
 - [Concurrent / Multi-model Search](config_search.md#multi-model-search-mode)
-  - **Search type:** Heuristic concurrent sweep of all models' search spaces to find an optimal configuration for all models
-  - **Default for:**
-    - None
+  - **Default Search type:** [Quick Search](config_search.md#quick-search-mode)
   - **Command:** `--run-config-profile-models-concurrently-enable`
+- [Ensemble Model Search](config_search.md#ensemble-model-search):
+  - **Default Search type:** [Quick Search](config_search.md#quick-search-mode)
+  - **Command:** N/A
+
+---
 
 ## Brute Search Mode
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -115,7 +115,7 @@ You can also modify the minimum/maximum values that the automatic search space w
 
 ---
 
-### [Request Concurrency Search Space](<(https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md#request-concurrency)>)
+### [Request Concurrency Search Space](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md#request-concurrency)
 
 - `Default:` 1 to 1024 concurrencies, sweeping over powers of 2 (i.e. 1, 2, 4, 8, ...)
 - `--run-config-search-min-concurrency: <val>`: Changes the request concurrency minimum automatic search space value

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -19,26 +19,24 @@ limitations under the License.
 Model Analyzer's `profile` subcommand supports multiple modes when searching to find the best model configuration.
 
 - [Brute Force Search](config_search.md#brute-search-mode)
-  - `Search type:` Brute-force sweep of the cross product of all possible configurations
-  - `Default for:`
+  - **Search type:** Brute-force sweep of the cross product of all possible configurations
+  - **Default for:**
     - Single non-ensemble models
     - Multiple models being profiled sequentially
-  - `Command:` `--run-config-search-mode brute`
+  - **Command:** `--run-config-search-mode brute`
 - [Quick Search](config_search.md#quick-search-mode)
-  - `Search type:` Heuristic sweep using a hill-climbing algorithm to find an optimal configuration
-  - `Default for:`
+  - **Search type:** Heuristic sweep using a hill-climbing algorithm to find an optimal configuration
+  - **Default for:**
     - Single ensemble models
-    - Multiple models beging profiled concurrently
-  - `Command:` `--run-config-search-mode quick`
+    - Multiple models being profiled concurrently
+  - **Command:** `--run-config-search-mode quick`
 - [Concurrent / Multi-model Search](config_search.md#multi-model-search-mode)
-  - `Search type:` Heuristic concurrent sweep of all models' search spaces to find an optimal configuration for all models
-  - `Default for: `
+  - **Search type:** Heuristic concurrent sweep of all models' search spaces to find an optimal configuration for all models
+  - **Default for:**
     - None
-  - `Command:` `--run-config-profile-models-concurrently-enable`
+  - **Command:** `--run-config-profile-models-concurrently-enable`
 
 ## Brute Search Mode
-
----
 
 **Default search mode when profiling non-ensemble models sequentially**
 
@@ -72,8 +70,6 @@ profile_models:
 ```
 
 You can also modify the minimum/maximum values that the automatic search space will iterate through:
-
----
 
 ### [Instance Group Search Space](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups)
 
@@ -169,7 +165,7 @@ profile_models:
 
 _This example shows how a value other than instance, batch size or concurrency can be swept, and will sweep through eight configs:<br>_
 
-- \[2 _ `max_batch_size`] \* \[2 _ `max_queue_delay_microseconds`] \* \[2 \* `instance_group`].
+- \[2 \* `max_batch_size`] \* \[2 \* `max_queue_delay_microseconds`] \* \[2 \* `instance_group`].
 
 ```yaml
 model_repository: /path/to/model/repository/

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -18,84 +18,132 @@ limitations under the License.
 
 Model Analyzer's `profile` subcommand supports multiple modes when searching to find the best model configuration.
 
-- [Brute](config_search.md#brute-search-mode) is the default when profiling non-ensemble models or when profling mulitple models sequentially, and will do a brute-force sweep of the cross product of all possible configurations
-- [Quick](config_search.md#quick-search-mode) is the default for ensemble models or when profiling multiple models concurrenty, and will use heuristics to try to find the optimal configuration much quicker than brute, and can be enabled via `--run-config-search-mode quick`
-- [Multi-model](config_search.md#multi-model-search-mode) will profile mutliple models to find the optimal configurations for all models while they are running concurrently. This feature is enabled via `--run-config-profile-models-concurrently-enable`
+- [Brute Force Search](config_search.md#brute-search-mode)
+  - `Search type:` Brute-force sweep of the cross product of all possible configurations
+  - `Default for:`
+    - Single non-ensemble models
+    - Multiple models being profiled sequentially
+  - `Command:` `--run-config-search-mode brute`
+- [Quick Search](config_search.md#quick-search-mode)
+  - `Search type:` Heuristic sweep using a hill-climbing algorithm to find an optimal configuration
+  - `Default for:`
+    - Single ensemble models
+    - Multiple models beging profiled concurrently
+  - `Command:` `--run-config-search-mode quick`
+- [Concurrent / Multi-model Search](config_search.md#multi-model-search-mode)
+  - `Search type:` Heuristic concurrent sweep of all models' search spaces to find an optimal configuration for all models
+  - `Default for: `
+    - None
+  - `Command:` `--run-config-profile-models-concurrently-enable`
 
 ## Brute Search Mode
 
-Model Analyzer's brute search mode will do a brute-force sweep of the cross product of all possible configurations. You can [Manually](config_search.md#manual-brute-search) provide `model_config_parameters` to tell Model Analyzer what to sweep over, or you can
-let it [Automatically](config_search.md#automatic-brute-search) sweep through configurations expected to have the highest impact on performance for Triton models.
+---
 
-This search mode is the default when profiling non-ensemble models sequentially.
+<strong>Default search mode when profiling non-ensemble models sequentially</strong>
 
-### Automatic Brute Search
+Model Analyzer's brute search mode will do a brute-force sweep of the cross product of all possible configurations. <br>
+It has two modes:
 
-Automatic configuration search is the default behavior when running Model
-Analyzer without manually specifying what values to search. The parameters
-that are automatically searched are
-[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size)
-and
-[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups).
-Additionally, [`dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher) will be enabled if it is legal to do so.
+- [Automatic](config_search.md#automatic-brute-search)
+  - <strong>No</strong> model config parameters are specified
+- [Manual](config_search.md#manual-brute-search)
+  - <strong>Any</strong> model config parameters are specified
+  - `--run-config-search-disable` option is specified
 
-An example model analyzer config that performs automatic config search looks
-like below:
+---
+
+## Automatic Brute Search
+
+<strong>Default brute search mode when no model config parameters are specified</strong>
+
+The parameters that are automatically searched are
+[model maximum batch size](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size),
+[model instance groups](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups), and [request concurrencies](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/perf_analyzer.md#request-concurrency).
+Additionally, [dynamic_batching](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher) will be enabled if it is legal to do so.
+
+_An example model analyzer YAML config that performs an Automatic Brute Search:_
 
 ```yaml
 model_repository: /path/to/model/repository/
 
 profile_models:
-  - model_1
-  - model_2
+  - model_A
 ```
 
-In the default mode, automatic config search will try values 1 through 5 for
-[`instance_group`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups).
-The maximum value can be changed using the `run_config_search_max_instance_count` key in the Model Analyzer Config.
-For each `instance_group`, Model Analyzer will sweep values 1 through 128 increasing exponentially (i.e. 1, 2, 4, 8, ...) for
-[`max_batch_size`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size). The start and end values can be changed using `run_config_search_min_model_batch_size` and `run_config_search_max_model_batch_size`.
-[`Dynamic_batching`](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#dynamic-batcher)
-will be enabled for all model configs generated using automatic search.
+You can also modify the minimum/maximum values that the automatic search space will iterate through:
 
-For each model config that is generated in automatic search, Model Analyzer will gather data for
-[`concurrency`](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md#request-concurrency)
-values 1 through 1024 increased exponentially (i.e. 1, 2, 4, 8, ...). The maximum value can be configured
-using the `run_config_search_max_concurrency` key in the Model Analyzer Config.
+---
 
-An example config that limits the search space used by Model Analyzer is
-described below:
+### [Instance Group Search Space](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups)
+
+- `Default:` 1 to 5 instance groups
+- `--run-config-search-min-instance-count: <val>`: Changes the instance count's minimum automatic search space value
+- `--run-config-search-max-instance-count: <val>`: Changes the instance count's maximum automatic search space value
+
+---
+
+### [Model Batch Size Search Space](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size)
+
+- `Default:` 1 to 128 max batch sizes, sweeping over powers of 2 (i.e. 1, 2, 4, 8, ...)
+- `--run-config-search-min-model-batch-size: <val>`: Changes the model's batch size minimum automatic search space value
+- `--run-config-search-max-model-batch-size: <val>`: Changes the model's batch size maximum automatic search space value
+
+---
+
+### [Request Concurrency Search Space](<(https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md#request-concurrency)>)
+
+- `Default:` 1 to 1024 concurrencies, sweeping over powers of 2 (i.e. 1, 2, 4, 8, ...)
+- `--run-config-search-min-concurrency: <val>`: Changes the request concurrency minimum automatic search space value
+- `--run-config-search-max-concurrency: <val>`: Changes the request concurrency maximum automatic search space value
+
+---
+
+_An example YAML config that limits the search space:_
 
 ```yaml
 model_repository: /path/to/model/repository/
 
 run_config_search_max_instance_count: 3
-run_config_search_max_concurrency: 8
+run_config_search_min_model_batch_size: 16
+run_config_search_min_concurrency: 8
+run_config_search_max_concurrency: 256
 profile_models:
-  - model_1
-  - model_2
+  - model_A
 ```
 
-If any `model_config_parameters` are specified for a model, it will disable
-automatic searching of model configs and will only search within the values specified.
-If `concurrency` is specified then only those values will be tried instead of the default concurrency sweep.
-If both `concurrency` and `model_config_parameters` are specified, automatic
-config search will be disabled.
+_This will perform an Automatic Brute Search with instance counts: 3-5, batch sizes: 16-128, and concurrencies: 8-256_
 
-For example, the config specified below will only automatically sweep through
-the `model_config_parameters` that was described above:
+---
 
-```yaml
-model_repository: /path/to/model/repository/
+### <strong>Interaction with Remote Triton Launch Mode</strong>
 
-profile_models:
-  model_1:
-    parameters:
-      concurrency: 1,2,3,128
-```
+When the triton launch mode is remote, _<strong>only concurrency values can be swept._</strong><br>
 
-The config described below will only sweep through different values for
-`concurrency`:
+Model Analyzer will ignore any model config parameters because we have no way of accessing and modifying the model repository of the remote Triton Server.
+
+---
+
+## Manual Brute Search
+
+<strong>Default brute search mode when any model config parameters or parameters are specified</strong>
+
+Using Manual Brute Search, you can create custom sweeps for any parameter that can be specified in the model configuration. There are two ways this mode is enabled when doing a brute search:
+
+- Any `model config parameters` are specified:
+  - You must manually specify the batch sizes and instance counts you want MA to sweep
+  - Request concurrencies will still be automatically swept (as they are not a model config parameter)
+- Any `parameters` are specified:
+  - You must manually specify the batch sizes, instance counts, and request concurrencies you want MA to sweep
+- `--run-config-search-disable` is specified:
+  - You must manually specify the batch sizes, instance counts, and request concurrencies you want MA to sweep
+
+_<strong>Note</strong>: Model Analyzer only checks the syntax of the `model config parameters` and cannot guarantee that the configuration that is generated is loadable by Triton. For a complete list of parameters allowed under model_config_parameters, refer to the [Triton Model
+Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md). <br><strong>It is your responsibility to ensure the sweep configuration specified works with your model.</strong>_
+
+---
+
+_In this example, MA will only sweep through different values of `request concurrencies`:_
 
 ```yaml
 model_repository: /path/to/model/repository/
@@ -108,29 +156,20 @@ profile_models:
           count: [1, 2]
 ```
 
-#### Important Note about Remote Mode
+_In this example, MA will not sweep through any values, and will only try the concurrencies listed below:_
 
-In the remote mode, `model_config_parameters` are always ignored because Model
-Analyzer has no way of accessing the model repository of the remote Triton
-Server. In this mode, only concurrency values can be swept.
+```yaml
+model_repository: /path/to/model/repository/
 
-### Manual Brute Search
+profile_models:
+  model_1:
+    parameters:
+      concurrency: 1,2,3,128
+```
 
-In addition to the automatic config search, Model Analyzer supports a manual
-config search mode. To enable this mode, you can specify `model_config_parameters`
-to sweep through, or set `--run-config-search-disable`
+_This example shows how a value other than instance, batch size or concurrency can be swept, and will sweep through eight configs:<br>_
 
-Unlike automatic mode, this mode is not limited to `max_batch_size`, `dynamic_batching`, and `instance_count` config parameters. Using manual
-config search, you can create custom sweeps for every parameter that can be
-specified in the model configuration. Model Analyzer only checks the syntax
-of the `model_config_parameters` that is specified and cannot guarantee that
-the configuration that is generated is loadable by Triton.
-
-You can also specify `concurrency` ranges to sweep through. If unspecified, it will
-automatically sweep concurrency for every model configuration (unless `--run-config-search-disable`
-is set, in which case it will only use the concurrency value of 1)
-
-An example Model Analyzer Config that performs manual sweeping looks like below:
+- \[2 _ `max_batch_size`] \* \[2 _ `max_queue_delay_microseconds`] \* \[2 \* `instance_group`].
 
 ```yaml
 model_repository: /path/to/model/repository/
@@ -147,57 +186,77 @@ profile_models:
           count: [1, 2]
 ```
 
-In this mode, Model Analyzer can sweep through every Triton model configuration
-parameter available. For a complete list of parameters allowed under
-`model_config_parameters`, refer to the [Triton Model
-Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md).
-It is your responsibility to make sure that the sweep configuration specified
-works with your model. For example, in the above config, if we change `[6, 8]`
-as the range for the `max_batch_size` to `[1]`, it will no longer be a valid
-Triton Model Configuration.
+---
 
-The configuration sweep described above, will sweep through 8 configs = (2
-`max_batch_size`) \* (2 `max_queue_delay_microseconds`) \* (2 `instance_group`) values.
+### <strong>Examples of Additional Model Config Parameters</strong>
 
-### Examples of Additional Model Config Parameters
-
-As mentioned in the previous section, manual configuration search allows you to
-sweep on every parameter that can be specified in Triton model configuration. In
-this section, we describe some of the parameters that might be of interest for
+In this section, we describe some of the parameters that might be of interest for
 manual sweep:
 
 - [Rate limiter](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#rate-limiter-config) setting
 - If the model is using [ONNX](https://github.com/triton-inference-server/onnxruntime_backend) or [Tensorflow backend](https://github.com/triton-inference-server/tensorflow_backend), the "execution_accelerators" parameters. More information about this parameter is
   available in the [Triton Optimization Guide](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/optimization.md#framework-specific-optimization)
 
+---
+
 ## Quick Search Mode
 
-Quick search can be enabled by adding the parameter `--run-config-search-mode quick` to the CLI.
+<strong>Default search mode when profiling ensemble models or multiple models concurrently</strong>
 
-This search mode is the default for ensemble models or when profiling concurrently.
-
-It uses a hill climbing algorithm to search the configuration space, looking for
+This mode uses a hill climbing algorithm to search the configuration space, looking for
 the maximal objective value within the specified constraints. In the majority of cases
 this will find greater than 95% of the maximum objective value (that could be found using a brute force search), while needing to search less than 10% of the configuration space.
 
-After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the default concurrency range before generation of the summary reports.
+After quick search has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the default concurrency range before generation of the summary reports.
 
-### Limiting Batch Size, Instance Count, and Client Concurrency
+---
 
-Using the `--run-config-search-<min/max>...` CLI options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's concurrency.
+_An example model analyzer YAML config that performs a Quick Search:_
 
-Note: That by default quick search runs unbounded and ignores any default values for these settings
+```yaml
+model_repository: /path/to/model/repository/
+
+run_config_search_mode: quick
+profile_models:
+  - model_A
+```
+
+---
+
+### <strong>Limiting Batch Size, Instance Count, and Client Concurrency</strong>
+
+Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's request concurrency.
+
+_Note: That by default quick search runs unbounded and ignores any default values for these settings_
+
+---
+
+_An example model analyzer YAML config that performs a Quick Search and constrains the search parameters:_
+
+```yaml
+model_repository: /path/to/model/repository/
+
+run_config_search_mode: quick
+run_config_search_max_instance_count: 4
+run_config_search_max_concurrency: 16
+run_config_search_min_model_batch_size: 8
+
+profile_models:
+  - model_A
+```
+
+---
 
 ## Ensemble Model Search
 
 _This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
-- Only supports up to 3 sub-models
+- Only supports up to 4 sub-models
 
-Non-BLS Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to three submodels.
+Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
 
-After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
+After MA has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 
 ## Multi-Model Search Mode
 
@@ -208,25 +267,47 @@ _This mode has the following limitations:_
 
 Multi-model concurrent search mode can be enabled by adding the parameter `--run-config-profile-models-concurrently-enable` to the CLI.
 
-It uses Quick Search mode's hill climbing algorithm to search all models configurations spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes of around 20-30 minutes (compared to the days it would take a brute force run to complete).
+It uses Quick Search mode's hill climbing algorithm to search all models configurations spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with typical runtimes of around 20-30 minutes (compared to the days it would take a brute force run to complete) for a two to three model run.
 
 After it has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the default concurrency range before generation of the summary reports.
 
 _Note:_ The algorithm attempts to find the most fair and optimal result for all models, by evaluating each model objective's gain/loss. In many cases this will result in the algorithm ranking higher a configuration that has a lower total combined throughput (if that was the objective), if this better balances the throughputs of all the models.
 
-### Model Weighting
+---
+
+_An example model analyzer YAML config that performs a Multi-model search:_
+
+```yaml
+model_repository: /path/to/model/repository/
+
+run_config_profile_models_concurrently_enable: true
+
+profile_models:
+  - model_A
+  - model_B
+```
+
+---
+
+### <strong>Model Weighting</strong>
 
 In additon to setting a model's objectives or constraints, in multi-model search mode, you have the ability to set a model's weighting. By default each model is set for equal weighting (value of 1), but in the YAML you can specify `weighting: <int>` which will bias that model's objectives when evaluating for an optimal result.
 
-In the example below, the resnet50_libtorch model's objective gains (towards maximing latency) will have 3x the importance of the add_sub models throughput gains:
+---
+
+_An example where model A's objective gains (towards minimizing latency) will have 3 times the importance versus maximizing model B's throughput gains:_
 
 ```yaml
+model_repository: /path/to/model/repository/
+
+run_config_profile_models_concurrently_enable: true
+
 profile_models:
-  resnet50_libtorch:
+  model_A:
     weighting: 3
     objectives:
       perf_latency_p99: 1
-  add_sub:
+  model_B:
     weighting: 1
     objectives:
       perf_throughput: 1

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -40,22 +40,22 @@ Model Analyzer's `profile` subcommand supports multiple modes when searching to 
 
 ---
 
-<strong>Default search mode when profiling non-ensemble models sequentially</strong>
+**Default search mode when profiling non-ensemble models sequentially**
 
 Model Analyzer's brute search mode will do a brute-force sweep of the cross product of all possible configurations. <br>
 It has two modes:
 
 - [Automatic](config_search.md#automatic-brute-search)
-  - <strong>No</strong> model config parameters are specified
+  - **No** model config parameters are specified
 - [Manual](config_search.md#manual-brute-search)
-  - <strong>Any</strong> model config parameters are specified
+  - **Any** model config parameters are specified
   - `--run-config-search-disable` option is specified
 
 ---
 
 ## Automatic Brute Search
 
-<strong>Default brute search mode when no model config parameters are specified</strong>
+**Default brute search mode when no model config parameters are specified**
 
 The parameters that are automatically searched are
 [model maximum batch size](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#maximum-batch-size),
@@ -116,9 +116,9 @@ _This will perform an Automatic Brute Search with instance counts: 3-5, batch si
 
 ---
 
-### <strong>Interaction with Remote Triton Launch Mode</strong>
+### **Interaction with Remote Triton Launch Mode**
 
-When the triton launch mode is remote, _<strong>only concurrency values can be swept._</strong><br>
+When the triton launch mode is remote, _\*\*only concurrency values can be swept._\*\*<br>
 
 Model Analyzer will ignore any model config parameters because we have no way of accessing and modifying the model repository of the remote Triton Server.
 
@@ -126,7 +126,7 @@ Model Analyzer will ignore any model config parameters because we have no way of
 
 ## Manual Brute Search
 
-<strong>Default brute search mode when any model config parameters or parameters are specified</strong>
+**Default brute search mode when any model config parameters or parameters are specified**
 
 Using Manual Brute Search, you can create custom sweeps for any parameter that can be specified in the model configuration. There are two ways this mode is enabled when doing a brute search:
 
@@ -138,8 +138,8 @@ Using Manual Brute Search, you can create custom sweeps for any parameter that c
 - `--run-config-search-disable` is specified:
   - You must manually specify the batch sizes, instance counts, and request concurrencies you want MA to sweep
 
-_<strong>Note</strong>: Model Analyzer only checks the syntax of the `model config parameters` and cannot guarantee that the configuration that is generated is loadable by Triton. For a complete list of parameters allowed under model_config_parameters, refer to the [Triton Model
-Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md). <br><strong>It is your responsibility to ensure the sweep configuration specified works with your model.</strong>_
+_**Note**: Model Analyzer only checks the syntax of the `model config parameters` and cannot guarantee that the configuration that is generated is loadable by Triton. For a complete list of parameters allowed under model_config_parameters, refer to the [Triton Model
+Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md). <br>**It is your responsibility to ensure the sweep configuration specified works with your model.**_
 
 ---
 
@@ -188,7 +188,7 @@ profile_models:
 
 ---
 
-### <strong>Examples of Additional Model Config Parameters</strong>
+### **Examples of Additional Model Config Parameters**
 
 In this section, we describe some of the parameters that might be of interest for
 manual sweep:
@@ -201,7 +201,7 @@ manual sweep:
 
 ## Quick Search Mode
 
-<strong>Default search mode when profiling ensemble models or multiple models concurrently</strong>
+**Default search mode when profiling ensemble models or multiple models concurrently**
 
 This mode uses a hill climbing algorithm to search the configuration space, looking for
 the maximal objective value within the specified constraints. In the majority of cases
@@ -223,7 +223,7 @@ profile_models:
 
 ---
 
-### <strong>Limiting Batch Size, Instance Count, and Client Concurrency</strong>
+### **Limiting Batch Size, Instance Count, and Client Concurrency**
 
 Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's request concurrency.
 
@@ -289,7 +289,7 @@ profile_models:
 
 ---
 
-### <strong>Model Weighting</strong>
+### **Model Weighting**
 
 In additon to setting a model's objectives or constraints, in multi-model search mode, you have the ability to set a model's weighting. By default each model is set for equal weighting (value of 1), but in the YAML you can specify `weighting: <int>` which will bias that model's objectives when evaluating for an optimal result.
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -101,9 +101,9 @@ You can also modify the minimum/maximum values that the automatic search space w
 
 ### [Instance Group Search Space](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md#instance-groups)
 
-- `Default:` 1 to 5 instance groups
-- `--run-config-search-min-instance-count: <val>`: Changes the instance count's minimum automatic search space value
-- `--run-config-search-max-instance-count: <val>`: Changes the instance count's maximum automatic search space value
+- `Default:` 1 to 5 instance group counts
+- `--run-config-search-min-instance-count: <val>`: Changes the instance group count's minimum automatic search space value
+- `--run-config-search-max-instance-count: <val>`: Changes the instance group count's maximum automatic search space value
 
 ---
 
@@ -136,7 +136,7 @@ profile_models:
   - model_A
 ```
 
-_This will perform an Automatic Brute Search with instance counts: 3-5, batch sizes: 16-128, and concurrencies: 8-256_
+_This will perform an Automatic Brute Search with instance group counts: 3-5, batch sizes: 16-128, and concurrencies: 8-256_
 
 ---
 
@@ -155,12 +155,12 @@ Model Analyzer will ignore any model config parameters because we have no way of
 Using Manual Brute Search, you can create custom sweeps for any parameter that can be specified in the model configuration. There are two ways this mode is enabled when doing a brute search:
 
 - Any [`model config parameters`](./config.md#model-config-parameters) are specified:
-  - You must manually specify the batch sizes and instance counts you want Model Analyzer to sweep
+  - You must manually specify the batch sizes and instance group counts you want Model Analyzer to sweep
   - Request concurrencies will still be automatically swept (as they are not a model config parameter)
 - Any [`parameters`](./config.md#test-configuration-parameter) are specified:
-  - You must manually specify the batch sizes, instance counts, and request concurrencies you want Model Analyzer to sweep
+  - You must manually specify the batch sizes, instance group counts, and request concurrencies you want Model Analyzer to sweep
 - `--run-config-search-disable` is specified:
-  - You must manually specify the batch sizes, instance counts, and request concurrencies you want Model Analyzer to sweep
+  - You must manually specify the batch sizes, instance group counts, and request concurrencies you want Model Analyzer to sweep
 
 _**Note**: Model Analyzer only checks the syntax of the `model config parameters` and cannot guarantee that the configuration that is generated is loadable by Triton. For a complete list of parameters allowed under model_config_parameters, refer to the [Triton Model
 Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md). <br>**It is your responsibility to ensure the sweep configuration specified works with your model.**_
@@ -247,9 +247,9 @@ profile_models:
 
 ---
 
-### **Limiting Batch Size, Instance Count, and Client Concurrency**
+### **Limiting Batch Size, Instance Group, and Client Concurrency**
 
-Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance count, as well as the client's request concurrency.
+Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance group count, as well as the client's request concurrency.
 
 _Note: By default, quick search runs unbounded and ignores any default values for these settings_
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -154,20 +154,20 @@ Model Analyzer will ignore any model config parameters because we have no way of
 
 Using Manual Brute Search, you can create custom sweeps for any parameter that can be specified in the model configuration. There are two ways this mode is enabled when doing a brute search:
 
-- Any `model config parameters` are specified:
-  - You must manually specify the batch sizes and instance counts you want MA to sweep
+- Any [`model config parameters`](./config.md#model-config-parameters) are specified:
+  - You must manually specify the batch sizes and instance counts you want Model Analyzer to sweep
   - Request concurrencies will still be automatically swept (as they are not a model config parameter)
-- Any `parameters` are specified:
-  - You must manually specify the batch sizes, instance counts, and request concurrencies you want MA to sweep
+- Any [`parameters`](./config.md#test-configuration-parameter) are specified:
+  - You must manually specify the batch sizes, instance counts, and request concurrencies you want Model Analyzer to sweep
 - `--run-config-search-disable` is specified:
-  - You must manually specify the batch sizes, instance counts, and request concurrencies you want MA to sweep
+  - You must manually specify the batch sizes, instance counts, and request concurrencies you want Model Analyzer to sweep
 
 _**Note**: Model Analyzer only checks the syntax of the `model config parameters` and cannot guarantee that the configuration that is generated is loadable by Triton. For a complete list of parameters allowed under model_config_parameters, refer to the [Triton Model
 Configuration](https://github.com/triton-inference-server/server/blob/master/docs/user_guide/model_configuration.md). <br>**It is your responsibility to ensure the sweep configuration specified works with your model.**_
 
 ---
 
-_In this example, MA will only sweep through different values of `request concurrencies`:_
+_In this example, Model Analyzer will only sweep through different values of `request concurrencies`:_
 
 ```yaml
 model_repository: /path/to/model/repository/
@@ -180,7 +180,7 @@ profile_models:
           count: [1, 2]
 ```
 
-_In this example, MA will not sweep through any values, and will only try the concurrencies listed below:_
+_In this example, Model Analyzer will not sweep through any values, and will only try the concurrencies listed below:_
 
 ```yaml
 model_repository: /path/to/model/repository/
@@ -280,7 +280,7 @@ _This mode has the following limitations:_
 
 Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
 
-After MA has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
+After Model Analyzer has found the best config(s), it will then sweep the top-N configurations found (specified by `--num-configs-per-model`) over the concurrency range before generation of the summary reports.
 
 ---
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -110,7 +110,7 @@ configuration:
   config search will not go beyond. <br>
 - `--run-config-search-max-model-batch-size` sets the highest max_batch_size that run config search will not go beyond.
 - `--run-config-search-max-instance-count`
-  sets the max instance count value that run config search will not go beyond.<br><br>
+  sets the max instance group count value that run config search will not go beyond.<br><br>
 
 With these options, model analyzer will test 5 configs (4 new configs as well as the unmodified default add_sub config), and each config will have 2 experiments run on Perf Analyzer (concurrency=1 and concurrency=2). This significantly reduces the search space, and therefore, model analyzer's runtime.
 


### PR DESCRIPTION
Overhaul of `config_search.md` to include more examples and be more explicit about our different modes, how they operate, and what options exist in each mode.