### PR TITLE
Multi-model detailed reporting changes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,7 +40,7 @@ throughput. If a latency budget is specified to the [profile subcommand](#subcom
 `--latency-budget`, then the best model configuration will be the one with the highest throughput in the given budget.
 
 In online mode the profile and report subcommands will generate summaries specific to online inference.
-See the example [online summary](../examples/online_summary.pdf) and [online detailed report](../examples/online_summary.pdf).
+See the example [online summary](../examples/online_summary.pdf) and [online detailed report](../examples/online_detailed_report.pdf).
 
 ### Offline Mode
 
@@ -89,7 +89,7 @@ subcommand will either perform a
 [manual](./config_search.md#manual-brute-search), [automatic](./config_search.md#automatic-brute-search), or
 [quick](./config_search.md#quick-search-mode) search over perf analyzer
 and model config file parameters. For each combination of [model config
-parameters](./config.md#model-config-parameters) (e.g. _max batch size_, _dynamic batching_, and _instance count_), it will run tritonserver and perf analyzer instances with
+parameters](./config.md#model-config-parameters) (e.g. _max batch size_, _dynamic batching_, and _instance group count_), it will run tritonserver and perf analyzer instances with
 all the specified run parameters (client request concurrency and static batch
 size). It will also save the protobuf (.pbtxt) model config files corresponding
 to each combination in the [_output model

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -83,7 +83,7 @@ Run the Model Analyzer `profile` subcommand inside the container with:
 model-analyzer profile \
     --model-repository <path-to-examples-quick-start> \
     --profile-models add_sub --triton-launch-mode=docker \
-    --output-model-repository-path <path-to-output-model-repo>/<output_dir>
+    --output-model-repository-path <path-to-output-model-repo>/<output_dir> \
     --export-path profile_results
 ```
 

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -69,9 +69,10 @@ class Analyzer:
         state_manager.load_checkpoint(checkpoint_required)
 
         self._constraint_manager = ConstraintManager(self._config)
-        self._result_manager = ResultManager(config=config,
-                                             state_manager=self._state_manager,
-                                             constraint_manager=self._constraint_manager)
+        self._result_manager = ResultManager(
+            config=config,
+            state_manager=self._state_manager,
+            constraint_manager=self._constraint_manager)
 
     def profile(self, client: TritonClient, gpus: List[GPUDevice], mode: str,
                 verbose: bool) -> None:
@@ -123,7 +124,10 @@ class Analyzer:
         if not self._config.skip_summary_reports:
             self._create_summary_tables(verbose)
             self._create_summary_reports(mode)
-            logger.info(self._get_report_command_help_string())
+
+            # TODO-TMA-650: Detailed reporting not supported for multi-model
+            if not self._config.run_config_profile_models_concurrently_enable:
+                logger.info(self._get_report_command_help_string())
 
     def report(self, mode: str) -> None:
         """

--- a/qa/L0_results/test.sh
+++ b/qa/L0_results/test.sh
@@ -23,7 +23,7 @@ MODEL_ANALYZER="`which model-analyzer`"
 REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
 CHECKPOINT_REPOSITORY=${CHECKPOINT_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/model_analyzer_checkpoints/2022_08_02"}
-QA_MODELS="vgg19_libtorch resnet50_libtorch"
+QA_MODELS="resnet50_libtorch"
 MODEL_NAMES="$(echo $QA_MODELS | sed 's/ /,/g')"
 EXPORT_PATH="`pwd`/results"
 FILENAME_SERVER_ONLY="server-metrics.csv"

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -155,6 +155,54 @@ class TestAnalyzer(trc.TestResultCollector):
             '--config-file /tmp/my_config.yml --checkpoint-directory '
             '/tmp/my_checkpoints`')
 
+    def test_multiple_models_in_report_model_config(self):
+        """
+        Test that multiple different models in the report are detected
+        """
+        # Single model config
+        args = [
+            'model-analyzer', 'report', '--report-model-configs',
+            'modelA_config_0', '--checkpoint-directory', '/tmp/my_checkpoints'
+        ]
+        config = evaluate_mock_config(args, '', subcommand="report")
+        state_manager = AnalyzerStateManager(config, None)
+        analyzer = Analyzer(config,
+                            None,
+                            state_manager,
+                            checkpoint_required=False)
+
+        self.assertFalse(analyzer._multiple_models_in_report_model_config())
+
+        # Multiple different models
+        args = [
+            'model-analyzer', 'report', '--report-model-configs',
+            'modelA_config_0,modelB_config_1', '--checkpoint-directory',
+            '/tmp/my_checkpoints'
+        ]
+        config = evaluate_mock_config(args, '', subcommand="report")
+        state_manager = AnalyzerStateManager(config, None)
+        analyzer = Analyzer(config,
+                            None,
+                            state_manager,
+                            checkpoint_required=False)
+
+        self.assertTrue(analyzer._multiple_models_in_report_model_config())
+
+        # Single model - multiple configs
+        args = [
+            'model-analyzer', 'report', '--report-model-configs',
+            'modelA_config_0,modelA_config_1', '--checkpoint-directory',
+            '/tmp/my_checkpoints'
+        ]
+        config = evaluate_mock_config(args, '', subcommand="report")
+        state_manager = AnalyzerStateManager(config, None)
+        analyzer = Analyzer(config,
+                            None,
+                            state_manager,
+                            checkpoint_required=False)
+
+        self.assertFalse(analyzer._multiple_models_in_report_model_config())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -148,8 +148,8 @@ class TestAnalyzer(trc.TestResultCollector):
                             state_manager,
                             checkpoint_required=False)
         self.assertEqual(
-            analyzer._get_report_command_help_string(),
-            'To generate detailed reports for the 3 best configurations, run '
+            analyzer._get_report_command_help_string(model_name='model1'),
+            'To generate detailed reports for the 3 best model1 configurations, run '
             '`model-analyzer report --report-model-configs '
             'config1,config3,config4 --export-path /tmp/my_export_path '
             '--config-file /tmp/my_config.yml --checkpoint-directory '


### PR DESCRIPTION
- Remove message in profile step that instructs user about running detail reporting
- Add error message in detailed report step when multiple different models are detected

Needed to modify **L0_results** test to only check for a single model config

