### PR TITLE
Add caveat to ensemble documentation

### DIFF
--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -277,6 +277,7 @@ _This mode has the following limitations:_
 
 - Can only be run in `quick` search mode
 - Only supports up to 4 sub-models
+- Does not support `cpu_only` option for submodels
 
 Ensemble models can be optimized using the Quick Search mode's hill climbing algorithm to search the ensemble sub-model's configuration spaces in parallel, looking for the maximal objective value within the specified constraints. Model Analyzer has observed positive outcomes towards finding the maximum objective value; with runtimes under one hour (compared to the days it would take a brute force run to complete) for ensembles with up to four submodels.
 


### PR DESCRIPTION
Adds caveat that we don't support submodel `cpu_only` for ensembles
Fixes typos pointed out by external user