### PR TITLE
Logic to create BLS composing models for default config

### DIFF
--- a/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_plus_concurrency_sweep_run_config_generator.py
@@ -51,6 +51,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
                  config: ConfigCommandProfile, gpus: List[GPUDevice],
                  models: List[ModelProfileSpec],
                  ensemble_composing_models: Dict[str, List[ModelProfileSpec]],
+                 bls_composing_models: List[ModelProfileSpec],
                  client: TritonClient, result_manager: ResultManager,
                  model_variant_name_manager: ModelVariantNameManager):
         """
@@ -65,6 +66,8 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
             List of models to profile
         ensemble_composing_models: Dict of List of ModelProfileSpec
             Dict indexed by model name of list of composing models to profile
+        bls_composing_models: List of ModelProfileSpec
+            List of BLS composing models to profile
         client: TritonClient
         result_manager: ResultManager
             The object that handles storing and sorting the results from the perf analyzer
@@ -78,6 +81,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
         self._gpus = gpus
         self._models = models
         self._ensemble_composing_models = ensemble_composing_models
+        self._bls_composing_models = bls_composing_models
         self._client = client
         self._result_manager = result_manager
         self._model_variant_name_manager = model_variant_name_manager
@@ -122,6 +126,7 @@ class QuickPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
             gpus=self._gpus,
             models=self._models,
             ensemble_composing_models=self._ensemble_composing_models,
+            bls_composing_models=self._bls_composing_models,
             client=self._client,
             model_variant_name_manager=self._model_variant_name_manager)
 

--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -73,11 +73,8 @@ class RunConfigGeneratorFactory:
         ensemble_composing_models = RunConfigGeneratorFactory._create_ensemble_composing_models(
             new_models, command_config, client, gpus)
 
-        bls_composing_models = [
-            ModelProfileSpec(bls_composing_model_spec, command_config, client,
-                             gpus)
-            for bls_composing_model_spec in command_config.bls_composing_models
-        ]
+        bls_composing_models = RunConfigGeneratorFactory._create_bls_composing_models(
+            command_config, client, gpus)
 
         if (command_config.run_config_search_mode == "quick" or
                 bls_composing_models):
@@ -227,3 +224,14 @@ class RunConfigGeneratorFactory:
                 composing_models[model.model_name()] = composing_model_configs
 
         return composing_models
+
+    @staticmethod
+    def _create_bls_composing_models(
+            config: ConfigCommandProfile, client: TritonClient,
+            gpus: List[GPUDevice]) -> List[ModelProfileSpec]:
+        bls_composing_models = [
+            ModelProfileSpec(bls_composing_model_spec, config, client, gpus)
+            for bls_composing_model_spec in config.bls_composing_models
+        ]
+
+        return bls_composing_models

--- a/model_analyzer/config/run/model_run_config.py
+++ b/model_analyzer/config/run/model_run_config.py
@@ -49,6 +49,7 @@ class ModelRunConfig:
         self._model_config = model_config
         self._perf_config = perf_config
         self._ensemble_composing_configs: List[ModelConfig] = []
+        self._bls_composing_configs: List[ModelConfig] = []
 
     def model_name(self) -> str:
         """
@@ -102,6 +103,13 @@ class ModelRunConfig:
 
         return self._ensemble_composing_configs
 
+    def bls_composing_configs(self) -> List[ModelConfig]:
+        """
+        Returns the list of BLS composing configs
+        """
+
+        return self._bls_composing_configs
+
     def representation(self) -> str:
         """
         Returns a representation string for the ModelRunConfig that can be used
@@ -141,6 +149,12 @@ class ModelRunConfig:
         model_configs = ensemble_composing_configs if self._ensemble_composing_configs else [
             self._model_config.get_config()
         ]
+
+        bls_composing_configs = [
+            composing_config.get_config()
+            for composing_config in self._bls_composing_configs
+        ]
+        model_configs.extend(bls_composing_configs)
 
         for model_config in model_configs:
             max_batch_size = model_config[
@@ -185,10 +199,18 @@ class ModelRunConfig:
     def add_ensemble_composing_model_configs(
             self, composing_model_configs: List[ModelConfig]) -> None:
         """
-        Adds a list of ensemble composing_model configs
+        Adds a list of ensemble composing model configs
         """
         for composing_model_config in composing_model_configs:
             self._ensemble_composing_configs.append(composing_model_config)
+
+    def add_bls_composing_model_configs(
+            self, composing_model_configs: List[ModelConfig]) -> None:
+        """
+        Adds a list of BLS composing model configs
+        """
+        for composing_model_config in composing_model_configs:
+            self._bls_composing_configs.append(composing_model_config)
 
     @classmethod
     def from_dict(cls, model_run_config_dict):
@@ -204,6 +226,13 @@ class ModelRunConfig:
                 ModelConfig.from_dict(ensemble_composing_config_dict)
                 for ensemble_composing_config_dict in
                 model_run_config_dict['_ensemble_composing_configs']
+            ]
+
+        if '_bls_composing_configs' in model_run_config_dict:
+            model_run_config._bls_composing_configs = [
+                ModelConfig.from_dict(bls_composing_config_dict)
+                for bls_composing_config_dict in
+                model_run_config_dict['_bls_composing_configs']
             ]
 
         return model_run_config

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -94,9 +94,9 @@ class ModelManager:
             The models to run
         """
 
-        # Note: this is not done in config_commmand, because there isn't a ModelConfig yet,
+        # Note: this is not done in config_command, because there isn't a ModelConfig yet,
         # so we cannot determine if the model is an ensemble
-        self._check_for_ensemble_model_incompatability(models)
+        self._check_for_ensemble_model_incompatibility(models)
 
         self._metrics_manager.start_new_model()
 
@@ -158,7 +158,7 @@ class ModelManager:
                     f"Triton server flags must be the same for all models to run concurrently"
                 )
 
-    def _check_for_ensemble_model_incompatability(
+    def _check_for_ensemble_model_incompatibility(
             self, models: List[ConfigModelProfileSpec]) -> None:
         for model in models:
             model_config = ModelConfig.create_from_profile_spec(

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -285,6 +285,13 @@ class MetricsManager:
                 self._create_model_variant(original_name,
                                            ensemble_composing_config)
 
+            for bls_composing_config in mrc.bls_composing_configs():
+                variant_name = bls_composing_config.get_field("name")
+                original_name = BaseModelConfigGenerator.extract_model_name_from_variant_name(
+                    variant_name)
+
+                self._create_model_variant(original_name, bls_composing_config)
+
     def _create_model_variant(self, original_name, variant_config):
         """
         Creates a directory for the model config variant in the output model
@@ -316,6 +323,11 @@ class MetricsManager:
         Loads all model variants in the client
         """
         for mrc in run_config.model_run_configs():
+            for bls_composing_config in mrc.bls_composing_configs():
+                if not self._load_model_variant(
+                        variant_config=bls_composing_config):
+                    return False
+
             if not self._load_model_variant(variant_config=mrc.model_config()):
                 return False
 

--- a/results/metrics-server-only.csv
+++ b/results/metrics-server-only.csv
@@ -1,0 +1,3 @@
+Model,GPU UUID,GPU Memory Usage (MB),GPU Utilization (%),GPU Power Usage (W)
+triton-server,GPU-8557549f-9c89-4384-8bd6-1fd823c342e0,457.0,0.0,56.1
+

--- a/results/metrics-server-only.csv
+++ b/results/metrics-server-only.csv
@@ -1,3 +1,0 @@
-Model,GPU UUID,GPU Memory Usage (MB),GPU Utilization (%),GPU Power Usage (W)
-triton-server,GPU-8557549f-9c89-4384-8bd6-1fd823c342e0,457.0,0.0,56.1
-

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1053,14 +1053,14 @@ class TestModelManager(trc.TestResultCollector):
             ConfigModelProfileSpec('test_model')
         ]
         with self.assertRaises(TritonModelAnalyzerException):
-            model_manager._check_for_ensemble_model_incompatability(models)
+            model_manager._check_for_ensemble_model_incompatibility(models)
 
         # RunConfigSearch check
         models = [
             ConfigModelProfileSpec('ensemble_model'),
         ]
         with self.assertRaises(TritonModelAnalyzerException):
-            model_manager._check_for_ensemble_model_incompatability(models)
+            model_manager._check_for_ensemble_model_incompatibility(models)
         self.mock_model_config.stop()
 
     @patch('model_analyzer.triton.model.model_config.ModelConfig.is_ensemble',
@@ -1091,7 +1091,7 @@ class TestModelManager(trc.TestResultCollector):
         models = [
             ConfigModelProfileSpec('ensemble_model'),
         ]
-        model_manager._check_for_ensemble_model_incompatability(models)
+        model_manager._check_for_ensemble_model_incompatibility(models)
 
         self.assertEqual(config.run_config_search_mode, "quick")
 

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -455,6 +455,72 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(ensemble_composing_configs[1].get_field("name"),
                          "resnet50_trt_config_default")
 
+    def test_default_bls_config_generation(self):
+        """
+        Test that the default BLS config is generated correctly
+        """
+
+        fake_config = {
+            "name": "my-model",
+            "platform": "pytorch",
+            "input": [{
+                "name": "INPUT__0",
+                "dataType": "TYPE_FP32",
+                "dims": [16]
+            }],
+            "max_batch_size": 4
+        }
+
+        args = [
+            'model-analyzer', 'profile', '--model-repository', '/tmp',
+            '--config-file', '/tmp/my_config.yml', '--bls-composing-models',
+            'bls_composing_modelA,bls_composing_modelB'
+        ]
+
+        # yapf: disable
+        yaml_str = ("""
+            profile_models:
+                - my-model:
+                    perf_analyzer_flags:
+                        percentile: 96
+            """)
+        # yapf: enable
+
+        config = evaluate_mock_config(args, yaml_str, subcommand="profile")
+
+        with patch(
+                "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
+                return_value=fake_config):
+            models = [
+                ModelProfileSpec(spec=config.profile_models[0],
+                                 config=config,
+                                 client=MagicMock(),
+                                 gpus=MagicMock())
+            ]
+
+        sc = SearchConfig(dimensions=MagicMock(), radius=5, min_initialized=2)
+
+        with patch(
+                "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
+                return_value=fake_config):
+            bls_composing_models = RunConfigGeneratorFactory._create_bls_composing_models(
+                config, MagicMock(), MagicMock())
+
+        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), models, {},
+                                       bls_composing_models, MagicMock(),
+                                       ModelVariantNameManager())
+
+        default_run_config = qrcg._create_default_run_config()
+        bls_composing_configs = default_run_config.model_run_configs(
+        )[0].bls_composing_configs()
+
+        self.assertTrue(
+            "my-model_config_default" in default_run_config.representation())
+        self.assertEqual(bls_composing_configs[0].get_field("name"),
+                         "bls_composing_modelA_config_default")
+        self.assertEqual(bls_composing_configs[1].get_field("name"),
+                         "bls_composing_modelB_config_default")
+
     def test_get_next_run_config_ensemble(self):
         """
         Test that get_next_run_config() creates a proper RunConfig for ensemble

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -114,7 +114,8 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         sc = SearchConfig(dimensions=self._dims, radius=5, min_initialized=2)
         config = self._create_config()
         self._qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
-                                             self._mock_models, {}, MagicMock(),
+                                             self._mock_models, {}, {},
+                                             MagicMock(),
                                              ModelVariantNameManager())
 
     def test_get_starting_coordinate(self):
@@ -129,7 +130,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         sc = SearchConfig(dimensions=dims,radius=2, min_initialized=2)
         #yapf: enable
         qrcg = QuickRunConfigGenerator(sc, MagicMock(), MagicMock(),
-                                       self._mock_models, {}, MagicMock(),
+                                       self._mock_models, {}, {}, MagicMock(),
                                        ModelVariantNameManager())
         self.assertEqual(qrcg._get_starting_coordinate(), Coordinate([2, 1, 3]))
 
@@ -296,8 +297,9 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
 
         sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
         config = self._create_config()
-        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), mock_models, {},
-                                       MagicMock(), ModelVariantNameManager())
+        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), mock_models,
+                                       {}, {}, MagicMock(),
+                                       ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([1, 2, 4, 5])
 
@@ -370,7 +372,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         ])
 
         sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
-        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), models, {},
+        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), models, {}, {},
                                        MagicMock(), ModelVariantNameManager())
 
         default_run_config = qrcg._create_default_run_config()
@@ -438,9 +440,9 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
             ensemble_composing_models = RunConfigGeneratorFactory._create_ensemble_composing_models(
                 models, config, MagicMock(), MagicMock())
 
-        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), models,
-                                       ensemble_composing_models, MagicMock(),
-                                       ModelVariantNameManager())
+        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
+                                       models, ensemble_composing_models, {},
+                                       MagicMock(), ModelVariantNameManager())
 
         default_run_config = qrcg._create_default_run_config()
         ensemble_composing_configs = default_run_config.model_run_configs(
@@ -488,7 +490,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         config = self._create_config(
             additional_args=['--run-config-search-max-model-batch-size', '16'])
         qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
-                                       self._mock_models, {}, MagicMock(),
+                                       self._mock_models, {}, {}, MagicMock(),
                                        ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([5, 7])
@@ -548,7 +550,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         config = self._create_config(
             additional_args=['--run-config-search-max-instance-count', '4'])
         qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
-                                       self._mock_models, {}, MagicMock(),
+                                       self._mock_models, {}, {}, MagicMock(),
                                        ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([5, 7])
@@ -608,7 +610,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         config = self._create_config(
             additional_args=['--run-config-search-min-model-batch-size', '64'])
         qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
-                                       self._mock_models, {}, MagicMock(),
+                                       self._mock_models, {}, {}, MagicMock(),
                                        ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([5, 7])
@@ -668,7 +670,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         config = self._create_config(
             additional_args=['--run-config-search-min-instance-count', '16'])
         qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
-                                       self._mock_models, {}, MagicMock(),
+                                       self._mock_models, {}, {}, MagicMock(),
                                        ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([5, 7])
@@ -809,9 +811,9 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
 
         sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
 
-        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(), models,
-                                       ensemble_composing_models, MagicMock(),
-                                       ModelVariantNameManager())
+        qrcg = QuickRunConfigGenerator(sc, config, MagicMock(),
+                                       models, ensemble_composing_models, {},
+                                       MagicMock(), ModelVariantNameManager())
 
         qrcg._coordinate_to_measure = Coordinate([1, 2, 4, 5])
 


### PR DESCRIPTION
Creates BLS composing models for the default config. Limited unit testing here, but more will be added once the non-default configs are generated.

In addition I have run this with a BLS model and confirmed that we are sending/load configs to PA/tritonserver correctly (but, I needed to hack the BLS composing configs name - which is the follow-on story to this)