### PR TITLE
Create unchanged BLS composing model output directory

### DIFF
--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -288,7 +288,7 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
     def create_original_config_from_variant(
             variant_config: ModelConfig) -> ModelConfig:
         """
-        Removes '_config_$/default' from the variant config and returns
+        Removes 'config_#/default' from the variant config and returns
         a new model config
         """
         original_config = deepcopy(variant_config)

--- a/model_analyzer/config/generate/base_model_config_generator.py
+++ b/model_analyzer/config/generate/base_model_config_generator.py
@@ -22,6 +22,7 @@ from typing import List, Optional, Generator, Dict, Any
 from model_analyzer.constants import LOGGER_NAME
 from model_analyzer.triton.model.model_config import ModelConfig
 from .model_profile_spec import ModelProfileSpec
+from copy import deepcopy
 import abc
 import logging
 
@@ -282,6 +283,21 @@ class BaseModelConfigGenerator(ConfigGeneratorInterface):
         the model name, eg. model_name_config_10 -> model_name
         """
         return variant_name[:variant_name.find("_config_")]
+
+    @staticmethod
+    def create_original_config_from_variant(
+            variant_config: ModelConfig) -> ModelConfig:
+        """
+        Removes '_config_$/default' from the variant config and returns
+        a new model config
+        """
+        original_config = deepcopy(variant_config)
+
+        original_config.set_model_name(
+            BaseModelConfigGenerator.extract_model_name_from_variant_name(
+                variant_config.get_field("name")))
+
+        return original_config
 
     @staticmethod
     def _apply_value_to_dict(key: Any, value: Any, dict_in: Dict) -> None:

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -328,6 +328,7 @@ class MetricsManager:
         Loads all model variants in the client
         """
         for mrc in run_config.model_run_configs():
+            # BLS composing configs cannot mutate the model names
             for bls_composing_config in mrc.bls_composing_configs():
                 bls_original_composing_config = BaseModelConfigGenerator.create_original_config_from_variant(
                     bls_composing_config)

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -292,6 +292,11 @@ class MetricsManager:
 
                 self._create_model_variant(original_name, bls_composing_config)
 
+                bls_original_composing_config = BaseModelConfigGenerator.create_original_config_from_variant(
+                    bls_composing_config)
+                self._create_model_variant(original_name,
+                                           bls_original_composing_config)
+
     def _create_model_variant(self, original_name, variant_config):
         """
         Creates a directory for the model config variant in the output model
@@ -324,8 +329,10 @@ class MetricsManager:
         """
         for mrc in run_config.model_run_configs():
             for bls_composing_config in mrc.bls_composing_configs():
+                bls_original_composing_config = BaseModelConfigGenerator.create_original_config_from_variant(
+                    bls_composing_config)
                 if not self._load_model_variant(
-                        variant_config=bls_composing_config):
+                        variant_config=bls_original_composing_config):
                     return False
 
             if not self._load_model_variant(variant_config=mrc.model_config()):

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -347,6 +347,11 @@ class ModelConfig:
 
         self._model_config = self.from_dict(model_config_dict)._model_config
 
+    def set_model_name(self, model_name: str) -> None:
+        model_config_dict = self.to_dict()
+        model_config_dict['name'] = model_name
+        self._model_config = self.from_dict(model_config_dict)._model_config
+
     def write_config_to_file(self, model_path, src_model_path,
                              first_variant_model_path):
         """

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -421,6 +421,14 @@ ensemble_scheduling {
 
         mock_model_config.stop()
 
+    def test_set_model_name(self):
+        """
+      Test that we can set the model name of a config
+      """
+        model_config = ModelConfig.create_from_dictionary(self._model_config)
+        model_config.set_model_name("new_model_name")
+        self.assertEqual(model_config.get_field("name"), "new_model_name")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
BLS composing configs cannot mutate their names. This change creates a directory using the original composing model name and changes the config.pbtxt to use this as the model name when loading on the tritonserver. 