### PR TITLE
Update codeql static analysis to run daily

### DIFF
--- a/workflows/codeql.yml
+++ b/workflows/codeql.yml
@@ -33,7 +33,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ 'main' ]
   schedule:
-    - cron: '0 1 * * 1-5'
+    - cron: '0 1 * * 1-6'
 
 jobs:
   analyze:

--- a/workflows/codeql.yml
+++ b/workflows/codeql.yml
@@ -33,7 +33,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ 'main' ]
   schedule:
-    - cron: '44 10 * * 1'
+    - cron: '0 1 * * 1-5'
 
 jobs:
   analyze:


### PR DESCRIPTION
Update the cron format to make codeql static analysis run Monday-Saturday at 1am UTC (so 6pm PST, Sunday-Friday).