### PR TITLE
Check to ensure composing models do not contain an ensemble

### DIFF
--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -192,6 +192,12 @@ class RunConfigGeneratorFactory:
                 RunConfigGeneratorFactory._create_ensemble_composing_models(
                     model, config, client, gpus))
 
+        for composing_model in composing_models:
+            if composing_model.is_ensemble():
+                raise TritonModelAnalyzerException(
+                    f"Model Analyzer does not support ensembles as a composing model type: {composing_model.model_name()}"
+                )
+
         return composing_models
 
     @staticmethod

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -16,6 +16,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from .common import test_result_collector as trc
+from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 from model_analyzer.config.generate.coordinate import Coordinate
 from model_analyzer.config.generate.search_config import SearchConfig
 from model_analyzer.config.generate.search_dimension import SearchDimension
@@ -78,6 +79,54 @@ def mock_ensemble_configs(*args, **kwargs):
         return fake_base_composing_config0
     elif model_name == 'fake_model_B':
         return fake_base_composing_config1
+
+
+def mock_composing_ensemble_configs(*args, **kwargs):
+    fake_config = {
+        "name": "my-model",
+        "platform": "ensemble",
+        "ensemble_scheduling": {
+            "step": [{
+                "model_name": "fake_model_A"
+            }, {
+                "model_name": "fake_model_B"
+            }]
+        },
+        "input": [{
+            "name": "INPUT__0",
+            "dataType": "TYPE_FP32",
+            "dims": [16]
+        }],
+        "max_batch_size": 4
+    }
+    fake_base_composing_config0 = {
+        "name": "fake_model_A",
+        "platform": "ensemble",
+        "ensemble_scheduling": {
+            "step": [{
+                "model_name": "fake_model_C"
+            }, {
+                "model_name": "fake_model_D"
+            }]
+        },
+        "input": [{
+            "name": "INPUT__0",
+            "dataType": "TYPE_FP32",
+            "dims": [16]
+        }],
+        "max_batch_size": 4,
+        "sequence_batching": {}
+    }
+
+    if args:
+        model_name = args[4]
+    else:
+        model_name = kwargs['model_name']
+
+    if model_name == 'my-model':
+        return fake_config
+    else:
+        return fake_base_composing_config0
 
 
 def mock_bls_configs(*args, **kwargs):
@@ -181,7 +230,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         """
         Test that get_next_run_config() creates a proper RunConfig
 
-        Sets up a case where the coordinate is [5,7], which cooresponds to
+        Sets up a case where the coordinate is [5,7], which corresponds to
           - max_batch_size = 32
           - instance_count = 8
           - concurrency = 32*8*2 = 512
@@ -429,25 +478,6 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         """
         Test that the default ensemble config is generated correctly
         """
-
-        fake_config = {
-            "name": "my-model",
-            "platform": "ensemble",
-            "ensemble_scheduling": {
-                "step": [{
-                    "model_name": "preprocess"
-                }, {
-                    "model_name": "resnet50_trt"
-                }]
-            },
-            "input": [{
-                "name": "INPUT__0",
-                "dataType": "TYPE_FP32",
-                "dims": [16]
-            }],
-            "max_batch_size": 4
-        }
-
         args = [
             'model-analyzer', 'profile', '--model-repository', '/tmp',
             '--config-file', '/tmp/my_config.yml'
@@ -466,7 +496,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
 
         with patch(
                 "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
-                return_value=fake_config):
+                side_effect=mock_ensemble_configs):
             models = [
                 ModelProfileSpec(spec=config.profile_models[0],
                                  config=config,
@@ -478,7 +508,7 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
 
         with patch(
                 "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
-                return_value=fake_config):
+                side_effect=mock_ensemble_configs):
             ensemble_composing_models = RunConfigGeneratorFactory._create_composing_models(
                 models, config, MagicMock(), MagicMock())
 
@@ -493,9 +523,9 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         self.assertTrue(
             "my-model_config_default" in default_run_config.representation())
         self.assertEqual(ensemble_composing_configs[0].get_field("name"),
-                         "preprocess_config_default")
+                         "fake_model_A_config_default")
         self.assertEqual(ensemble_composing_configs[1].get_field("name"),
-                         "resnet50_trt_config_default")
+                         "fake_model_B_config_default")
 
     def test_default_bls_config_generation(self):
         """
@@ -838,6 +868,30 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         self.assertEqual(model_config.to_dict(), expected_model_config)
         self.assertEqual(perf_config['concurrency-range'], 1024)
         self.assertEqual(perf_config['batch-size'], 1)
+
+    def test_ensemble_in_composing_models(self):
+        """
+        Test that an ensemble as a composing model raises an exception
+        """
+        additional_args = []
+        config = self._create_config(additional_args)
+
+        with patch(
+                "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
+                side_effect=mock_ensemble_configs):
+            models = [
+                ModelProfileSpec(spec=config.profile_models[0],
+                                 config=config,
+                                 client=MagicMock(),
+                                 gpus=MagicMock())
+            ]
+
+        with patch(
+                "model_analyzer.triton.model.model_config.ModelConfig.create_model_config_dict",
+                side_effect=mock_composing_ensemble_configs
+        ) and self.assertRaises(TritonModelAnalyzerException):
+            ensemble_composing_models = RunConfigGeneratorFactory._create_composing_models(
+                models, config, MagicMock(), MagicMock())
 
     def _get_next_run_config_ensemble(self,
                                       max_concurrency=0,


### PR DESCRIPTION
Added a unit test to check this and also fixed a unit test that was mistakenly creating an ensemble in a composing model.