### PR TITLE
Adding request rate doc to config search

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -513,10 +513,11 @@ cannot be specified globally.
 
 Options available under this parameter are described in table below:
 
-| Option Name   | Description                                             | Supporting Types                                   |
-| :------------ | :------------------------------------------------------ | :------------------------------------------------- |
-| `concurrency` | Request concurrency used for generating the input load. | `<range>`, `<comma-delimited-list>`, or a `<list>` |
-| `batch_sizes` | Static batch size used for generating requests.         | `<range>`, `<comma-delimited-list>`, or a `<list>` |
+| Option Name    | Description                                             | Supporting Types                                   |
+| :------------- | :------------------------------------------------------ | :------------------------------------------------- |
+| `concurrency`  | Request concurrency used for generating the input load. | `<range>`, `<comma-delimited-list>`, or a `<list>` |
+| `request_rate` | Request rate used for generating the input load.        | `<range>`, `<comma-delimited-list>`, or a `<list>` |
+| `batch_sizes`  | Static batch size used for generating requests.         | `<range>`, `<comma-delimited-list>`, or a `<list>` |
 
 An example `<parameter>` looks like below:
 
@@ -765,6 +766,7 @@ More information about this can be found in the
 - Model Analyzer also provides certain arguments to the `perf_analyzer`
   instances it launches. They are the following:
   - `concurrency-range`
+  - `request-rate-range`
   - `batch-size`
   - `model-name`
   - `measurement-mode`
@@ -773,7 +775,7 @@ More information about this can be found in the
   - `model-repository`
   - `protocol`
   - `url`
-    If provided under the `perf_analyzer_flags` section, their values will be overriden. Caution should therefore be exercised when overriding these.
+    If provided under the `perf_analyzer_flags` section, their values will be overridden. Caution should therefore be exercised when overriding these.
     <br>
 
 ## `<triton-server-flags>`

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -117,11 +117,17 @@ You can also modify the minimum/maximum values that the automatic search space w
 
 ---
 
-### [Request Concurrency Search Space](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md#request-concurrency)
+### [Request Concurrency Search Space](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/docs/inference_load_modes.md#concurrency-mode))
 
 - `Default:` 1 to 1024 concurrencies, sweeping over powers of 2 (i.e. 1, 2, 4, 8, ...)
 - `--run-config-search-min-concurrency: <val>`: Changes the request concurrency minimum automatic search space value
 - `--run-config-search-max-concurrency: <val>`: Changes the request concurrency maximum automatic search space value
+
+### [Request Rate Search Space](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/docs/inference_load_modes.md#request-rate-mode)
+
+- `Default:` 1 to 1024 concurrencies, sweeping over powers of 2 (i.e. 1, 2, 4, 8, ...)
+- `--run-config-search-min-request-rate: <val>`: Changes the request rate minimum automatic search space value
+- `--run-config-search-max-request-rate: <val>`: Changes the request rate maximum automatic search space value
 
 ---
 
@@ -144,7 +150,7 @@ _This will perform an Automatic Brute Search with instance group counts: 3-5, ba
 
 ### **Interaction with Remote Triton Launch Mode**
 
-When the triton launch mode is remote, _\*\*only concurrency values can be swept._\*\*<br>
+When the triton launch mode is remote, _\*\*only concurrency or request rate values can be swept._\*\*<br>
 
 Model Analyzer will ignore any model config parameters because we have no way of accessing and modifying the model repository of the remote Triton Server.
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -255,9 +255,9 @@ profile_models:
 
 ---
 
-### **Limiting Batch Size, Instance Group, and Client Concurrency or Request Rate**
+### **Limiting Batch Size, Instance Group, and Client Concurrency**
 
-Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance group count, as well as the client's request concurrency or rate.
+Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance group count, as well as the client's request concurrency.
 
 _Note: By default, quick search runs unbounded and ignores any default values for these settings_
 

--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -255,9 +255,9 @@ profile_models:
 
 ---
 
-### **Limiting Batch Size, Instance Group, and Client Concurrency**
+### **Limiting Batch Size, Instance Group, and Client Concurrency or Request Rate**
 
-Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance group count, as well as the client's request concurrency.
+Using the `--run-config-search-<min/max>...` config options you have the ability to clamp the algorithm's upper or lower bounds for the model's batch size and instance group count, as well as the client's request concurrency or rate.
 
 _Note: By default, quick search runs unbounded and ignores any default values for these settings_
 


### PR DESCRIPTION
Most documentation changes went in with the new config/CLI options.
Not sure where else this needs to be documented, other than in our release notes.