### PR TITLE
Add binary search to L0_quick_search

### DIFF
--- a/qa/L0_quick_search/test.sh
+++ b/qa/L0_quick_search/test.sh
@@ -52,6 +52,7 @@ MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url http://localhost:
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS -e $EXPORT_PATH --filename-server-only=$FILENAME_SERVER_ONLY"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --filename-model-inference=$FILENAME_INFERENCE_MODEL --filename-model-gpu=$FILENAME_GPU_MODEL"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --latency-budget 10"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --skip-summary-reports"
 MODEL_ANALYZER_SUBCOMMAND="profile"
 run_analyzer


### PR DESCRIPTION
Adding  `--latency-budget 10` to **L0_quick_search** will enable a binary search.

This exposed some bugs in the code around cases where PA doesn't return a result and we add `None` to the ConcurrencySearch's RCM list.

I've updated the code to check and deal with None.