### PR TITLE
Detect when tritonserver fails to launch

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -205,7 +205,9 @@ class Analyzer:
 
             logger.info('Profiling server only metrics...')
             self._server.start()
-            client.wait_for_server_ready(self._config.client_max_retries)
+            client.wait_for_server_ready(
+                num_retries=self._config.client_max_retries,
+                log_file=self._server.log_file())
             self._metrics_manager.profile_server()
             self._server.stop()
 

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -103,7 +103,7 @@ class MetricsManager:
     def _init_state(self):
         """
         Sets MetricsManager object managed
-        state variables in AnalyerState
+        state variables in AnalyzerState
         """
 
         gpu_info = self._state_manager.get_state_variable(
@@ -361,7 +361,9 @@ class MetricsManager:
         """
         Loads a model variant in the client
         """
-        self._client.wait_for_server_ready(self._config.client_max_retries)
+        self._client.wait_for_server_ready(
+            num_retries=self._config.client_max_retries,
+            log_file=self._server.log_file())
 
         variant_name = variant_config.get_field('name')
         if self._client.load_model(model_name=variant_name) == -1:
@@ -483,7 +485,7 @@ class MetricsManager:
                 perf_output_writer.write(perf_analyzer.output() + '\n',
                                          append=True)
 
-        # PerfAnalyzer run was not succesful
+        # PerfAnalyzer run was not successful
         if status == 1:
             return (None, None)
 
@@ -539,7 +541,7 @@ class MetricsManager:
     def _get_cpu_inference_metrics(self):
         """
         Stops any monitors that just need the records to be aggregated
-        like the CPU mmetrics
+        like the CPU metrics
         """
 
         cpu_records = self._cpu_monitor.stop_recording_metrics()
@@ -558,7 +560,9 @@ class MetricsManager:
         """
 
         if self._config.triton_launch_mode != 'remote' and self._config.triton_launch_mode != 'c_api':
-            self._client.wait_for_server_ready(self._config.client_max_retries)
+            self._client.wait_for_server_ready(
+                num_retries=self._config.client_max_retries,
+                log_file=self._server.log_file())
 
             model_analyzer_gpus = [gpu.device_uuid() for gpu in self._gpus]
             triton_gpus = self._get_triton_metrics_gpus()

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -65,6 +65,9 @@ class TritonClient:
                     log_file.seek(0)
                     log_output = log_file.read()
 
+                    if not type(log_output) == str:
+                        log_output = log_output.decode('utf-8')
+
                     if log_output:
                         if "Unexpected argument:" in log_output:
                             error_start = log_output.find(

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -61,21 +61,7 @@ class TritonClient:
                     time.sleep(sleep_time)
                     retries -= 1
             except Exception as e:
-                if log_file:
-                    log_file.seek(0)
-                    log_output = log_file.read()
-
-                    if not type(log_output) == str:
-                        log_output = log_output.decode('utf-8')
-
-                    if log_output:
-                        if "Unexpected argument:" in log_output:
-                            error_start = log_output.find(
-                                "Unexpected argument:")
-                            raise TritonModelAnalyzerException(
-                                f'Error: TritonServer did not launch successfully\n\n{log_output[error_start:]}'
-                            )
-
+                self._check_for_triton_log_errors(log_file)
                 time.sleep(sleep_time)
                 retries -= 1
                 if retries == 0:
@@ -197,3 +183,20 @@ class TritonClient:
         Returns true if the server is ready. Else False
         """
         return self._client.is_server_ready()
+
+    def _check_for_triton_log_errors(self, log_file):
+        if not log_file:
+            return
+
+        log_file.seek(0)
+        log_output = log_file.read()
+
+        if not type(log_output) == str:
+            log_output = log_output.decode('utf-8')
+
+        if log_output:
+            if "Unexpected argument:" in log_output:
+                error_start = log_output.find("Unexpected argument:")
+                raise TritonModelAnalyzerException(
+                    f'Error: TritonServer did not launch successfully\n\n{log_output[error_start:]}'
+                )

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 from model_analyzer.constants import LOGGER_NAME
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 
 import time
 import logging
-from io import TextIOWrapper
 
 logger = logging.getLogger(LOGGER_NAME)
 

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -41,6 +41,10 @@ class TritonClient:
             number of times to send a ready status
             request to the server before raising
             an exception
+        sleep_time: int
+            amount of time in seconds to sleep between retries
+        log_file: TextIOWrapper
+            file that contains the server's output log
         Raises
         ------
         TritonModelAnalyzerException
@@ -55,6 +59,7 @@ class TritonClient:
                     time.sleep(sleep_time)
                     return
                 else:
+                    self._check_for_triton_log_errors(log_file)
                     time.sleep(sleep_time)
                     retries -= 1
             except Exception as e:

--- a/model_analyzer/triton/client/grpc_client.py
+++ b/model_analyzer/triton/client/grpc_client.py
@@ -68,7 +68,7 @@ class TritonGRPCClient(TritonClient):
         Returns
         -------
         dict
-            A dictionary containg the model config.
+            A dictionary containing the model config.
         """
 
         self.wait_for_model_ready(model_name, num_retries)

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -138,7 +138,8 @@ class ModelConfig:
             config, gpus, use_model_repository=True)
 
         server.start()
-        client.wait_for_server_ready(config.client_max_retries)
+        client.wait_for_server_ready(num_retries=config.client_max_retries,
+                                     log_file=server.log_file())
 
         if (client.load_model(model_name) == -1):
             server.stop()

--- a/model_analyzer/triton/server/server.py
+++ b/model_analyzer/triton/server/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from io import TextIOWrapper
 
 
 class TritonServer(ABC):
@@ -36,6 +37,12 @@ class TritonServer(ABC):
     def stop(self):
         """
         Stops and cleans up after the server
+        """
+
+    @abstractmethod
+    def log_file(self) -> TextIOWrapper:
+        """
+        Returns the server's log file
         """
 
     @abstractmethod

--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -21,6 +21,8 @@ from .server import TritonServer
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 
+from io import TextIOWrapper
+
 LOCAL_HTTP_PORT = 8000
 LOCAL_GRPC_PORT = 8001
 LOCAL_METRICS_PORT = 8002
@@ -205,3 +207,6 @@ class TritonServerDocker(TritonServer):
         # Divide by 1.0e6 to convert from kilobytes to MB
         return float(used_mem_bytes.decode("utf-8")) // 1.0e3, float(
             available_mem_bytes.decode("utf-8")) // 1.0e3
+
+    def log_file(self) -> TextIOWrapper:
+        return self._log_file

--- a/model_analyzer/triton/server/server_local.py
+++ b/model_analyzer/triton/server/server_local.py
@@ -95,8 +95,6 @@ class TritonServerLocal(TritonServer):
             else:
                 self._log_file = tempfile.NamedTemporaryFile()
 
-            # self._log_file = DEVNULL
-
             self._is_first_time_starting_server = False
 
             # Construct Popen command

--- a/tests/mocks/mock_server.py
+++ b/tests/mocks/mock_server.py
@@ -24,7 +24,7 @@ class MockServerMethods(MockBase):
     """
 
     @abstractmethod
-    def assert_server_process_start_called_with(self, **args):
+    def assert_server_process_start_called_with(self, *args, **kwargs):
         """
         Asserts that the tritonserver process was started with
         the supplied arguments

--- a/tests/mocks/mock_server_local.py
+++ b/tests/mocks/mock_server_local.py
@@ -15,7 +15,6 @@
 from .mock_server import MockServerMethods
 from unittest.mock import patch, Mock, MagicMock
 import os
-import tempfile
 
 
 class MockServerLocalMethods(MockServerMethods):
@@ -70,7 +69,10 @@ class MockServerLocalMethods(MockServerMethods):
         self._patchers.append(self.patcher_pipe)
         self._patchers.append(self.patcher_psutil)
 
-    def assert_server_process_start_called_with(self, cmd, gpus, stdout):
+    def assert_server_process_start_called_with(self,
+                                                cmd,
+                                                gpus,
+                                                stdout=MagicMock()):
         """
         Asserts that Popen was called
         with the cmd provided.

--- a/tests/mocks/mock_server_local.py
+++ b/tests/mocks/mock_server_local.py
@@ -47,6 +47,7 @@ class MockServerLocalMethods(MockServerMethods):
         self.patcher_psutil = patch(
             'model_analyzer.triton.server.server_local.psutil',
             Mock(**psutil_attrs))
+        self._log_path = "./test_log_path"
         super().__init__()
 
     def start(self):
@@ -80,7 +81,8 @@ class MockServerLocalMethods(MockServerMethods):
             [gpu.device_uuid() for gpu in gpus])
 
         self.popen_mock.assert_called_once_with(cmd,
-                                                stdout=self.pipe_mock,
+                                                stdout=open(
+                                                    self._log_path, 'a+'),
                                                 stderr=self.stdout_mock,
                                                 start_new_session=True,
                                                 universal_newlines=True,

--- a/tests/mocks/mock_server_local.py
+++ b/tests/mocks/mock_server_local.py
@@ -15,6 +15,7 @@
 from .mock_server import MockServerMethods
 from unittest.mock import patch, Mock, MagicMock
 import os
+import tempfile
 
 
 class MockServerLocalMethods(MockServerMethods):
@@ -47,7 +48,6 @@ class MockServerLocalMethods(MockServerMethods):
         self.patcher_psutil = patch(
             'model_analyzer.triton.server.server_local.psutil',
             Mock(**psutil_attrs))
-        self._log_path = "./test_log_path"
         super().__init__()
 
     def start(self):
@@ -70,7 +70,7 @@ class MockServerLocalMethods(MockServerMethods):
         self._patchers.append(self.patcher_pipe)
         self._patchers.append(self.patcher_psutil)
 
-    def assert_server_process_start_called_with(self, cmd, gpus):
+    def assert_server_process_start_called_with(self, cmd, gpus, stdout):
         """
         Asserts that Popen was called
         with the cmd provided.
@@ -81,8 +81,7 @@ class MockServerLocalMethods(MockServerMethods):
             [gpu.device_uuid() for gpu in gpus])
 
         self.popen_mock.assert_called_once_with(cmd,
-                                                stdout=open(
-                                                    self._log_path, 'a+'),
+                                                stdout=stdout,
                                                 stderr=self.stdout_mock,
                                                 start_new_session=True,
                                                 universal_newlines=True,

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -194,7 +194,10 @@ class TestTritonServerMethods(trc.TestResultCollector):
 
         # Create local server which runs triton as a subprocess
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
+            path=TRITON_LOCAL_BIN_PATH,
+            config=server_config,
+            gpus=gpus,
+            log_path="./test_log_path")
 
         # Check that API functions are called
         self.server.start()

--- a/tests/test_triton_server.py
+++ b/tests/test_triton_server.py
@@ -194,10 +194,7 @@ class TestTritonServerMethods(trc.TestResultCollector):
 
         # Create local server which runs triton as a subprocess
         self.server = TritonServerFactory.create_server_local(
-            path=TRITON_LOCAL_BIN_PATH,
-            config=server_config,
-            gpus=gpus,
-            log_path="./test_log_path")
+            path=TRITON_LOCAL_BIN_PATH, config=server_config, gpus=gpus)
 
         # Check that API functions are called
         self.server.start()
@@ -207,7 +204,8 @@ class TestTritonServerMethods(trc.TestResultCollector):
                 TRITON_LOCAL_BIN_PATH, '--model-repository',
                 MODEL_REPOSITORY_PATH
             ],
-            gpus=gpus)
+            gpus=gpus,
+            stdout=self.server._log_file)
 
         self.server.stop()
         self.server_local_mock.assert_server_process_terminate_called()


### PR DESCRIPTION
Will now scan the triton_output log looking for `Unexpected argument:` and will terminate the `wait_for_server_ready()` method early (saving about 50 retries and around 15 seconds of user time).

Will now print out the failure message rather than the generic client error.

Have tested this live and added a unit test to check this case.

Note: We will now delete an existing log file (rather than append) to ensure that any error messages seen are for the current run.