### PR TITLE
Capture PA errors in a log file

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -137,7 +137,6 @@ class Analyzer:
             if self._metrics_manager.encountered_perf_analyzer_error():
                 logger.warning(f"Perf Analyzer encountered an error when profiling one or more configurations. " \
                       f"See {PA_ERROR_LOG_FILENAME} for further details.\n")
-                print(f"")
 
     def report(self, mode: str) -> None:
         """

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -135,8 +135,9 @@ class Analyzer:
                             model.model_name()))
 
             if self._metrics_manager.encountered_perf_analyzer_error():
+                output_path = self._config.perf_output_path if self._config.perf_output_path else self._config.export_path
                 logger.warning(f"Perf Analyzer encountered an error when profiling one or more configurations. " \
-                      f"See {self._config.export_path}/{PA_ERROR_LOG_FILENAME} for further details.\n")
+                      f"See {output_path}/{PA_ERROR_LOG_FILENAME} for further details.\n")
 
     def report(self, mode: str) -> None:
         """

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -135,9 +135,8 @@ class Analyzer:
                             model.model_name()))
 
             if self._metrics_manager.encountered_perf_analyzer_error():
-                output_path = self._config.perf_output_path if self._config.perf_output_path else self._config.export_path
                 logger.warning(f"Perf Analyzer encountered an error when profiling one or more configurations. " \
-                      f"See {output_path}/{PA_ERROR_LOG_FILENAME} for further details.\n")
+                      f"See {self._config.export_path}/{PA_ERROR_LOG_FILENAME} for further details.\n")
 
     def report(self, mode: str) -> None:
         """

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -14,7 +14,7 @@
 
 from typing import List, Union, Optional
 import sys
-from model_analyzer.constants import LOGGER_NAME
+from model_analyzer.constants import LOGGER_NAME, PA_ERROR_LOG_FILENAME
 from .model_manager import ModelManager
 from .result.result_manager import ResultManager
 from .result.result_table_manager import ResultTableManager
@@ -133,6 +133,11 @@ class Analyzer:
                     logger.info(
                         self._get_report_command_help_string(
                             model.model_name()))
+
+            if self._metrics_manager.encountered_perf_analyzer_error():
+                logger.warning(f"Perf Analyzer encountered an error when profiling one or more configurations. " \
+                      f"See {PA_ERROR_LOG_FILENAME} for further details.\n")
+                print(f"")
 
     def report(self, mode: str) -> None:
         """

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -136,7 +136,7 @@ class Analyzer:
 
             if self._metrics_manager.encountered_perf_analyzer_error():
                 logger.warning(f"Perf Analyzer encountered an error when profiling one or more configurations. " \
-                      f"See {PA_ERROR_LOG_FILENAME} for further details.\n")
+                      f"See {self._config.export_path}/{PA_ERROR_LOG_FILENAME} for further details.\n")
 
     def report(self, mode: str) -> None:
         """

--- a/model_analyzer/constants.py
+++ b/model_analyzer/constants.py
@@ -57,5 +57,8 @@ SERVER_OUTPUT_TIMEOUT_SECS = 5
 # Logging
 LOGGER_NAME = "model_analyzer_logger"
 
+# PA Error Log Filename
+PA_ERROR_LOG_FILENAME = "perf_analyzer_error.log"
+
 # Constraints
 GLOBAL_CONSTRAINTS_KEY = "__default__"

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, Tuple, Dict, List
+
 from .record_aggregator import RecordAggregator
-from .record import RecordType
+from .record import RecordType, Record
 from model_analyzer.constants import LOGGER_NAME, PA_ERROR_LOG_FILENAME
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
@@ -22,6 +24,7 @@ from model_analyzer.monitor.dcgm.dcgm_monitor import DCGMMonitor
 from model_analyzer.monitor.remote_monitor import RemoteMonitor
 from model_analyzer.output.file_writer import FileWriter
 from model_analyzer.perf_analyzer.perf_analyzer import PerfAnalyzer
+from model_analyzer.config.run.run_config import RunConfig
 from model_analyzer.result.run_config_measurement import RunConfigMeasurement
 from model_analyzer.config.generate.base_model_config_generator import BaseModelConfigGenerator
 
@@ -169,7 +172,8 @@ class MetricsManager:
             self._result_manager.add_server_data(data=server_gpu_metrics)
         self._destroy_monitors(cpu_only=cpu_only)
 
-    def execute_run_config(self, run_config):
+    def execute_run_config(
+            self, run_config: RunConfig) -> Optional[RunConfigMeasurement]:
         """
         Executes the RunConfig. Returns obtained measurement. Also sends 
         measurement to the result manager
@@ -192,7 +196,7 @@ class MetricsManager:
             if not self._load_model_variants(run_config):
                 self._server.stop()
                 self._loaded_models = None
-                return
+                return None
 
             self._loaded_models = current_model_variants
 
@@ -200,7 +204,8 @@ class MetricsManager:
 
         return measurement
 
-    def profile_models(self, run_config):
+    def profile_models(self,
+                       run_config: RunConfig) -> Optional[RunConfigMeasurement]:
         """
         Runs monitors while running perf_analyzer with a specific set of
         arguments. This will profile model inferencing.
@@ -270,7 +275,7 @@ class MetricsManager:
     def finalize(self):
         self._server.stop()
 
-    def _create_model_variants(self, run_config):
+    def _create_model_variants(self, run_config: RunConfig) -> None:
         """
         Creates and fills all model variant directories
         """
@@ -445,7 +450,9 @@ class MetricsManager:
         self._gpu_monitor = None
         self._cpu_monitor = None
 
-    def _run_perf_analyzer(self, run_config, perf_output_writer):
+    def _run_perf_analyzer(
+        self, run_config: RunConfig, perf_output_writer: Optional[FileWriter]
+    ) -> Tuple[Optional[Dict], Optional[Dict[int, List[Record]]]]:
         """
         Runs perf_analyzer and returns the aggregated metrics
 
@@ -454,7 +461,7 @@ class MetricsManager:
         run_config : RunConfig
             The RunConfig to execute on perf analyzer
 
-        perf_output_writer : OutputWriter
+        perf_output_writer : FileWriter
             Writer that writes the output from perf_analyzer to the output
             stream/file. If None, the output is not written
 
@@ -480,34 +487,10 @@ class MetricsManager:
         metrics_to_gather = self._perf_metrics + self._gpu_metrics
         status = perf_analyzer.run(metrics_to_gather, env=perf_analyzer_env)
 
-        if perf_output_writer:
-            perf_output_writer.write(
-                '============== Perf Analyzer Launched ==============\n'
-                f'Command: {perf_analyzer.get_cmd()}\n\n',
-                append=True)
-            if perf_analyzer.output():
-                perf_output_writer.write(perf_analyzer.output() + '\n',
-                                         append=True)
+        self._write_perf_analyzer_output(perf_output_writer, perf_analyzer)
 
-        # PerfAnalyzer run was not successful
         if status == 1:
-            self._encountered_perf_analyzer_error = True
-            perf_error_log = FileWriter(
-                f"{self._config.export_path}/{PA_ERROR_LOG_FILENAME}")
-            perf_error_log.write('Command: \n' + perf_analyzer.get_cmd() +
-                                 '\n\n',
-                                 append=True)
-
-            if perf_analyzer.output():
-                perf_error_log.write('Error: \n' + perf_analyzer.output() +
-                                     '\n',
-                                     append=True)
-            else:
-                perf_error_log.write(
-                    'Error: ' +
-                    'perf_analyzer did not produce any output. It was most likely terminated with a SIGABRT.'
-                    + '\n\n',
-                    append=True)
+            self._handle_unsuccessful_perf_analyzer_run(perf_analyzer)
             return (None, None)
 
         perf_records = perf_analyzer.get_perf_records()
@@ -517,6 +500,36 @@ class MetricsManager:
         aggregated_gpu_records = self._aggregate_gpu_records(gpu_records)
 
         return aggregated_perf_records, aggregated_gpu_records
+
+    def _write_perf_analyzer_output(self,
+                                    perf_output_writer: Optional[FileWriter],
+                                    perf_analyzer: PerfAnalyzer) -> None:
+        if perf_output_writer:
+            perf_output_writer.write(
+                '============== Perf Analyzer Launched ==============\n'
+                f'Command: {perf_analyzer.get_cmd()}\n\n',
+                append=True)
+            if perf_analyzer.output():
+                perf_output_writer.write(perf_analyzer.output() + '\n',
+                                         append=True)
+
+    def _handle_unsuccessful_perf_analyzer_run(
+            self, perf_analyzer: PerfAnalyzer) -> None:
+        self._encountered_perf_analyzer_error = True
+        perf_error_log = FileWriter(
+            f"{self._config.export_path}/{PA_ERROR_LOG_FILENAME}")
+        perf_error_log.write('Command: \n' + perf_analyzer.get_cmd() + '\n\n',
+                             append=True)
+
+        if perf_analyzer.output():
+            perf_error_log.write('Error: \n' + perf_analyzer.output() + '\n',
+                                 append=True)
+        else:
+            perf_error_log.write(
+                'Error: ' +
+                'perf_analyzer did not produce any output. It was likely terminated with a SIGABRT.'
+                + '\n\n',
+                append=True)
 
     def _aggregate_perf_records(self, perf_records):
         per_model_perf_records = {}

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -515,9 +515,15 @@ class MetricsManager:
 
     def _handle_unsuccessful_perf_analyzer_run(
             self, perf_analyzer: PerfAnalyzer) -> None:
-        self._encountered_perf_analyzer_error = True
         output_path = self._config.perf_output_path if self._config.perf_output_path else self._config.export_path
-        perf_error_log = FileWriter(f"{output_path}/{PA_ERROR_LOG_FILENAME}")
+        output_file = f"{output_path}/{PA_ERROR_LOG_FILENAME}"
+
+        if not self._encountered_perf_analyzer_error:
+            self._encountered_perf_analyzer_error = True
+            if os.path.exists(output_file):
+                os.remove(output_file)
+
+        perf_error_log = FileWriter(output_file)
         perf_error_log.write('Command: \n' + perf_analyzer.get_cmd() + '\n\n',
                              append=True)
 

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -515,8 +515,7 @@ class MetricsManager:
 
     def _handle_unsuccessful_perf_analyzer_run(
             self, perf_analyzer: PerfAnalyzer) -> None:
-        output_path = self._config.perf_output_path if self._config.perf_output_path else self._config.export_path
-        output_file = f"{output_path}/{PA_ERROR_LOG_FILENAME}"
+        output_file = f"{self._config.export_path}/{PA_ERROR_LOG_FILENAME}"
 
         if not self._encountered_perf_analyzer_error:
             self._encountered_perf_analyzer_error = True

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -516,8 +516,8 @@ class MetricsManager:
     def _handle_unsuccessful_perf_analyzer_run(
             self, perf_analyzer: PerfAnalyzer) -> None:
         self._encountered_perf_analyzer_error = True
-        perf_error_log = FileWriter(
-            f"{self._config.export_path}/{PA_ERROR_LOG_FILENAME}")
+        output_path = self._config.perf_output_path if self._config.perf_output_path else self._config.export_path
+        perf_error_log = FileWriter(f"{output_path}/{PA_ERROR_LOG_FILENAME}")
         perf_error_log.write('Command: \n' + perf_analyzer.get_cmd() + '\n\n',
                              append=True)
 

--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -16,6 +16,7 @@ from model_analyzer.constants import LOGGER_NAME
 from model_analyzer.model_analyzer_exceptions \
     import TritonModelAnalyzerException
 
+from subprocess import DEVNULL
 import time
 import logging
 
@@ -187,7 +188,7 @@ class TritonClient:
         return self._client.is_server_ready()
 
     def _check_for_triton_log_errors(self, log_file):
-        if not log_file:
+        if not log_file or log_file == DEVNULL:
             return
 
         log_file.seek(0)


### PR DESCRIPTION
Current behavior only prints PA errors to stdout. 

The new behavior will capture PA errors that occur during profiling to a log file, inform the user that errors occurred, and point them to the new log file.

The log file contains (per PA error) the configuration name, PA command line. and PA error.

There is no unit testing for this (as neither metrics manager or analyzer has a unit test env), but I've run this on live tests that have known PA errors and observed the log file being properly created.