### PR TITLE
Create export_path if it doesn't exist

### DIFF
--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -822,7 +822,7 @@ class ConfigCommandProfile(ConfigCommand):
                         flags=['-e', '--export-path'],
                         default_value=DEFAULT_EXPORT_PATH,
                         field_type=ConfigPrimitive(
-                            str, validator=file_path_validator),
+                            str, validator=parent_path_validator),
                         description=
                         "Full path to directory in which to store the results"))
         self._add_config(
@@ -1045,9 +1045,12 @@ class ConfigCommandProfile(ConfigCommand):
             logger.warning(
                 f"--export-path not specified. Using {self._fields['export_path'].default_value()}"
             )
-        elif self.export_path and not os.path.isdir(self.export_path):
+        elif os.path.exists(self.export_path) and os.path.isfile(
+                self.export_path):
             raise TritonModelAnalyzerException(
                 f"Export path {self.export_path} is not a directory.")
+        elif not os.path.exists(self.export_path):
+            os.makedirs(self.export_path)
 
         if self.num_top_model_configs > 0 and not self.constraints:
             raise TritonModelAnalyzerException(

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -1045,8 +1045,8 @@ class ConfigCommandProfile(ConfigCommand):
             logger.warning(
                 f"--export-path not specified. Using {self._fields['export_path'].default_value()}"
             )
-        elif os.path.exists(self.export_path) and os.path.isfile(
-                self.export_path):
+        elif os.path.exists(
+                self.export_path) and not os.path.isdir(self.export_path):
             raise TritonModelAnalyzerException(
                 f"Export path {self.export_path} is not a directory.")
         elif not os.path.exists(self.export_path):

--- a/tests/mocks/mock_os.py
+++ b/tests/mocks/mock_os.py
@@ -79,3 +79,11 @@ class MockOSMethods(MockBase):
 
         for mock in self._os_mocks.values():
             mock.path.join.return_value = value
+
+    def set_os_path_isfile_return_value(self, value):
+        """
+        Sets the return value for os.path.isfile
+        """
+
+        for mock in self._os_mocks.values():
+            mock.path.isfile.return_value = value

--- a/tests/test_report_manager.py
+++ b/tests/test_report_manager.py
@@ -138,6 +138,7 @@ class TestReportManagerMethods(trc.TestResultCollector):
             "model_analyzer.config.input.config_command_report"
         ])
         self.os_mock.start()
+        self.os_mock.set_os_path_isfile_return_value(False)
         # Required patch ordering here
         # html_report must be patched before pdf_report
         # Likely due to patching dealing with parent + child classes


### PR DESCRIPTION
Instead of erroring, we will now create an export path for the user if it doesn't exist, but it's parent directory does. 
We will still error in the case where the export path is a file or if multiple levels of directories need to be created.