### PR TITLE
Detect and handle invalid metrics url

### DIFF
--- a/model_analyzer/monitor/cpu_monitor.py
+++ b/model_analyzer/monitor/cpu_monitor.py
@@ -41,6 +41,9 @@ class CPUMonitor(Monitor):
         self._cpu_memory_records = []
         self._server = server
 
+    def is_monitoring_connected(self) -> bool:
+        return True
+
     def _monitoring_iteration(self):
         """
         Get memory info of process and 

--- a/model_analyzer/monitor/dcgm/dcgm_monitor.py
+++ b/model_analyzer/monitor/dcgm/dcgm_monitor.py
@@ -89,6 +89,9 @@ class DCGMMonitor(Monitor):
             dcgm_handle, self.group_id, self.dcgm_field_group_id.value,
             structs.DCGM_OPERATION_MODE_MANUAL, frequency, 3600, 0, 0)
 
+    def is_monitoring_connected(self) -> bool:
+        return True
+
     def _monitoring_iteration(self):
         self.group_watcher.GetMore()
 

--- a/model_analyzer/monitor/monitor.py
+++ b/model_analyzer/monitor/monitor.py
@@ -87,6 +87,20 @@ class Monitor(ABC):
 
         pass
 
+    @abstractmethod
+    def is_monitoring_connected(self) -> bool:
+        """
+        This method is called to determine if we can connect to the
+        monitor
+        
+        Returns
+        -------
+        bool
+           True if connection to the monitor was successful
+        """
+
+        pass
+
     def start_recording_metrics(self):
         """
         Start recording the metrics.
@@ -97,7 +111,7 @@ class Monitor(ABC):
 
     def stop_recording_metrics(self):
         """
-        Stop recording metrics. This will stop monitring all the metrics.
+        Stop recording metrics. This will stop monitoring all the metrics.
 
         Returns
         ------

--- a/model_analyzer/monitor/remote_monitor.py
+++ b/model_analyzer/monitor/remote_monitor.py
@@ -52,10 +52,18 @@ class RemoteMonitor(Monitor):
                 f"GPU monitoring does not currently support the following metrics: {unsupported_metrics}]"
             )
 
+    def is_monitoring_connected(self) -> bool:
+        try:
+            status_code = requests.get(self._metrics_url).status_code
+        except:
+            return False
+
+        return status_code == requests.code["okay"]
+
     def _monitoring_iteration(self):
         """
         When this function runs, it requests all the metrics
-        that triton has collected aand organizes them into
+        that triton has collected and organizes them into
         the dict. This function should run as fast
         as possible
         """
@@ -66,7 +74,7 @@ class RemoteMonitor(Monitor):
     def _collect_records(self):
         """
         This function will organize the metrics responses
-        and creat Records out of them
+        and create Records out of them
         """
 
         records = []

--- a/model_analyzer/monitor/remote_monitor.py
+++ b/model_analyzer/monitor/remote_monitor.py
@@ -55,7 +55,7 @@ class RemoteMonitor(Monitor):
     def is_monitoring_connected(self) -> bool:
         try:
             status_code = requests.get(self._metrics_url).status_code
-        except:
+        except Exception as ex:
             return False
 
         return status_code == requests.codes["okay"]

--- a/model_analyzer/monitor/remote_monitor.py
+++ b/model_analyzer/monitor/remote_monitor.py
@@ -58,7 +58,7 @@ class RemoteMonitor(Monitor):
         except:
             return False
 
-        return status_code == requests.code["okay"]
+        return status_code == requests.codes["okay"]
 
     def _monitoring_iteration(self):
         """

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -559,13 +559,19 @@ class MetricsManager:
         # Stop and destroy DCGM monitor
         gpu_records = self._gpu_monitor.stop_recording_metrics()
 
-        if not gpu_records:
+        if not gpu_records and self._expected_gpu_records():
             raise TritonModelAnalyzerException(
                 f'No GPU metrics returned. Please check that the `triton_metrics_url` value is set correctly.'
             )
 
         gpu_metrics = self._aggregate_gpu_records(gpu_records)
         return gpu_metrics
+
+    def _expected_gpu_records(self) -> bool:
+        if self._config.triton_launch_mode == 'remote':
+            return False
+
+        return True
 
     def _aggregate_gpu_records(self, gpu_records):
         # Insert all records into aggregator and get aggregated DCGM records

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -568,7 +568,7 @@ class MetricsManager:
         return gpu_metrics
 
     def _expected_gpu_records(self) -> bool:
-        if self._config.triton_launch_mode == 'remote':
+        if self._config.triton_launch_mode == 'remote' or self._config.triton_launch_mode == 'c_api':
             return False
 
         return True

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -422,7 +422,8 @@ class MetricsManager:
                 self._destroy_monitors()
                 raise
             finally:
-                if not self._gpu_monitor.is_monitoring_connected():
+                if not self._gpu_monitor.is_monitoring_connected(
+                ) and self._config.triton_launch_mode != 'c_api':
                     raise TritonModelAnalyzerException(
                     f'Failed to connect to Tritonserver\'s GPU metrics monitor. ' \
                     f'Please check that the `triton_metrics_url` value is set correctly: {self._config.triton_metrics_url}.'

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -559,6 +559,11 @@ class MetricsManager:
         # Stop and destroy DCGM monitor
         gpu_records = self._gpu_monitor.stop_recording_metrics()
 
+        if not gpu_records:
+            raise TritonModelAnalyzerException(
+                f'No GPU metrics returned. Please check that the `triton_metrics_url` value is set correctly.'
+            )
+
         gpu_metrics = self._aggregate_gpu_records(gpu_records)
         return gpu_metrics
 

--- a/qa/L0_ssl_https/test.sh
+++ b/qa/L0_ssl_https/test.sh
@@ -24,7 +24,7 @@ MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_V
 TRITON_LAUNCH_MODE=${TRITON_LAUNCH_MODE:="remote"}
 CLIENT_PROTOCOL="http"
 PORTS=(`find_available_ports 2`)
-HTTP_PORT=8000
+HTTP_PORT="8000"
 GRPC_PORT="${PORTS[1]}"
 METRICS_PORT="${PORTS[2]}"
 GPUS=(`get_all_gpus_uuids`)

--- a/qa/L0_ssl_https/test.sh
+++ b/qa/L0_ssl_https/test.sh
@@ -87,8 +87,8 @@ create_result_paths -test-name $TEST_NAME
 
 MODEL_ANALYZER_ARGS="-m $MODEL_REPOSITORY -f $WORKING_CONFIG_FILE -e $EXPORT_PATH --checkpoint-directory $CHECKPOINT_DIRECTORY"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --client-protocol=$CLIENT_PROTOCOL --triton-launch-mode=$TRITON_LAUNCH_MODE"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${PORTS[1]}"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url https://localhost:${PORTS[2]}/metrics"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${PORTS[0]}"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url https://localhost:${PORTS[1]}/metrics"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
 MODEL_ANALYZER_SUBCOMMAND="profile"
 run_analyzer
@@ -104,8 +104,8 @@ create_result_paths -test-name $TEST_NAME
 
 MODEL_ANALYZER_ARGS="-m $MODEL_REPOSITORY -f $BROKEN_CONFIG_FILE -e $EXPORT_PATH --checkpoint-directory $CHECKPOINT_DIRECTORY"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --client-protocol=$CLIENT_PROTOCOL --triton-launch-mode=$TRITON_LAUNCH_MODE"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${PORTS[1]}"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url https://localhost:${PORTS[2]}/metrics"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${PORTS[0]}"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url https://localhost:${PORTS[1]}/metrics"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
 MODEL_ANALYZER_SUBCOMMAND="profile"
 run_analyzer

--- a/qa/L0_ssl_https/test.sh
+++ b/qa/L0_ssl_https/test.sh
@@ -25,8 +25,8 @@ TRITON_LAUNCH_MODE=${TRITON_LAUNCH_MODE:="remote"}
 CLIENT_PROTOCOL="http"
 PORTS=(`find_available_ports 2`)
 HTTP_PORT="8000"
-GRPC_PORT="${PORTS[1]}"
-METRICS_PORT="${PORTS[2]}"
+GRPC_PORT="${PORTS[0]}"
+METRICS_PORT="${PORTS[1]}"
 GPUS=(`get_all_gpus_uuids`)
 OUTPUT_MODEL_REPOSITORY=${OUTPUT_MODEL_REPOSITORY:=`get_output_directory`}
 WORKING_CONFIG_FILE="working_config.yml"

--- a/qa/L0_ssl_https/test.sh
+++ b/qa/L0_ssl_https/test.sh
@@ -23,8 +23,8 @@ REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 MODEL_REPOSITORY=${MODEL_REPOSITORY:="/mnt/nvdl/datasets/inferenceserver/$REPO_VERSION/libtorch_model_store"}
 TRITON_LAUNCH_MODE=${TRITON_LAUNCH_MODE:="remote"}
 CLIENT_PROTOCOL="http"
-PORTS=(`find_available_ports 3`)
-HTTP_PORT="${PORTS[0]}"
+PORTS=(`find_available_ports 2`)
+HTTP_PORT=8000
 GRPC_PORT="${PORTS[1]}"
 METRICS_PORT="${PORTS[2]}"
 GPUS=(`get_all_gpus_uuids`)
@@ -89,7 +89,7 @@ create_result_paths -test-name $TEST_NAME
 
 MODEL_ANALYZER_ARGS="-m $MODEL_REPOSITORY -f $WORKING_CONFIG_FILE -e $EXPORT_PATH --checkpoint-directory $CHECKPOINT_DIRECTORY"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --client-protocol=$CLIENT_PROTOCOL --triton-launch-mode=$TRITON_LAUNCH_MODE"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint localhost:${HTTP_PORT} --triton-grpc-endpoint localhost:${GRPC_PORT}"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${GRPC_PORT}"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url http://localhost:${METRICS_PORT}/metrics"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
 MODEL_ANALYZER_SUBCOMMAND="profile"
@@ -106,7 +106,7 @@ create_result_paths -test-name $TEST_NAME
 
 MODEL_ANALYZER_ARGS="-m $MODEL_REPOSITORY -f $BROKEN_CONFIG_FILE -e $EXPORT_PATH --checkpoint-directory $CHECKPOINT_DIRECTORY"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --client-protocol=$CLIENT_PROTOCOL --triton-launch-mode=$TRITON_LAUNCH_MODE"
-MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint localhost:${HTTP_PORT} --triton-grpc-endpoint localhost:${GRPC_PORT}"
+MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-http-endpoint https://localhost:443 --triton-grpc-endpoint localhost:${GRPC_PORT}"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --triton-metrics-url http://localhost:${METRICS_PORT}/metrics"
 MODEL_ANALYZER_ARGS="$MODEL_ANALYZER_ARGS --output-model-repository-path $OUTPUT_MODEL_REPOSITORY --override-output-model-repository"
 MODEL_ANALYZER_SUBCOMMAND="profile"


### PR DESCRIPTION
Will now raise an error in local or docker mode if no GPU records are returned from the tritonserver before the first measurement is taken.