### PR TITLE
Add timeout to requests.get calls

### DIFF
--- a/model_analyzer/monitor/remote_monitor.py
+++ b/model_analyzer/monitor/remote_monitor.py
@@ -54,7 +54,7 @@ class RemoteMonitor(Monitor):
 
     def is_monitoring_connected(self) -> bool:
         try:
-            status_code = requests.get(self._metrics_url).status_code
+            status_code = requests.get(self._metrics_url, timeout=10).status_code
         except Exception as ex:
             return False
 
@@ -69,7 +69,7 @@ class RemoteMonitor(Monitor):
         """
 
         self._metrics_responses.append(
-            str(requests.get(self._metrics_url).content, encoding='ascii'))
+            str(requests.get(self._metrics_url, timeout=10).content, encoding='ascii'))
 
     def _collect_records(self):
         """

--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -629,7 +629,7 @@ class MetricsManager:
         """
 
         triton_prom_str = str(requests.get(
-            self._config.triton_metrics_url).content,
+            self._config.triton_metrics_url, timeout=10).content,
                               encoding='ascii')
         metrics = text_string_to_metric_families(triton_prom_str)
 


### PR DESCRIPTION
Fix wheeltamer failures caused by requests.get not having a timeout