### PR TITLE
Fix error in docker mode when triton output path is not specified

### DIFF
--- a/model_analyzer/triton/server/server_docker.py
+++ b/model_analyzer/triton/server/server_docker.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 import logging
+import tempfile
 from io import TextIOWrapper
 from multiprocessing.pool import ThreadPool
+from subprocess import DEVNULL
 
 import docker
 
@@ -66,6 +68,7 @@ class TritonServerDocker(TritonServer):
         self._tritonserver_image = image
         self._tritonserver_container = None
         self._log_path = log_path
+        self._log_file = DEVNULL
         self._mounts = mounts
         self._labels = labels if labels else {}
         self._gpus = gpus
@@ -173,6 +176,8 @@ class TritonServerDocker(TritonServer):
                 self._log_pool.apply_async(self._logging_worker)
             except OSError as e:
                 raise TritonModelAnalyzerException(e)
+        else:
+            self._log_file = tempfile.NamedTemporaryFile()
 
     def _logging_worker(self):
         """


### PR DESCRIPTION
See [https://github.com/triton-inference-server/model_analyzer/issues/725](https://github.com/triton-inference-server/model_analyzer/issues/725) for details on the failure.

The solution is to implement a temp log file (to match the code in `server_local.py`)