### PR TITLE
Quick search preserves model config parameters

### DIFF
--- a/docs/config_search.md
+++ b/docs/config_search.md
@@ -235,6 +235,10 @@ manual sweep:
 
 **Default search mode when profiling ensemble models, BLS models, or multiple models concurrently**
 
+_This mode has the following limitations:_
+
+- If model config parameters are specified, they can contain only one possible combination of parameters
+
 This mode uses a hill climbing algorithm to search the configuration space, looking for
 the maximal objective value within the specified constraints. In the majority of cases
 this will find greater than 95% of the maximum objective value (that could be found using a brute force search), while needing to search less than 10% of the configuration space.

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -431,7 +431,10 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             model_config_params.pop("max_batch_size", None)
 
             # This is guaranteed to only generate one combination (check is in config_command)
-            param_combo = GeneratorUtils.generate_combinations(model_config_params)[0]
+            param_combos = GeneratorUtils.generate_combinations(model_config_params)
+            assert len(param_combos) == 1
+
+            param_combo = param_combos[0]
         else:
             param_combo = {}
 

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -43,8 +43,10 @@ from model_analyzer.triton.client.client import TritonClient
 from model_analyzer.triton.model.model_config import ModelConfig
 
 from .config_generator_interface import ConfigGeneratorInterface
+from .generator_utils import GeneratorUtils
 
 logger = logging.getLogger(LOGGER_NAME)
+from copy import deepcopy
 
 
 class QuickRunConfigGenerator(ConfigGeneratorInterface):
@@ -424,17 +426,24 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
             self._coordinate_to_measure, dimension_index
         )
 
+        model_config_params = deepcopy(model.model_config_parameters())
+        if model_config_params:
+            max_batch_sizes = model_config_params.pop("max_batch_size", None)
+
+            # This is guaranteed to only generate one combination (check is in config_command)
+            param_combo = GeneratorUtils.generate_combinations(model_config_params)[0]
+        else:
+            param_combo = {}
+
         kind = "KIND_CPU" if model.cpu_only() else "KIND_GPU"
         instance_count = self._calculate_instance_count(dimension_values)
 
-        param_combo: dict = {
-            "instance_group": [
-                {
-                    "count": instance_count,
-                    "kind": kind,
-                }
-            ]
-        }
+        param_combo["instance_group"] = [
+            {
+                "count": instance_count,
+                "kind": kind,
+            }
+        ]
 
         if "max_batch_size" in dimension_values:
             param_combo["max_batch_size"] = self._calculate_model_batch_size(

--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -428,7 +428,7 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
         model_config_params = deepcopy(model.model_config_parameters())
         if model_config_params:
-            max_batch_sizes = model_config_params.pop("max_batch_size", None)
+            model_config_params.pop("max_batch_size", None)
 
             # This is guaranteed to only generate one combination (check is in config_command)
             param_combo = GeneratorUtils.generate_combinations(model_config_params)[0]

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -253,7 +253,7 @@ class ConfigCommand:
         self._check_per_model_parameters(profile_models)
         self._check_per_model_model_config_parameters(profile_models)
 
-    def _check_per_model_parameters(self, profile_models: List[Dict]) -> None:
+    def _check_per_model_parameters(self, profile_models: Dict) -> None:
         for model in profile_models.values():
             if not "parameters" in model:
                 continue
@@ -267,9 +267,7 @@ class ConfigCommand:
                     "\nPlease use brute search mode or remove concurrency/batch sizes list."
                 )
 
-    def _check_per_model_model_config_parameters(
-        self, profile_models: List[Dict]
-    ) -> None:
+    def _check_per_model_model_config_parameters(self, profile_models: Dict) -> None:
         for model in profile_models.values():
             if not "model_config_parameters" in model:
                 continue

--- a/model_analyzer/config/input/config_command.py
+++ b/model_analyzer/config/input/config_command.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
+from model_analyzer.config.generate.generator_utils import GeneratorUtils
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
 from .yaml_config_validator import YamlConfigValidator
@@ -102,6 +103,10 @@ class ConfigCommand:
         self._set_field_values(args, yaml_config)
         self._preprocess_and_verify_arguments()
         self._autofill_values()
+
+        # This is done after the model(s) are populated so that we
+        # can easily count the parameter combinations
+        self._check_quick_search_model_config_parameters_combinations()
 
     def _load_yaml_config(self, args: Namespace) -> Optional[Dict[str, List]]:
         if "config_file" in args:
@@ -198,9 +203,9 @@ class ConfigCommand:
         ):
             return
 
-        self._check_no_search_disable(args, yaml_config)
-        self._check_no_global_list_values(args, yaml_config)
-        self._check_no_per_model_list_values(args, yaml_config)
+        self._check_quick_search_no_search_disable(args, yaml_config)
+        self._check_quick_search_no_global_list_values(args, yaml_config)
+        self._check_quick_search_no_per_model_list_values(args, yaml_config)
 
     def _check_for_bls_incompatibility(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
@@ -208,11 +213,11 @@ class ConfigCommand:
         if not self._get_config_value("bls_composing_models", args, yaml_config):
             return
 
-        self._check_no_brute_search(args, yaml_config)
-        self._check_no_multi_model(args, yaml_config)
-        self._check_no_concurrent_search(args, yaml_config)
+        self._check_bls_no_brute_search(args, yaml_config)
+        self._check_bls_no_multi_model(args, yaml_config)
+        self._check_bls_no_concurrent_search(args, yaml_config)
 
-    def _check_no_search_disable(
+    def _check_quick_search_no_search_disable(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         if self._get_config_value("run_config_search_disable", args, yaml_config):
@@ -221,7 +226,7 @@ class ConfigCommand:
                 "\nPlease use brute search mode or remove --run-config-search-disable."
             )
 
-    def _check_no_global_list_values(
+    def _check_quick_search_no_global_list_values(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         concurrency = self._get_config_value("concurrency", args, yaml_config)
@@ -233,7 +238,7 @@ class ConfigCommand:
                 "\nPlease use brute search mode or remove concurrency/batch sizes list."
             )
 
-    def _check_no_per_model_list_values(
+    def _check_quick_search_no_per_model_list_values(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         profile_models = self._get_config_value("profile_models", args, yaml_config)
@@ -245,6 +250,10 @@ class ConfigCommand:
         ):
             return
 
+        self._check_per_model_parameters(profile_models)
+        self._check_per_model_model_config_parameters(profile_models)
+
+    def _check_per_model_parameters(self, profile_models: List[Dict]) -> None:
         for model in profile_models.values():
             if not "parameters" in model:
                 continue
@@ -258,17 +267,45 @@ class ConfigCommand:
                     "\nPlease use brute search mode or remove concurrency/batch sizes list."
                 )
 
+    def _check_per_model_model_config_parameters(
+        self, profile_models: List[Dict]
+    ) -> None:
         for model in profile_models.values():
             if not "model_config_parameters" in model:
                 continue
 
             if "max_batch_size" in model["model_config_parameters"]:
                 raise TritonModelAnalyzerException(
-                    f"\nProfiling of models in quick search mode is not supported with lists max batch sizes."
+                    f"\nProfiling of models in quick search mode is not supported with lists of max batch sizes."
                     "\nPlease use brute search mode or remove max batch size list."
                 )
 
-    def _check_no_brute_search(
+            if "instance_group" in model["model_config_parameters"]:
+                raise TritonModelAnalyzerException(
+                    f"\nProfiling of models in quick search mode is not supported with instance group as a model config parameter"
+                    "\nPlease use brute search mode or remove instance_group from 'model_config_parameters'."
+                )
+
+    def _check_quick_search_model_config_parameters_combinations(self) -> None:
+        config = self.get_config()
+        if not "profile_models" in config:
+            return
+
+        if config["run_config_search_mode"] != "quick":
+            return
+
+        profile_models = config()["profile_models"].value()
+        for model in profile_models:
+            model_config_params = deepcopy(model.model_config_parameters())
+            if model_config_params:
+                if len(GeneratorUtils.generate_combinations(model_config_params)) > 1:
+                    raise TritonModelAnalyzerException(
+                        f"\nProfiling of models in quick search mode is not supported for the specified model config parameters, "
+                        f"as more than one combination of parameters can be generated."
+                        f"\nPlease use brute search mode to profile or remove the model config parameters specified."
+                    )
+
+    def _check_bls_no_brute_search(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         if (
@@ -280,7 +317,7 @@ class ConfigCommand:
                 "\nPlease use quick search mode."
             )
 
-    def _check_no_multi_model(
+    def _check_bls_no_multi_model(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         profile_models: Union[Dict, List, str] = self._get_config_value(
@@ -298,7 +335,7 @@ class ConfigCommand:
                 f"\nProfiling of multiple models is not supported for BLS models."
             )
 
-    def _check_no_concurrent_search(
+    def _check_bls_no_concurrent_search(
         self, args: Namespace, yaml_config: Optional[Dict[str, List]]
     ) -> None:
         if self._get_config_value(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2041,7 +2041,33 @@ profile_models:
         profile_models:
           model_1:
             model_config_parameters:
-              max batch size: 2
+              max_batch_size: 2
+        """
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self._evaluate_config(args, yaml_content, subcommand="profile")
+
+        yaml_content = """
+        profile_models:
+          model_1:
+            model_config_parameters:
+              instance_group:
+                - kind: KIND_GPU
+        """
+
+        with self.assertRaises(TritonModelAnalyzerException):
+            self._evaluate_config(args, yaml_content, subcommand="profile")
+
+        yaml_content = """
+        profile_models:
+          model_1:
+            model_config_parameters:
+               optimization:
+                 execution_accelerators:
+                   gpu_execution_accelerator:
+                     - name: tensorrt
+                       parameters:
+                       precision_mode: [FP16, FP32]
         """
 
         with self.assertRaises(TritonModelAnalyzerException):

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -306,11 +306,6 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         model_config = rc.model_run_configs()[0].model_config()
         perf_config = rc.model_run_configs()[0].perf_config()
 
-        foo = model_config.to_dict()
-        self.assertEqual(
-            model_config.to_dict()["optimization"],
-            expected_model_config["optimization"],
-        )
         self.assertEqual(model_config.to_dict(), expected_model_config)
         self.assertEqual(perf_config["concurrency-range"], 512)
         self.assertEqual(perf_config["batch-size"], 1)

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -283,20 +283,24 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
         qrcg._coordinate_to_measure = Coordinate([5, 7])
 
         expected_model_config = {
-            'cpu_only': False,
-            'dynamicBatching': {},
-            'instanceGroup': [{
-                'count': 8,
-                'kind': 'KIND_GPU',
-            }],
-            'maxBatchSize': 32,
-            'name': 'fake_model_name_config_0',
-            'input': [{
-                "name": "INPUT__0",
-                "dataType": "TYPE_FP32",
-                "dims": ['16']
-            }],
-            'optimization': {'executionAccelerators': {'gpuExecutionAccelerator': [{'name': 'tensorrt', 'parameters': {'precision_mode': 'FP16'}}]}}
+            "cpu_only": False,
+            "dynamicBatching": {},
+            "instanceGroup": [
+                {
+                    "count": 8,
+                    "kind": "KIND_GPU",
+                }
+            ],
+            "maxBatchSize": 32,
+            "name": "fake_model_name_config_0",
+            "input": [{"name": "INPUT__0", "dataType": "TYPE_FP32", "dims": ["16"]}],
+            "optimization": {
+                "executionAccelerators": {
+                    "gpuExecutionAccelerator": [
+                        {"name": "tensorrt", "parameters": {"precision_mode": "FP16"}}
+                    ]
+                }
+            },
         }
         # yapf: enable
 


### PR DESCRIPTION
In brute search mode, we toggle between automatic and manual search based on the presence of `model_config_parameters`.
In quick search mode, we currently ignore any model config parameters and silently overwrite them when generating configurations.

This is remedied in two ways:

1. Added a config check which checks that only a single configuration of parameters can be generated (else it tells the user to run in brute search mode)
2. Quick search parameters are now additive and will preserve the original model config parameters set by the user

Unit testing was added to check for these cases and documentation is updated to reflect this restriction in quick search.