### PR TITLE
Remove deprecated distutils

### DIFF
--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -16,7 +16,7 @@
 
 import os
 from copy import deepcopy
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from typing import Any, Dict, List, Optional
 
 from google.protobuf import json_format, text_format
@@ -419,7 +419,7 @@ class ModelConfig:
                     )
         else:
             # Create first variant model as copy of source model
-            copy_tree(src_model_path, model_path)
+            copytree(src_model_path, model_path)
 
         with open(os.path.join(model_path, "config.pbtxt"), "wb") as f:
             f.write(model_config_bytes)

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -419,7 +419,7 @@ class ModelConfig:
                     )
         else:
             # Create first variant model as copy of source model
-            copytree(src_model_path, model_path)
+            copytree(src_model_path, model_path, dirs_exist_ok=True)
 
         with open(os.path.join(model_path, "config.pbtxt"), "wb") as f:
             f.write(model_config_bytes)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -200,7 +200,7 @@ ensemble_scheduling {
             "model_analyzer.triton.model.model_config.open", mock_open()
         ) as mocked_file:
             with patch(
-                "model_analyzer.triton.model.model_config.copy_tree", MagicMock()
+                "model_analyzer.triton.model.model_config.copytree", MagicMock()
             ):
                 model_config.write_config_to_file(model_output_path, "/mock/path", None)
             content = mocked_file().write.call_args.args[0]
@@ -232,7 +232,7 @@ ensemble_scheduling {
         "model_analyzer.triton.model.model_config.os.listdir",
         MagicMock(return_value=["1", "config.pbtxt", "output0_labels.txt"]),
     )
-    @patch("model_analyzer.triton.model.model_config.copy_tree")
+    @patch("model_analyzer.triton.model.model_config.copytree")
     @patch("model_analyzer.triton.model.model_config.os.symlink")
     def test_write_config_to_file_with_relative_path(self, mock_os_symlink, *args):
         """


### PR DESCRIPTION
Distutils is being deprecated. Replace its usage with shutil (used elsewhere in Model Analyzer).

Related server PR: https://github.com/triton-inference-server/server/pull/6190
Related client PR: https://github.com/triton-inference-server/client/pull/382