### PR TITLE
Add remote mode config sweep to brute search 

### DIFF
--- a/model_analyzer/config/generate/brute_run_config_generator.py
+++ b/model_analyzer/config/generate/brute_run_config_generator.py
@@ -101,12 +101,7 @@ class BruteRunConfigGenerator(ConfigGeneratorInterface):
     def _get_next_config(self) -> Generator[RunConfig, None, None]:
         if not self._skip_default_config:
             yield from self._generate_subset(0, default_only=True)
-
-        if self._should_generate_non_default_configs():
             yield from self._generate_subset(0, default_only=False)
-
-    def _should_generate_non_default_configs(self) -> bool:
-        return self._config.triton_launch_mode != "remote"
 
     def _generate_subset(
         self, index: int, default_only: bool

--- a/model_analyzer/config/generate/manual_model_config_generator.py
+++ b/model_analyzer/config/generate/manual_model_config_generator.py
@@ -130,23 +130,14 @@ class ManualModelConfigGenerator(BaseModelConfigGenerator):
 
     def _generate_model_config_variants(self) -> List[List[ModelConfigVariant]]:
         """Generate all model config combinations"""
-        if self._remote_mode:
-            configs = self._generate_remote_mode_model_config_variants()
-        else:
-            configs = self._generate_direct_modes_model_config_variants()
+        configs = self._generate_all_modes_model_config_variants()
 
         return configs
 
-    def _generate_remote_mode_model_config_variants(
+    def _generate_all_modes_model_config_variants(
         self,
     ) -> List[List[ModelConfigVariant]]:
-        """Generate model configs for remote mode"""
-        return [[self._make_remote_model_config_variant()]]
-
-    def _generate_direct_modes_model_config_variants(
-        self,
-    ) -> List[List[ModelConfigVariant]]:
-        """Generate model configs for direct (non-remote) modes"""
+        """Generate model configs for all modes"""
         model_config_variants = []
         for param_combo in self._non_max_batch_size_param_combos:
             configs_with_max_batch_size = []
@@ -171,9 +162,6 @@ class ManualModelConfigGenerator(BaseModelConfigGenerator):
         """
         Determine self._max_batch_sizes and self._non_max_batch_size_param_combos
         """
-        if self._remote_mode:
-            return
-
         if self._default_only:
             self._non_max_batch_size_param_combos = [DEFAULT_CONFIG_PARAMS]
         else:

--- a/model_analyzer/config/generate/model_config_generator_factory.py
+++ b/model_analyzer/config/generate/model_config_generator_factory.py
@@ -67,11 +67,10 @@ class ModelConfigGeneratorFactory:
         A generator that implements ConfigGeneratorInterface and creates ModelConfigs
         """
 
-        remote_mode = config.triton_launch_mode == "remote"
         search_disabled = config.run_config_search_disable
         model_config_params = model.model_config_parameters()
 
-        if remote_mode or search_disabled or model_config_params:
+        if search_disabled or model_config_params:
             return ManualModelConfigGenerator(
                 config,
                 gpus,

--- a/qa/L0_config_search/test_config_generator.py
+++ b/qa/L0_config_search/test_config_generator.py
@@ -70,7 +70,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 1, 2, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 2, 2, model_config)
 
     def generate_max_limit_with_model_config(self):
         concurrency_count = 2
@@ -91,7 +91,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 2, 2, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 2, 2, model_config)
 
     def generate_max_limit(self):
         concurrency_count = 2
@@ -105,7 +105,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 2, 8, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 8, 8, model_config)
 
     def generate_max_limit_with_param(self):
         concurrency_count = 1  # 1 because concurrency parameter is 1 entry below
@@ -124,7 +124,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 1, 6, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 6, 6, model_config)
 
     def generate_max_limit_with_param_and_model_config(self):
         concurrency_count = 1  # 1 because concurrency parameter is 1 entry below
@@ -146,7 +146,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 1, 2, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 2, 2, model_config)
 
     def generate_max_limit_with_dynamic_batch_disable(self):
         concurrency_count = 2
@@ -160,7 +160,7 @@ class TestConfigGenerator:
         total_param_count = self._calculate_total_params(
             concurrency_count, instance_count
         )
-        self._write_file(total_param_count, 2, 4, 1, model_config)
+        self._write_file(total_param_count, total_param_count, 4, 4, model_config)
 
     def _calculate_total_params(
         self, concurrency_count, instance_count, default_config_count=1

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -257,24 +257,31 @@ class TestModelManager(trc.TestResultCollector):
     def test_remote_mode(self):
         """
         Test remote mode
-
-        In remote mode all model_config_parameters (ie. instance count) are ignored
         """
 
         expected_ranges = [
             {
-                "instances": [None],
-                "kind": [None],
+                "instances": [1, 2],
+                "kind": ["KIND_GPU"],
+                "batching": [0],
+                "batch_sizes": [1],
+                "max_batch_size": [8],
+                "concurrency": [1, 2, 4, 8, 16],
+            },
+            {
+                "instances": [1],
+                "kind": ["KIND_CPU"],
                 "batching": [None],
                 "batch_sizes": [1],
-                "concurrency": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
-            }
+                "max_batch_size": [8],
+                "concurrency": [1, 2, 4, 8, 16],
+            },
         ]
 
         yaml_str = """
             profile_models: test_model
-            run_config_search_max_concurrency: 512
-            run_config_search_max_instance_count: 7
+            run_config_search_max_concurrency: 16
+            run_config_search_max_instance_count: 2
             run_config_search_min_model_batch_size: 8
             run_config_search_max_model_batch_size: 8
             run_config_search_disable: False


### PR DESCRIPTION
This changes the current behavior of only running a single configuration in remote mode to now having remote mode behave just like the other modes. It will generate either an automatic or manual search and create multiple configurations. Loading them via API to the remote tritonserver.

Unit tests and L0's are updated to reflect this new reality and I have successfully run a full automatic and manual sweep on my local machine. 