### PR TITLE
Exception if remote server is not in explicit mode

### DIFF
--- a/model_analyzer/triton/client/client.py
+++ b/model_analyzer/triton/client/client.py
@@ -105,6 +105,10 @@ class TritonClient:
             return None
         except Exception as e:
             logger.info(f"Model {variant_name} load failed: {e}")
+            if hasattr(e, "_msg") and "polling is enabled" in e._msg:
+                raise TritonModelAnalyzerException(
+                    "The remote Tritonserver needs to be launched in EXPLICIT mode"
+                )
             return -1
 
     def unload_model(self, model_name):


### PR DESCRIPTION
The current behavior is that we print an info message to the user when the model fails to load, but in this specific case we should immediately terminate MA and tell the user exactly what is wrong.

There is no API call to determine what mode the server is in, so I'm string matching on the relevant part of the exception message being returned.