### PR TITLE
Remove requirement that remote mode have a model repository path

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -119,7 +119,7 @@ class Analyzer:
         if self._config.triton_launch_mode == "remote":
             self._warn_if_other_models_loaded_on_remote_server(client)
 
-        if self._config.model_repository:
+        if self._config.model_repository or self._config.triton_launch_mode == "remote":
             self._get_server_only_metrics(client, gpus)
             self._profile_models()
 

--- a/model_analyzer/entrypoint.py
+++ b/model_analyzer/entrypoint.py
@@ -254,7 +254,7 @@ def main():
     try:
         # Make calls to correct analyzer subcommand functions
         if args.subcommand == "profile" or args.subcommand == "analyze":
-            if args.subcommand == "profile" and not config.model_repository:
+            if _is_a_model_repository_required(args, config):
                 raise TritonModelAnalyzerException(
                     "No model repository specified. Please specify it using the YAML config file or using the --model-repository flag in CLI."
                 )
@@ -289,6 +289,15 @@ def main():
     finally:
         if server is not None:
             server.stop()
+
+
+def _is_a_model_repository_required(args, config):
+    model_repository_required = (
+        args.subcommand == "profile"
+        and not config.model_repository
+        and not config.triton_launch_mode == "remote"
+    )
+    return model_repository_required
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, in all modes we require a path to the model repository. This is no longer necessary for remote mode, as we are now loading the models via API with the tritonserver in explicit mode, therefore the tritonserver already needs to be pointed to the model directory (on the remote machine) and MA doesn't need access (only the model name).

This story also fixed/refactoring the error messages around creating the default configuration.