### PR TITLE
Fix protobuf dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ RUN python3 -m pip install --upgrade pip && \
 #Other pip packages
 RUN python3 -m pip install coverage
 RUN python3 -m pip install mypy
-RUN python3 -m pip install protobuf
 RUN python3 -m pip install types-PyYAML
 RUN python3 -m pip install types-requests
 RUN python3 -m pip install types-protobuf

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN python3 -m pip install --upgrade pip && \
 #Other pip packages
 RUN python3 -m pip install coverage
 RUN python3 -m pip install mypy
+RUN python3 -m pip install protobuf
 RUN python3 -m pip install types-PyYAML
 RUN python3 -m pip install types-requests
 RUN python3 -m pip install types-protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ matplotlib>=3.3.4
 numba>=0.51.2
 pdfkit>=0.6.1
 prometheus_client>=0.9.0
+protobuf
 psutil>=5.8.0
 pyyaml>=5.3.1
 requests>=2.24.0


### PR DESCRIPTION
Protobuf was magically coming from the client repo, and was recently removed. MA should be making sure it exists, as it has code that uses it. This change fixes that issue.