### PR TITLE
Update plot colors to be colorblind compatible

### DIFF
--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -72,12 +72,13 @@ class DetailedPlot:
             )
         ]
 
+        # Okabe-Ito guideline colors for colorblind
         self._bar_colors = {
-            "perf_server_queue": "#9daecc",
-            "perf_server_compute_input": "#7eb7e8",
-            "perf_server_compute_infer": "#0072ce",
-            "perf_server_compute_output": "#254b87",
-            "perf_throughput": "#5E5E5E",
+            "perf_server_queue": "#e69f00",
+            "perf_server_compute_input": "#56b4e9",
+            "perf_server_compute_infer": "#009e73",
+            "perf_server_compute_output": "#f0e442",
+            "perf_throughput": "#000000",
         }
 
         self._bar_width = bar_width

--- a/model_analyzer/plots/detailed_plot.py
+++ b/model_analyzer/plots/detailed_plot.py
@@ -73,6 +73,7 @@ class DetailedPlot:
         ]
 
         # Okabe-Ito guideline colors for colorblind
+        # https://jfly.uni-koeln.de/color/#select
         self._bar_colors = {
             "perf_server_queue": "#e69f00",
             "perf_server_compute_input": "#56b4e9",


### PR DESCRIPTION
Thanks to https://github.com/triton-inference-server/model_analyzer/issues/804 for the suggestion, the bars on the detailed plots will now have colors that are compatible with colorblind.

![image](https://github.com/triton-inference-server/model_analyzer/assets/50968584/6c99aa06-439d-4ba2-9786-7b16a47dc5a2)
