### PR TITLE
Fix loading of composing models for ensembles

### DIFF
--- a/model_analyzer/record/metrics_manager.py
+++ b/model_analyzer/record/metrics_manager.py
@@ -430,19 +430,15 @@ class MetricsManager:
         """
         Loads all model variants in the client
         """
-        # TODO TMA-1487: Make BLS and ensemble both load all composing model variants first
         for mrc in run_config.model_run_configs():
+            # Load all composing model variants first, and then the parent model
+            for composing_config_variant in mrc.composing_config_variants():
+                if not self._load_model_variant(
+                    variant_config=composing_config_variant
+                ):
+                    return False
             if not self._load_model_variant(variant_config=mrc.model_config_variant()):
                 return False
-
-            # Composing configs for BLS models are not automatically loaded by the top-level model
-            if mrc.is_bls_model():
-                for composing_config_variant in mrc.composing_config_variants():
-                    if not self._load_model_variant(
-                        variant_config=composing_config_variant
-                    ):
-                        return False
-
         return True
 
     def _load_model_variant(self, variant_config: ModelConfigVariant) -> bool:


### PR DESCRIPTION
Before this change, there was no way for Model Analyzer to load ensemble composing models via the API. This meant that they all defaulted to auto-complete configs. Now (with a required change to Triton) they can be loaded and won't be overwritten when the main ensemble config is loaded.

Fixes https://github.com/triton-inference-server/model_analyzer/issues/791
Needs this change to work: https://github.com/triton-inference-server/core/pull/304