### PR TITLE
Update QRCG to set concurrency for default config

### DIFF
--- a/model_analyzer/config/generate/quick_run_config_generator.py
+++ b/model_analyzer/config/generate/quick_run_config_generator.py
@@ -719,12 +719,8 @@ class QuickRunConfigGenerator(ConfigGeneratorInterface):
 
     def _calculate_default_concurrency(self, model_config: ModelConfig) -> int:
         default_max_batch_size = model_config.max_batch_size()
-
-        # string format is: "<count>:GPU"
-        default_instance_count = int(
-            model_config.instance_group_string(system_gpu_count=len(self._gpus)).split(
-                ":"
-            )[0]
+        default_instance_count = model_config.instance_group_count(
+            system_gpu_count=len(self._gpus)
         )
         default_concurrency = 2 * default_max_batch_size * default_instance_count
 

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -17,6 +17,7 @@
 import json
 import os
 from copy import deepcopy
+from itertools import chain
 from shutil import copytree
 from typing import Any, Dict, List, Optional
 
@@ -485,6 +486,21 @@ class ModelConfig:
             return "Enabled"
         else:
             return "Disabled"
+
+    def instance_group_count(self, system_gpu_count: int) -> int:
+        """
+        Returns:
+            int: The total number of instance groups (cpu + gpu)
+        """
+
+        # format is: "<count>:GPU + <count>:CPU"
+        instance_group_string = self.instance_group_string(system_gpu_count)
+        instance_group_counts = [
+            int(group_count.split(":")[0])
+            for group_count in instance_group_string.split("+")
+        ]
+
+        return sum(instance_group_counts)
 
     def instance_group_string(self, system_gpu_count: int) -> str:
         """

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -17,7 +17,6 @@
 import json
 import os
 from copy import deepcopy
-from itertools import chain
 from shutil import copytree
 from typing import Any, Dict, List, Optional
 

--- a/model_analyzer/triton/model/model_config.py
+++ b/model_analyzer/triton/model/model_config.py
@@ -492,14 +492,10 @@ class ModelConfig:
             int: The total number of instance groups (cpu + gpu)
         """
 
-        # format is: "<count>:GPU + <count>:CPU"
-        instance_group_string = self.instance_group_string(system_gpu_count)
-        instance_group_counts = [
-            int(group_count.split(":")[0])
-            for group_count in instance_group_string.split("+")
-        ]
+        kind_to_count = self._get_instance_groups(system_gpu_count)
+        instance_group_count = sum([count for count in kind_to_count.values()])
 
-        return sum(instance_group_counts)
+        return instance_group_count
 
     def instance_group_string(self, system_gpu_count: int) -> str:
         """
@@ -508,8 +504,23 @@ class ModelConfig:
         str
             representation of the instance group used
             to generate this result
+
+            Format is "GPU:<count> + CPU:<count>"
         """
 
+        kind_to_count = self._get_instance_groups(system_gpu_count)
+
+        ret_str = ""
+        for k, v in kind_to_count.items():
+            if ret_str != "":
+                ret_str += " + "
+            ret_str += f"{v}:{k}"
+        return ret_str
+
+    def _get_instance_groups(self, system_gpu_count: int) -> Dict[str, int]:
+        """
+        Returns a dictionary with type of instance (GPU/CPU) and its count
+        """
         model_config = self.get_config()
 
         # TODO change when remote mode is fixed
@@ -542,9 +553,4 @@ class ModelConfig:
                 kind_to_count[group_kind] = 0
             kind_to_count[group_kind] += group_total_count
 
-        ret_str = ""
-        for k, v in kind_to_count.items():
-            if ret_str != "":
-                ret_str += " + "
-            ret_str += f"{v}:{k}"
-        return ret_str
+        return kind_to_count

--- a/tests/test_quick_run_config_generator.py
+++ b/tests/test_quick_run_config_generator.py
@@ -533,12 +533,16 @@ class TestQuickRunConfigGenerator(trc.TestResultCollector):
 
         sc = SearchConfig(dimensions=dims, radius=5, min_initialized=2)
         qrcg = QuickRunConfigGenerator(
-            sc, config, MagicMock(), models, {}, MagicMock(), ModelVariantNameManager()
+            sc, config, ["GPU0"], models, {}, MagicMock(), ModelVariantNameManager()
         )
 
         default_run_config = qrcg._create_default_run_config()
 
         self.assertIn("--percentile=96", default_run_config.representation())
+        self.assertIn(
+            "--concurrency-range=8",
+            default_run_config.model_run_configs()[0].perf_config().representation(),
+        )
 
     def test_default_ensemble_config_generation(self):
         """


### PR DESCRIPTION
Updated unit test to check for this case and here's a run with the new formula showing that concurrency is set to 16 (max batch size is 8, instance count is 1) for the default config:

![image](https://github.com/triton-inference-server/model_analyzer/assets/92820864/8c8a04a7-6586-4586-9cf6-09fca1c36859)
