### PR TITLE
Fix incorrect remote mode warnings

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -403,9 +403,13 @@ class Analyzer:
         repository_index = client.get_model_repository_index()
         profile_model_names = [pm.model_name() for pm in self._config.profile_models]
 
-        for model in repository_index:
-            if model["name"] not in profile_model_names:
-                model_name = model["name"]
+        model_names_loaded_on_server = []
+        for repository_item in repository_index:
+            if client.is_model_ready(repository_item["name"]):
+                model_names_loaded_on_server.append(repository_item["name"])
+
+        for model_name in model_names_loaded_on_server:
+            if model_name not in profile_model_names:
                 logger.warning(
                     f"A model not being profiled ({model_name}) is loaded on the remote Tritonserver. "
                     "This could impact the profile results."

--- a/model_analyzer/triton/client/grpc_client.py
+++ b/model_analyzer/triton/client/grpc_client.py
@@ -84,3 +84,9 @@ class TritonGRPCClient(TritonClient):
         Returns the JSON dict holding the model repository index.
         """
         return self._client.get_model_repository_index(as_json=True)["models"]
+
+    def is_model_ready(self, model_name: str) -> bool:
+        """
+        Returns true if the model is loaded on the server
+        """
+        return self._client.is_model_ready(model_name)

--- a/model_analyzer/triton/client/http_client.py
+++ b/model_analyzer/triton/client/http_client.py
@@ -99,3 +99,11 @@ class TritonHTTPClient(TritonClient):
         Returns the JSON dict holding the model repository index.
         """
         return self._client.get_model_repository_index()
+
+    def is_model_ready(self, model_name: str) -> bool:
+        """
+        Returns true if the model is loaded on the server
+        """
+        foo = self._client.is_model_ready(model_name)
+
+        return foo

--- a/model_analyzer/triton/client/http_client.py
+++ b/model_analyzer/triton/client/http_client.py
@@ -104,6 +104,4 @@ class TritonHTTPClient(TritonClient):
         """
         Returns true if the model is loaded on the server
         """
-        foo = self._client.is_model_ready(model_name)
-
-        return foo
+        return self._client.is_model_ready(model_name)

--- a/model_analyzer/triton/server/server_factory.py
+++ b/model_analyzer/triton/server/server_factory.py
@@ -163,11 +163,6 @@ class TritonServerFactory:
             ' using the "local" or "docker" mode if you want to accurately'
             " monitor the GPU memory usage for different models."
         )
-        logger.warning(
-            'Config sweep parameters are ignored in the "remote" mode because'
-            " Model Analyzer does not have access to the model repository of"
-            " the remote Triton Server."
-        )
 
         return server
 


### PR DESCRIPTION
Removed the incorrect warning in `server_factory.py` (we now have control of the model in remote mode).

The check for models already loaded was incorrect. The repository index is just a list of models that could be loaded, not what is currently loaded. 

After getting the list of potential models, I've added a call to `is_model_ready()` which will only return true if the model is actually loaded. 

No easy way to unit test this (it probably needs an L0, but that seems overkill for a warning message), but I have run it locally and confirmed that the warning messages both go away and then come back if I load a model on the server before running MA.