### PR TITLE
Move MA concurrency and request-rate check to autofill

### DIFF
--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -1424,7 +1424,7 @@ class ConfigCommandProfile(ConfigCommand):
                 elif not "request_rate" in model.parameters():
                     new_model["parameters"].update({"concurrency": self.concurrency})
                 else:
-                    new_model["parameters"].update({"concurrency": None})
+                    new_model["parameters"].update({"concurrency": []})
 
                 if "request_rate" in model.parameters():
                     new_model["parameters"].update(

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -1421,8 +1421,10 @@ class ConfigCommandProfile(ConfigCommand):
                     new_model["parameters"].update(
                         {"concurrency": model.parameters()["concurrency"]}
                     )
-                else:
+                elif not "request_rate" in model.parameters():
                     new_model["parameters"].update({"concurrency": self.concurrency})
+                else:
+                    new_model["parameters"].update({"concurrency": None})
 
                 if "request_rate" in model.parameters():
                     new_model["parameters"].update(


### PR DESCRIPTION
During preprocessing, Model Analyzer checks whether request rate and concurrency are both missing if "run config search" is disabled. However, self.request_rate_ and self.concurrency_ are not set in the code, so the code always sets a concurrency value of 1. This results in an error if request-rate is provided with "run config search" disabled.

Move this check later to when the provided parameters are being checked and default values are set. Use the user-provided values and default values to determine whether concurrency and request-rate are set before using a default value for concurrency.

Fixes #838.