### PR TITLE
DOC: minor fix for incorrect folder in quickstart

### DIFF
--- a/docs/ensemble_quick_start.md
+++ b/docs/ensemble_quick_start.md
@@ -45,7 +45,7 @@ git pull origin main
 **3. Add a version directory to ensemble_add_sub**
 
 ```
-mkdir examples/quick/ensemble_add_sub/1
+mkdir examples/quick-start/ensemble_add_sub/1
 ```
 
 ## `Step 2:` Pull and Run the SDK Container


### PR DESCRIPTION
Minor change from `examples/quick` to `examples/quick-start` based on [latest folder structure](https://github.com/triton-inference-server/model_analyzer/tree/main/examples/quick-start)
