### PR TITLE
Adding BLS composing models to SearchParameters

### DIFF
--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -423,5 +423,14 @@ class Analyzer:
     def _populate_search_parameters(self):
         for model in self._config.profile_models:
             self._search_parameters[model.model_name()] = SearchParameters(
-                self._config, model.parameters(), model.model_config_parameters()
+                self._config,
+                model.parameters(),
+                model.model_config_parameters(),
+                is_bls_model=bool(self._config.bls_composing_models),
+            )
+        for model in self._config.bls_composing_models:
+            self._search_parameters[model.model_name()] = SearchParameters(
+                self._config,
+                model.parameters(),
+                model.model_config_parameters(),
             )

--- a/model_analyzer/analyzer.py
+++ b/model_analyzer/analyzer.py
@@ -84,6 +84,7 @@ class Analyzer:
         )
 
         self._search_parameters: Dict[str, SearchParameters] = {}
+        self._composing_search_parameters: Dict[str, SearchParameters] = {}
 
     def profile(
         self, client: TritonClient, gpus: List[GPUDevice], mode: str, verbose: bool
@@ -119,6 +120,7 @@ class Analyzer:
         self._create_metrics_manager(client, gpus)
         self._create_model_manager(client, gpus)
         self._populate_search_parameters()
+        self._populate_composing_search_parameters()
 
         if self._config.triton_launch_mode == "remote":
             self._warn_if_other_models_loaded_on_remote_server(client)
@@ -428,9 +430,12 @@ class Analyzer:
                 model.model_config_parameters(),
                 is_bls_model=bool(self._config.bls_composing_models),
             )
+
+    def _populate_composing_search_parameters(self):
         for model in self._config.bls_composing_models:
-            self._search_parameters[model.model_name()] = SearchParameters(
+            self._composing_search_parameters[model.model_name()] = SearchParameters(
                 self._config,
                 model.parameters(),
                 model.model_config_parameters(),
+                is_composing_model=True,
             )

--- a/model_analyzer/config/generate/optuna_run_config_generator.py
+++ b/model_analyzer/config/generate/optuna_run_config_generator.py
@@ -98,6 +98,13 @@ class OptunaRunConfigGenerator(ConfigGeneratorInterface):
         # TODO: TMA-1927: Add support for multi-model
         self._search_parameters = search_parameters[models[0].model_name()]
 
+        # TODO: need to add in ensemble support
+        self._composing_search_parameters = {}
+        for composing_model in self._config.bls_composing_models:
+            self._composing_search_parameters[
+                composing_model.model_name()
+            ] = search_parameters[composing_model.model_name()]
+
         self._model_variant_name_manager = model_variant_name_manager
 
         self._triton_env = BruteRunConfigGenerator.determine_triton_server_env(models)

--- a/model_analyzer/config/generate/search_parameters.py
+++ b/model_analyzer/config/generate/search_parameters.py
@@ -46,12 +46,14 @@ class SearchParameters:
         parameters: Dict[str, Any] = {},
         model_config_parameters: Dict[str, Any] = {},
         is_bls_model: bool = False,
+        is_composing_model: bool = False,
     ):
         self._config = config
         self._parameters = parameters
         self._model_config_parameters = model_config_parameters
         self._search_parameters: Dict[str, SearchParameter] = {}
         self._is_bls_model = is_bls_model
+        self._is_composing_model = is_composing_model
 
         self._populate_search_parameters()
 
@@ -123,7 +125,7 @@ class SearchParameters:
     def _populate_parameters(self) -> None:
         self._populate_batch_sizes()
 
-        if not self._is_bls_model:
+        if not self._is_composing_model:
             self._populate_concurrency()
             # TODO: Populate request rate - TMA-1903
 

--- a/model_analyzer/config/generate/search_parameters.py
+++ b/model_analyzer/config/generate/search_parameters.py
@@ -45,11 +45,13 @@ class SearchParameters:
         config: ConfigCommandProfile = ConfigCommandProfile(),
         parameters: Dict[str, Any] = {},
         model_config_parameters: Dict[str, Any] = {},
+        is_bls_model: bool = False,
     ):
         self._config = config
         self._parameters = parameters
         self._model_config_parameters = model_config_parameters
         self._search_parameters: Dict[str, SearchParameter] = {}
+        self._is_bls_model = is_bls_model
 
         self._populate_search_parameters()
 
@@ -120,11 +122,15 @@ class SearchParameters:
 
     def _populate_parameters(self) -> None:
         self._populate_batch_sizes()
-        self._populate_concurrency()
-        # TODO: Populate request rate - TMA-1903
+
+        if not self._is_bls_model:
+            self._populate_concurrency()
+            # TODO: Populate request rate - TMA-1903
 
     def _populate_model_config_parameters(self) -> None:
-        self._populate_max_batch_size()
+        if not self._is_bls_model:
+            self._populate_max_batch_size()
+
         self._populate_instance_group()
         self._populate_max_queue_delay_microseconds()
 

--- a/model_analyzer/config/input/config_command_profile.py
+++ b/model_analyzer/config/input/config_command_profile.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import os
+from copy import deepcopy
 
 import numba.cuda
 import psutil
@@ -1691,6 +1692,11 @@ class ConfigCommandProfile(ConfigCommand):
                 new_model["model_config_parameters"] = model.model_config_parameters()
 
             new_profile_models[model.model_name()] = new_model
+
+        # deepcopy is necessary, else it gets overwritten when updating profile_models
+        self._fields["bls_composing_models"] = deepcopy(
+            self._fields["bls_composing_models"]
+        )
         self._fields["profile_models"].set_value(new_profile_models)
 
     def _using_request_rate(self) -> bool:


### PR DESCRIPTION
Composing models in a BLS can also have search parameters:
```
run_config_search_mode: optuna
use_concurrency_formula: True
profile_models: bls
bls_composing_models:
  add:
    model_config_parameters:
      max_batch_size: [1, 4, 8]
      dynamic_batching:
        max_queue_delay_microseconds: [100, 200, 300]
  sub:
    model_config_parameters:
      max_batch_size: [32, 64, 128]
      dynamic_batching:
        max_queue_delay_microseconds: [400, 500, 600]
```
This story adds support for this to the SearchParameters class (which is used by OptunaRCG).