### PR TITLE
Adds BLS scaffolding to everything up to OptunaRCG

### DIFF
--- a/model_analyzer/config/generate/optuna_plus_concurrency_sweep_run_config_generator.py
+++ b/model_analyzer/config/generate/optuna_plus_concurrency_sweep_run_config_generator.py
@@ -50,9 +50,11 @@ class OptunaPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
         config: ConfigCommandProfile,
         gpu_count: int,
         models: List[ModelProfileSpec],
+        composing_models: List[ModelProfileSpec],
         result_manager: ResultManager,
         model_variant_name_manager: ModelVariantNameManager,
         search_parameters: Dict[str, SearchParameters],
+        composing_search_parameters: Dict[str, SearchParameters],
     ):
         """
         Parameters
@@ -62,19 +64,25 @@ class OptunaPlusConcurrencySweepRunConfigGenerator(ConfigGeneratorInterface):
         gpu_count: Number of gpus in the system
         models: List of ModelProfileSpec
             List of models to profile
+        composing_models: List of ModelProfileSpec
+            List of composing models that exist inside of the supplied models
         result_manager: ResultManager
             The object that handles storing and sorting the results from the perf analyzer
         model_variant_name_manager: ModelVariantNameManager
             Maps model variants to config names
         search_parameters: SearchParameters
             The object that handles the users configuration search parameters
+        composing_search_parameters: SearchParameters
+            The object that handles the users configuration search parameters for composing models
         """
         self._config = config
         self._gpu_count = gpu_count
         self._models = models
+        self._composing_models = composing_models
         self._result_manager = result_manager
         self._model_variant_name_manager = model_variant_name_manager
         self._search_parameters = search_parameters
+        self._composing_search_parameters = composing_search_parameters
 
     def set_last_results(
         self, measurements: List[Optional[RunConfigMeasurement]]

--- a/model_analyzer/config/generate/run_config_generator_factory.py
+++ b/model_analyzer/config/generate/run_config_generator_factory.py
@@ -61,6 +61,7 @@ class RunConfigGeneratorFactory:
         result_manager: ResultManager,
         model_variant_name_manager: ModelVariantNameManager,
         search_parameters: Dict[str, SearchParameters],
+        composing_search_parameters: Dict[str, SearchParameters],
     ) -> ConfigGeneratorInterface:
         """
         Parameters
@@ -78,6 +79,8 @@ class RunConfigGeneratorFactory:
             Maps model variants to config names
         search_parameters: SearchParameters
             The object that handles the users configuration search parameters
+        composing_search_parameters: SearchParameters
+            The object that handles the users configuration search parameters for composing models
 
         Returns
         -------
@@ -97,8 +100,10 @@ class RunConfigGeneratorFactory:
                 command_config=command_config,
                 gpu_count=len(gpus),
                 models=new_models,
+                composing_models=composing_models,
                 result_manager=result_manager,
                 search_parameters=search_parameters,
+                composing_search_parameters=composing_search_parameters,
                 model_variant_name_manager=model_variant_name_manager,
             )
         elif command_config.run_config_search_mode == "quick" or composing_models:
@@ -147,17 +152,21 @@ class RunConfigGeneratorFactory:
         command_config: ConfigCommandProfile,
         gpu_count: int,
         models: List[ModelProfileSpec],
+        composing_models: List[ModelProfileSpec],
         result_manager: ResultManager,
         model_variant_name_manager: ModelVariantNameManager,
         search_parameters: Dict[str, SearchParameters],
+        composing_search_parameters: Dict[str, SearchParameters],
     ) -> ConfigGeneratorInterface:
         return OptunaPlusConcurrencySweepRunConfigGenerator(
             config=command_config,
             gpu_count=gpu_count,
+            composing_models=composing_models,
             models=models,
             result_manager=result_manager,
             model_variant_name_manager=model_variant_name_manager,
             search_parameters=search_parameters,
+            composing_search_parameters=composing_search_parameters,
         )
 
     @staticmethod

--- a/model_analyzer/config/generate/search_parameters.py
+++ b/model_analyzer/config/generate/search_parameters.py
@@ -17,6 +17,7 @@
 from math import log2
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from model_analyzer.config.generate.model_profile_spec import ModelProfileSpec
 from model_analyzer.config.input.config_command_profile import ConfigCommandProfile
 from model_analyzer.model_analyzer_exceptions import TritonModelAnalyzerException
 
@@ -42,15 +43,15 @@ class SearchParameters:
 
     def __init__(
         self,
+        model: ModelProfileSpec,
         config: ConfigCommandProfile = ConfigCommandProfile(),
-        parameters: Dict[str, Any] = {},
-        model_config_parameters: Dict[str, Any] = {},
         is_bls_model: bool = False,
         is_composing_model: bool = False,
     ):
         self._config = config
-        self._parameters = parameters
-        self._model_config_parameters = model_config_parameters
+        self._parameters = model.parameters()
+        self._model_config_parameters = model.model_config_parameters()
+        self._supports_max_batch_size = model.supports_batching()
         self._search_parameters: Dict[str, SearchParameter] = {}
         self._is_bls_model = is_bls_model
         self._is_composing_model = is_composing_model
@@ -130,9 +131,7 @@ class SearchParameters:
             # TODO: Populate request rate - TMA-1903
 
     def _populate_model_config_parameters(self) -> None:
-        if not self._is_bls_model:
-            self._populate_max_batch_size()
-
+        self._populate_max_batch_size()
         self._populate_instance_group()
         self._populate_max_queue_delay_microseconds()
 
@@ -171,7 +170,7 @@ class SearchParameters:
                 parameter_list=parameter_list,
                 parameter_category=ParameterCategory.INT_LIST,
             )
-        else:
+        elif self._supports_max_batch_size and not self._is_bls_model:
             # Need to populate max_batch_size based on RCS min/max values
             # when no model config parameters are present
             self._populate_rcs_parameter(

--- a/model_analyzer/config/run/run_config.py
+++ b/model_analyzer/config/run/run_config.py
@@ -127,12 +127,35 @@ class RunConfig:
         """
         return self._model_run_configs[0].composing_config_variants()
 
+    def composing_model_variants_name(self):
+        """
+        Returns a single comma-joined name of the composing model variant names
+        (an ensemble/BLS cannot be part of a multi-model profile)
+        """
+        return ",".join(
+            [
+                cvc.variant_name
+                for cvc in self.model_run_configs()[0].composing_config_variants()
+            ]
+        )
+
     def composing_configs(self):
         """
         Returns a list of composing model configs from the first model run config
         (an ensemble/BLS cannot be part of a multi-model profile)
         """
         return self._model_run_configs[0].composing_configs()
+
+    def combined_model_variants_name(self):
+        """
+        Combines the model + composing model's variant names (joined with a '::')
+        """
+        if self.composing_model_variants_name():
+            return (
+                f"{self.model_variants_name()}::{self.composing_model_variants_name()}"
+            )
+        else:
+            return self.model_variants_name()
 
     @classmethod
     def from_dict(cls, run_config_dict):

--- a/model_analyzer/model_manager.py
+++ b/model_analyzer/model_manager.py
@@ -61,6 +61,7 @@ class ModelManager:
         state_manager: AnalyzerStateManager,
         constraint_manager: ConstraintManager,
         search_parameters: Dict[str, SearchParameters],
+        composing_search_parameters: Dict[str, SearchParameters],
     ):
         """
         Parameters
@@ -83,6 +84,8 @@ class ModelManager:
             constraints on a given measurements
         search_parameters: SearchParameters
             The object that handles the users configuration search parameters
+        composing_search_parameters: SearchParameters
+            The object that handles the users configuration search parameters for composing models
         """
 
         self._config = config
@@ -94,6 +97,7 @@ class ModelManager:
         self._state_manager = state_manager
         self._constraint_manager = constraint_manager
         self._search_parameters = search_parameters
+        self._composing_search_parameters = composing_search_parameters
 
         if state_manager.starting_fresh_run():
             self._init_state()
@@ -137,6 +141,7 @@ class ModelManager:
             client=self._client,
             result_manager=self._result_manager,
             search_parameters=self._search_parameters,
+            composing_search_parameters=self._composing_search_parameters,
             model_variant_name_manager=self._model_variant_name_manager,
         )
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -70,6 +70,8 @@ class TestAnalyzer(trc.TestResultCollector):
         _get_server_only_metrics=MagicMock(),
         _profile_models=MagicMock(),
         _check_for_perf_analyzer_errors=MagicMock(),
+        _populate_search_parameters=MagicMock(),
+        _populate_composing_search_parameters=MagicMock(),
     )
     def test_profile_skip_summary_reports(self, **mocks):
         """

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1161,6 +1161,7 @@ class TestModelManager(trc.TestResultCollector):
             state_manager,
             MagicMock(),
             MagicMock(),
+            MagicMock(),
         )
 
         # Multiple model check
@@ -1212,6 +1213,7 @@ class TestModelManager(trc.TestResultCollector):
             state_manager,
             MagicMock(),
             MagicMock(),
+            MagicMock(),
         )
 
         models = [
@@ -1256,6 +1258,7 @@ class TestModelManager(trc.TestResultCollector):
             state_manager,
             MagicMock(),
             MagicMock(),
+            MagicMock(),
         )
 
         # RunConfigSearch check
@@ -1294,6 +1297,7 @@ class TestModelManager(trc.TestResultCollector):
             metrics_manager,
             MagicMock(),
             state_manager,
+            MagicMock(),
             MagicMock(),
             MagicMock(),
         )


### PR DESCRIPTION
I've split the BLS OptunaRCG work into two stories to make it easier to review. 

This first story contains all the code changes to support BLS outside of the OptunaRCG class:

- Adds populate composing search parameters
- Adds missing check that batch size is supported when generating search parameters (discovered during BLS testing)
- PIpes composing_models all the way to OptunaRCG
- Updates unit-testing to have an actual ModelConfigProfileSpec (which is necessary to check if batch size exists in the protobuf)
- Adds new method to print the full variant name: `model_A::composing_model_A,composing_model_B...`