### PR TITLE
Fixing copyright issue

### DIFF
--- a/qa/L0_ensemble_model/check_results.py
+++ b/qa/L0_ensemble_model/check_results.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-#!/bin/bash
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
I somehow accidently modified this file when I was checking in the new L0_optuna tests. The copyright issue is due to the `#!bin/bash`. This test is now passing locally and I will push this once it also passes on the CI.