### PR TITLE
Fix genai-perf command line for LLM model type

### DIFF
--- a/model_analyzer/perf_analyzer/perf_analyzer.py
+++ b/model_analyzer/perf_analyzer/perf_analyzer.py
@@ -325,7 +325,7 @@ class PerfAnalyzer:
 
     def _get_single_model_cmd(self, index):
         if self._model_type == "LLM":
-            cmd = ["genai-perf", "-m", self._config.models_name()]
+            cmd = ["genai-perf", "profile -m", self._config.models_name()]
             cmd += self._get_genai_perf_cli_command(index).replace("=", " ").split()
             cmd += ["--"]
             cmd += (


### PR DESCRIPTION
Fix from this issue https://github.com/triton-inference-server/model_analyzer/issues/935
If we run model-analyzer from nvcr.io/nvidia/tritonserver:24.08-py3-sdk docker container for model with LLM model type,
It will fail with the following error message:

Command: 
genai-perf -m my_model -- -b 1 -u server:8001 -i grpc -f my_model-results.csv --verbose-csv --concurrency-range 64 --measurement-mode count_windows --collect-metrics --metrics-url http://server:8002 --metrics-interval 1000

Error: 
2024-10-01 10:42 [INFO] genai_perf.parser:803 - Detected passthrough args: ['-b', '1', '-u', 'server:8001', '-i', 'grpc', '-f', 'my_model-results.csv', '--verbose-csv', '--concurrency-range', '64', '--measurement-mode', 'count_windows', '--collect-metrics', '--metrics-url', 'http://server:8002', '--metrics-interval', '1000']
usage: genai-perf [-h] [--version] {compare,profile} ...
genai-perf: error: argument subcommand: invalid choice: 'my_model' (choose from 'compare', 'profile')
It looks like the genai-perf command line created by model_analyzer missing required mode (genai-perf profile ...).

it seems that genai-perf has changed their CLI and now it requires profile. We could try adding profile to line 328 of perf_analyzer.py. It should now look like:

 cmd = ["genai-perf", "profile -m", self._config.models_name()]