### PR TITLE
feat(docker): add auditwheel to model_analyzer Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN find /tmp/tritonclient -maxdepth 1 -type f -name \
 WORKDIR /opt/triton-model-analyzer
 
 RUN python3 -m pip install \
+        auditwheel \
         build \
         coverage \
         mkdocs \


### PR DESCRIPTION
<sup>
Resolves: TRI-286<br/>
triton-inference-server/client#888<br/>
triton-inference-server/server#8743<br/>
</sup>

## Description

Add `auditwheel` to the `pip3 install` block in the model_analyzer Dockerfile. This makes `auditwheel repair` available in the model_analyzer devel container for the Kitmaker 2.0 (K2) wheel publishing workflow.

## Changes
- feat(TRI-286): add auditwheel to model_analyzer devel container

## Affected Files
- `Dockerfile`