### PR TITLE
[r26.07] update grpcio requirement (#1030)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ dependencies = [
     "distro>=1.5.0",
     "docker>=4.3.1",
     "gevent>=22.08.0",
-    "grpcio>=1.63.0,<1.68",
+    "grpcio>=1.81.1",
     "httplib2>=0.19.0",
     "importlib_metadata>=7.1.0",
     "matplotlib>=3.3.4",
@@ -110,4 +110,3 @@ line_length = 88
 balanced_wrapping = true
 indent = "    "
 skip = ["build"]
-


### PR DESCRIPTION
#### What does the PR do?
Cherry-pick of #1030 onto `r26.07` — update grpcio requirement. Backport of the coordinated `grpcio` dependency update. Clean cherry-pick, no conflicts.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field (`cherry-pick`)
- [x] Verified copyright is correct on all changed files.
- [x] All template sections are filled out.

#### Commit Type:
Cherry-pick — preserves the original commit type from #1030.

#### Related PRs:
- triton-inference-server/server#8887
- triton-inference-server/client#907
- triton-inference-server/third_party#78
- triton-inference-server/python_backend#448

#### Where should the reviewer start?
Changed file(s): `pyproject.toml`. This is a direct cherry-pick of the already-reviewed #1030; the diff is identical.

#### Test plan:
Verified via existing CI on `r26.07`.
- CI Pipeline ID: N/A (clean cherry-pick of #1030)

#### Caveats:
None — clean cherry-pick, no conflicts.

#### Background
Backporting the `main` `grpcio` dependency update to the `r26.07` release branch.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-836
